### PR TITLE
#166772877 ; get_data queries

### DIFF
--- a/bcipy/acquisition/buffer_server.py
+++ b/bcipy/acquisition/buffer_server.py
@@ -109,7 +109,7 @@ def stop(mailbox, delete_archive=True):
     return _rpc(mailbox, request)
 
 
-def _rpc(mailbox, request, win=None, wait_reply=True):
+def _rpc(mailbox, request, wait_reply=True):
     """Makes a process call and optionally awaits its reply.
 
     Parameters
@@ -118,8 +118,6 @@ def _rpc(mailbox, request, win=None, wait_reply=True):
             process queue
         request : tuple
             (command, params), where command is a str and params is a tuple.
-        win : Window
-            window to reload in case Windows changes focus
         wait_reply : boolean, optional
             waits (blocks) until a response is provided from the server process
 
@@ -170,7 +168,7 @@ def count(mailbox):
 # pylint: disable=redefined-outer-name
 
 
-def get_data(mailbox, start=None, end=None, field='_rowid_', win=None):
+def get_data(mailbox, start=None, end=None, field='_rowid_'):
     """Query the buffer for a slice of data records.
 
     Parameters
@@ -181,8 +179,6 @@ def get_data(mailbox, start=None, end=None, field='_rowid_', win=None):
             timestamp of data lower bound; if missing, gets all data
         end : float, optional
             timestamp of data upper bound
-        win : Window
-            window to pass to _rpc for reloading
     Returns
     -------
         list of data rows within the given range.
@@ -191,8 +187,6 @@ def get_data(mailbox, start=None, end=None, field='_rowid_', win=None):
         request = (MSG_GET_ALL, None)
     else:
         request = (MSG_QUERY_SLICE, (start, end, field))
-    if win:
-        return _rpc(mailbox, request, win)
 
     return _rpc(mailbox, request)
 

--- a/bcipy/acquisition/client.py
+++ b/bcipy/acquisition/client.py
@@ -182,7 +182,7 @@ class DataAcquisitionClient:
         self.marker_writer.cleanup()
         self.marker_writer = NullMarkerWriter()
 
-    def get_data(self, start=None, end=None, field='_rowid_', win=None):
+    def get_data(self, start=None, end=None, field='_rowid_'):
         """Queries the buffer by field.
 
         Parameters
@@ -193,8 +193,6 @@ class DataAcquisitionClient:
                 end of time slice; units are those of the acquisition clock.
             field: str, optional
                 field on which to query; default value is the row id.
-            win : Window
-                window to pass to server for reloading
         Returns
         -------
             list of Records
@@ -203,7 +201,7 @@ class DataAcquisitionClient:
         if self._buf is None:
             return []
 
-        return buffer_server.get_data(self._buf, start, end, field, win)
+        return buffer_server.get_data(self._buf, start, end, field)
 
     def get_data_for_clock(self, calib_time: float, start_time: float,
                            end_time: float):

--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -170,7 +170,7 @@ def process_data_for_decision(
     # Query for raw data
     try:
         # Call get_data method on daq with start/end
-        raw_data = daq.get_data(start=time1, end=time2, win=window)
+        raw_data = daq.get_data(start=time1, end=time2)
 
         # If not enough raw_data returned in the first query, let's try again
         #  using only the start param. This is known issue on Windows.
@@ -178,7 +178,7 @@ def process_data_for_decision(
         if len(raw_data) < data_limit:
 
             # Call get_data method on daq with just start
-            raw_data = daq.get_data(start=time1, win=window)
+            raw_data = daq.get_data(start=time1)
 
             # If there is still insufficient data returned, throw an error
             if len(raw_data) < data_limit:


### PR DESCRIPTION
get_data queries in Windows take a long time to execute due to the multiprocessing Manager() call. This patch changes the method of inter-process communication in the buffer_server to make these queries more efficient.