### PR TITLE
Icon task bug fixes

### DIFF
--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -90,7 +90,7 @@ def alphabet(parameters=None):
             # construct an array of paths to images
             path = parameters['path_to_presentation_images']
             stimulus_array = []
-            for stimulus_filename in os.listdir(path):
+            for stimulus_filename in sorted(os.listdir(path)):
                 # PLUS.png is reserved for the fixation symbol
                 if stimulus_filename.endswith(
                         '.png') and not stimulus_filename.endswith('PLUS.png'):

--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -76,7 +76,7 @@ def calculate_stimulation_freq(flash_time: float) -> float:
     return 1 / flash_time
 
 
-def alphabet(parameters=None):
+def alphabet(parameters=None, include_path=True):
     """Alphabet.
 
     Function used to standardize the symbols we use as alphabet.
@@ -94,8 +94,11 @@ def alphabet(parameters=None):
                 # PLUS.png is reserved for the fixation symbol
                 if stimulus_filename.endswith(
                         '.png') and not stimulus_filename.endswith('PLUS.png'):
-                    stimulus_array.append(os.path.join(path, stimulus_filename))
-
+                    if include_path:
+                        img = os.path.join(path, stimulus_filename)
+                    else:
+                        img = os.path.splitext(stimulus_filename)[0]
+                    stimulus_array.append(img)
             return stimulus_array
 
     return ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
@@ -109,7 +112,7 @@ def process_data_for_decision(
         window,
         parameters,
         first_session_stim_time,
-        static_offset=0,
+        static_offset=None,
         buf_length=None):
     """Process Data for Decision.
 
@@ -135,6 +138,7 @@ def process_data_for_decision(
     _, first_stim_time = sequence_timing[0]
     _, last_stim_time = sequence_timing[-1]
 
+    static_offset = static_offset or parameters['static_trigger_offset']
     # if there is an argument supplied for buffer length use that
     if buf_length:
         buffer_length = buf_length

--- a/bcipy/tasks/rsvp/icon_to_icon.py
+++ b/bcipy/tasks/rsvp/icon_to_icon.py
@@ -12,7 +12,7 @@ from psychopy import core
 
 from bcipy.helpers.system_utils import auto_str
 from bcipy.display.rsvp.mode.icon_to_icon import IconToIconDisplay
-from bcipy.feedback.visual.visual_feedback import VisualFeedback
+from bcipy.feedback.visual.visual_feedback import VisualFeedback, FeedbackType
 from bcipy.helpers.task import (
     alphabet, fake_copy_phrase_decision, get_user_input,
     process_data_for_decision, trial_complete_message)
@@ -65,8 +65,7 @@ class RSVPIconToIconTask(Task):
         # Alphabet is comprised of the image base names
         self.alp = [
             path.splitext(path.basename(img))[0]
-            for img in glob.glob(self.image_path + '*.png')
-            if not img.endswith('PLUS.png')
+            for img in alphabet(parameters)
         ]
 
         self.rsvp = _init_icon_to_icon_display_task(
@@ -232,7 +231,8 @@ class RSVPIconToIconTask(Task):
         feedback.administer(
             self.img_path(selection),
             compare_assertion=None,
-            message='Decision: ')
+            message='Decision: ',
+            stimuli_type=FeedbackType.IMAGE)
 
     def write_data(self, correct_trials: int, selections: int):
         """Write trial data to icon_data.csv in file save location."""
@@ -396,7 +396,7 @@ class RSVPIconToIconTask(Task):
                 ev_hist = copy_phrase_task.conjugator.evidence_history
                 likelihood = copy_phrase_task.conjugator.likelihood
                 entry['lm_evidence'] = ev_hist['LM'][0].tolist()
-                entry['eeg_evidence'] = ev_hist['ERP'][0].tolist()
+                entry['eeg_evidence'] = ev_hist['ERP'][-1].tolist()
                 entry['likelihood'] = likelihood.tolist()
 
                 if decision_made:

--- a/bcipy/tasks/rsvp/icon_to_icon.py
+++ b/bcipy/tasks/rsvp/icon_to_icon.py
@@ -63,10 +63,7 @@ class RSVPIconToIconTask(Task):
 
         self.image_path = parameters['path_to_presentation_images']
         # Alphabet is comprised of the image base names
-        self.alp = [
-            path.splitext(path.basename(img))[0]
-            for img in alphabet(parameters)
-        ]
+        self.alp = alphabet(parameters, include_path=False)
 
         self.rsvp = _init_icon_to_icon_display_task(
             self.parameters, self.window, self.daq, self.static_clock,
@@ -116,6 +113,7 @@ class RSVPIconToIconTask(Task):
         self.word_matching_text_size = parameters['word_matching_text_size']
         self.collection_window_len = parameters[
             'collection_window_after_trial_length']
+
         self.data_save_path = parameters['data_save_loc']
 
         match_type = 'Word' if self.is_word else 'Icon'


### PR DESCRIPTION
This PR fixes 3 bugs with the Icon Task:

1. Non-deterministic ordering or icons prevented analysis of the session.json file.
2. Feedback was being presented as a string, rather than an image
3. The process_data_for_decision helper was not using the configured static offset, so the wrong raw_data was being acquired, which prevented users from selecting the correct icon.