### PR TITLE
Lsl copy phrase bug

### DIFF
--- a/bcipy/acquisition/client.py
+++ b/bcipy/acquisition/client.py
@@ -391,7 +391,7 @@ if __name__ == "__main__":
 
     import argparse
     import json
-    import protocols.registry as registry
+    import bcipy.acquisition.protocols.registry as registry
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-b', '--buffer', default='buffer.db',

--- a/bcipy/acquisition/datastream/lsl_server.py
+++ b/bcipy/acquisition/datastream/lsl_server.py
@@ -35,12 +35,12 @@ class LslDataServer(StoppableThread):
     """
 
     def __init__(self, params, generator, include_meta=True,
-                 add_markers=False):
+                 add_markers=False, name='TestStream'):
         super(LslDataServer, self).__init__()
 
         self.channels = params['channels']
         self.hz = int(params['hz'])
-        stream_name = params.get('name', 'TestStream')
+        stream_name = params.get('name', name)
 
         params['channel_count'] = len(self.channels)
         self.channel_count = len(self.channels)
@@ -144,6 +144,7 @@ def main():
                         help='sample rate in hz')
 
     parser.add_argument('-m', '--markers', action="store_true", default=False)
+    parser.add_argument('-n', '--name', default='LSL')
     args = parser.parse_args()
 
     params = {'channels': args.channels.split(','),
@@ -156,7 +157,7 @@ def main():
     markers = True if args.markers else False
     try:
         server = LslDataServer(params=params, generator=generator,
-                               add_markers=markers)
+                               add_markers=markers, name=args.name)
 
         logging.debug("New server created")
         server.start()

--- a/bcipy/bci_tasks/rsvp/copy_phrase.py
+++ b/bcipy/bci_tasks/rsvp/copy_phrase.py
@@ -93,12 +93,12 @@ class RSVPCopyPhraseTask(Task):
         # Try Initializing Copy Phrase Wrapper:
         #       (sig_pro, decision maker, signal_model)
         try:
-            copy_phrase_task = CopyPhraseWrapper(signal_model=self.classifier, fs=self.daq._device.fs,
+            copy_phrase_task = CopyPhraseWrapper(signal_model=self.classifier, fs=self.daq.device_info.fs,
                                                  k=2, alp=self.alp, task_list=task_list,
                                                  lmodel=self.lmodel,
                                                  is_txt_sti=self.is_txt_sti,
-                                                 device_name=self.daq._device.name,
-                                                 device_channels=self.daq._device.channels)
+                                                 device_name=self.daq.device_info.name,
+                                                 device_channels=self.daq.device_info.channels)
         except Exception as e:
             print("Error initializing Copy Phrase Task")
             raise e

--- a/bcipy/helpers/acquisition_related.py
+++ b/bcipy/helpers/acquisition_related.py
@@ -75,7 +75,7 @@ def init_eeg_acquisition(parameters, save_folder,
             channels = ['ch{}'.format(c + 1) for c in range(16)]
             dataserver = LslDataServer(params={'name': 'LSL',
                                                'channels': channels,
-                                               'hz': 512},
+                                               'hz': 256},
                                        generator=generator.random_data(
                                            channel_count=16))
             await_start(dataserver)

--- a/bcipy/helpers/bci_task_related.py
+++ b/bcipy/helpers/bci_task_related.py
@@ -1,6 +1,7 @@
 import os
 from psychopy import visual, event
 import numpy as np
+from typing import Any
 
 
 def fake_copy_phrase_decision(copy_phrase, target_letter, text_task):
@@ -75,7 +76,7 @@ def process_data_for_decision(sequence_timing, daq):
     """Process Data for Decision.
 
     Processes the raw data (triggers and eeg) into a form that can be passed to
-        signal processing and classifiers.
+    signal processing and classifiers.
 
     Parameters
     ----------
@@ -122,18 +123,8 @@ def process_data_for_decision(sequence_timing, daq):
             if len(raw_data) < data_limit:
                 raise Exception("Not enough data received")
 
-
-        def float_val(col):
-            """Convert marker data to float values so we can put them in a
-            typed np.array. The marker column has type float if it has a 0.0
-            value, and would only have type str for a marker value."""
-            if type(col) is str:
-                return 1.0
-            else:
-                return float(col)
-
         # Take only the sensor data from raw data and transpose it;
-        raw_data = np.array([np.array([float_val(col) for col in record.data])
+        raw_data = np.array([np.array([_float_val(col) for col in record.data])
                              for record in raw_data],
                             dtype=np.float64).transpose()
 
@@ -142,6 +133,16 @@ def process_data_for_decision(sequence_timing, daq):
         raise e
 
     return raw_data, triggers, target_info
+
+
+def _float_val(col: Any) -> float:
+    """Convert marker data to float values so we can put them in a
+    typed np.array. The marker column has type float if it has a 0.0
+    value, and would only have type str for a marker value."""
+    if isinstance(col, str):
+        return 1.0
+    else:
+        return float(col)
 
 
 def trial_complete_message(win, parameters):
@@ -374,4 +375,5 @@ def trial_reshaper(trial_target_info: list,
         return reshaped_trials, labels, num_of_sequences, trials_per_seq
 
     except Exception as e:
-        raise Exception(f'Could not reshape trial for mode: {mode}, {fs}, {k}. Error: {e}')
+        raise Exception(
+            f'Could not reshape trial for mode: {mode}, {fs}, {k}. Error: {e}')

--- a/bcipy/helpers/bci_task_related.py
+++ b/bcipy/helpers/bci_task_related.py
@@ -122,9 +122,20 @@ def process_data_for_decision(sequence_timing, daq):
             if len(raw_data) < data_limit:
                 raise Exception("Not enough data received")
 
-        # Take only the sensor data from raw data and transpose it
-        raw_data = np.array([np.array(raw_data[i][0]) for i in
-                             range(len(raw_data))]).transpose()
+
+        def float_val(col):
+            """Convert marker data to float values so we can put them in a
+            typed np.array. The marker column has type float if it has a 0.0
+            value, and would only have type str for a marker value."""
+            if type(col) is str:
+                return 1.0
+            else:
+                return float(col)
+
+        # Take only the sensor data from raw data and transpose it;
+        raw_data = np.array([np.array([float_val(col) for col in record.data])
+                             for record in raw_data],
+                            dtype=np.float64).transpose()
 
     except Exception as e:
         print("Error in daq: get_data()")
@@ -276,7 +287,8 @@ def trial_reshaper(trial_target_info: list,
             timing_info = list(filter(lambda x: x != -1, timing_info))
 
             # triggers in seconds are mapped to triggers in number of samples.
-            triggers = list(map(lambda x: int((x - offset) * after_filter_frequency), timing_info))
+            triggers = list(
+                map(lambda x: int((x - offset) * after_filter_frequency), timing_info))
 
             # 3 dimensional np array first dimension is channels
             # second dimension is trials and third dimension is time samples.
@@ -355,7 +367,8 @@ def trial_reshaper(trial_target_info: list,
             # Since there is only one sequence, all trials are in the sequence
             trials_per_seq = len(triggers)
         else:
-            raise Exception('Trial_reshaper does not work in this operating mode.')
+            raise Exception(
+                'Trial_reshaper does not work in this operating mode.')
 
         # Return our trials, labels and some useful information about the arrays
         return reshaped_trials, labels, num_of_sequences, trials_per_seq


### PR DESCRIPTION
* Updated copy_phrase to use the acquisition public properties; this fixes a bug where fs was not being set since it was getting a value of undefined; this was reported in Pivotal Tracker bug #158405692.

* Updated process_data_for_decision method to ensure that output np.array has dtype of float. All downstream code is expecting a float array parameter. This is the default return value when all channel data are floats, however, when we write markers directly to LSL, these values are strings and need to be explicitly converted to sentinel float values.