### PR TITLE
Small changes to clean up after tests and make sure all tests pass

### DIFF
--- a/bcipy/acquisition/tests/test_client.py
+++ b/bcipy/acquisition/tests/test_client.py
@@ -75,7 +75,10 @@ class TestDataAcquistionClient(unittest.TestCase):
         daq.start_acquisition()
         time.sleep(0.1)
         daq.stop_acquisition()
-
+        
+        #Make sure we are able to stop the buffer process
+        buf_temp = daq._buf
+        
         daq._buf = None
 
         #test get_data
@@ -87,9 +90,10 @@ class TestDataAcquistionClient(unittest.TestCase):
         self.assertEqual(data_length,0)
 
         #test offset
-        offset = daq.offset()
+        offset = daq.offset
         self.assertEqual(offset,None)
-
+        
+        daq._buf = buf_temp
         daq.cleanup()
 
     def test_get_data(self):

--- a/bcipy/display/tests/test_display.py
+++ b/bcipy/display/tests/test_display.py
@@ -39,3 +39,5 @@ class TestInitializeDisplayWindow(unittest.TestCase):
 
         self.assertIsInstance(display_window, type(self.window))
         self.assertEqual(display_window, self.window)
+        
+        display_window.close()

--- a/bcipy/display/tests/test_display.py
+++ b/bcipy/display/tests/test_display.py
@@ -28,16 +28,14 @@ class TestInitializeDisplayWindow(unittest.TestCase):
 
         self.parameters = load_json_parameters(parameters_used,
                                                value_cast=True)
+                                               
+        self.display_window = init_display_window(self.parameters)
 
     def tearDown(self):
+        self.display_window.close()
         unstub()
 
     def test_init_display_window_returns_psychopy_window(self):
         """Test display window is created."""
-
-        display_window = init_display_window(self.parameters)
-
-        self.assertIsInstance(display_window, type(self.window))
-        self.assertEqual(display_window, self.window)
-        
-        display_window.close()
+        self.assertIsInstance(self.display_window, type(self.window))
+        self.assertEqual(self.display_window, self.window)

--- a/bcipy/feedback/demo/demo_visual_feedback.py
+++ b/bcipy/feedback/demo/demo_visual_feedback.py
@@ -20,3 +20,4 @@ timing = visual_feedback.administer(
     stimulus, compare_assertion=assertion, message=message)
 print(timing)
 print(visual_feedback._type())
+display.close()

--- a/bcipy/feedback/tests/test_visual_feedback.py
+++ b/bcipy/feedback/tests/test_visual_feedback.py
@@ -71,6 +71,7 @@ class TestVisualFeedback(unittest.TestCase):
 
     def tearDown(self):
         # clean up by removing the data folder we used for testing
+        self.display.close()
         unstub()
 
     def test_feedback_type(self):

--- a/bcipy/tasks/tests/test_main_frame.py
+++ b/bcipy/tasks/tests/test_main_frame.py
@@ -33,7 +33,6 @@ class TestDecisionMaker(unittest.TestCase):
         """Test do_epoch method"""
         self.decision_maker.do_epoch()
         self.assertEqual(self.decision_maker.sequence_counter,0)
-        print(self.decision_maker.state)
 
     def test_decide_with_commit(self):
         """Test decide method with case of commit"""
@@ -82,6 +81,13 @@ class TestDecisionMaker(unittest.TestCase):
         self.decision_maker.form_display_state(self.decision_maker.state)
         self.assertEqual(self.decision_maker.displayed_state,'ABE')
         self.decision_maker.reset()
+        
+    def test_do_epoch(self):
+        """Test do_epoch method"""
+        probability_distribution = np.ones(len(self.decision_maker.alphabet)) / 8
+        decision, chosen_stimuli = self.decision_maker.decide(probability_distribution)
+        self.decision_maker.do_epoch()
+        self.assertEqual(self.decision_maker.sequence_counter,0)
 '''
     def test_schedule_sequence(self):
         old_count = self.decision_maker.sequence_counter

--- a/bcipy/tasks/tests/test_main_frame.py
+++ b/bcipy/tasks/tests/test_main_frame.py
@@ -30,10 +30,15 @@ class TestDecisionMaker(unittest.TestCase):
         #print(self.decision_maker.list_epoch[-1]['list_distribution'][-1])
         #print(probability_distribution)
         self.assertFalse(decision)
+        """Test do_epoch method"""
+        self.decision_maker.do_epoch()
+        self.assertEqual(self.decision_maker.sequence_counter,0)
+        print(self.decision_maker.state)
 
     def test_decide_with_commit(self):
         """Test decide method with case of commit"""
         probability_distribution = np.ones(len(self.decision_maker.alphabet))
+        self.decision_maker.sequence_counter = self.decision_maker.min_num_seq
         decision, chosen_stimuli = self.decision_maker.decide(probability_distribution)
         #self.assertTrue(np.all(self.decision_maker.list_epoch[-1]['list_distribution'][-1] == probability_distribution))
         #print(self.decision_maker.list_epoch[-1]['list_distribution'][-1])
@@ -77,12 +82,6 @@ class TestDecisionMaker(unittest.TestCase):
         self.decision_maker.form_display_state(self.decision_maker.state)
         self.assertEqual(self.decision_maker.displayed_state,'ABE')
         self.decision_maker.reset()
-
-    def test_do_epoch(self):
-        """Test do_epoch method"""
-        self.decision_maker.do_epoch()
-        self.assertEqual(self.decision_maker.sequence_counter,0)
-        print(self.decision_maker.state)
 '''
     def test_schedule_sequence(self):
         old_count = self.decision_maker.sequence_counter


### PR DESCRIPTION
-Closes buffer processes to prevent them from running forever in the background
-Closes all display windows to prevent them from running forever in the background
-Moves test_do_epoch into test_decide_without_commit so that it passes and doesn't have to make more decisions based on fake probability data than are necessary 
-Fixes test_decide_with_commit