### PR TITLE
fix copy phrase in fake data mode

### DIFF
--- a/bci_main.py
+++ b/bci_main.py
@@ -150,7 +150,7 @@ if __name__ == "__main__":
     parser.add_argument('-p', '--parameters', default='bcipy/parameters/parameters.json',
                         help='Parameter location. Must be in parameters directory. Pass as parameters/parameters.json')
     parser.add_argument('-u', '--user', default='test_user')
-    parser.add_argument('-t', '--type', default=2,
+    parser.add_argument('-t', '--type', default=1,
                         help=f'Task type. Options: ({task_options})')
     parser.add_argument('-m', '--mode', default='RSVP',
                         help='BCI mode. Ex. RSVP, MATRIX, SHUFFLE')

--- a/bci_main.py
+++ b/bci_main.py
@@ -150,7 +150,7 @@ if __name__ == "__main__":
     parser.add_argument('-p', '--parameters', default='bcipy/parameters/parameters.json',
                         help='Parameter location. Must be in parameters directory. Pass as parameters/parameters.json')
     parser.add_argument('-u', '--user', default='test_user')
-    parser.add_argument('-t', '--type', default=1,
+    parser.add_argument('-t', '--type', default=2,
                         help=f'Task type. Options: ({task_options})')
     parser.add_argument('-m', '--mode', default='RSVP',
                         help='BCI mode. Ex. RSVP, MATRIX, SHUFFLE')

--- a/bcipy/helpers/signal_model.py
+++ b/bcipy/helpers/signal_model.py
@@ -120,12 +120,7 @@ class CopyPhraseWrapper:
 
         lik_r = inference(x, letters, self.signal_model, self.alp)
         prob = self.conjugator.update_and_fuse({'ERP': lik_r})
-        decision, arg = self.decision_maker.decide(prob)
-
-        if 'stimuli' in arg:
-            sti = arg['stimuli']
-        else:
-            sti = None
+        decision, sti = self.decision_maker.decide(prob)
 
         return decision, sti
 
@@ -211,8 +206,8 @@ class CopyPhraseWrapper:
                 raise lm_exception
 
             # Get decision maker to give us back some decisions and stimuli
-            is_accepted, arg = self.decision_maker.decide(prob_dist)
-            sti = arg['stimuli']
+            is_accepted, sti = self.decision_maker.decide(prob_dist)
+
 
         except Exception as init_exception:
             print("Error in initialize_epoch: %s" % (init_exception))

--- a/bcipy/tasks/rsvp/copy_phrase.py
+++ b/bcipy/tasks/rsvp/copy_phrase.py
@@ -274,7 +274,7 @@ class RSVPCopyPhraseTask(Task):
                 # here we assume, in fake mode, all sequences result in a
                 # selection.
                 last_selection = text_task[-1]
-                new_epoch = True
+                new_epoch, sti = copy_phrase_task.initialize_epoch()
                 # Update next state for this record
                 data['epochs'][
                     epoch_counter][

--- a/bcipy/tasks/rsvp/main_frame.py
+++ b/bcipy/tasks/rsvp/main_frame.py
@@ -329,10 +329,10 @@ class DecisionMaker:
         # Check stopping criteria
         if self.criteria_evaluator.should_commit(self.list_epoch[-1], params):
             self.do_epoch()
-            return True, []
+            return True, None
         else:
             stimuli = self.schedule_sequence()
-            return False, {'stimuli': stimuli}
+            return False, stimuli
 
     def do_epoch(self):
         """ Epoch refers to a commitment to a decision.


### PR DESCRIPTION
# Fix Copy Phrase Task

There is a reported bug in copy phrase when using fake data where it fails after max_number_sequences.

## Updated

- `helpers/signal_model`: return values for tasks
- `tasks/rsvp/copy_phrase`: handling of fake data sequences
