### PR TITLE
#169822844 ; language model histogram

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# Overview
+
+Define what you did...
+
+## Ticket
+
+Link a pivotal ticket here
+
+## Contributions
+
+- Bullet points about your contribution here
+
+## Test
+
+- Define steps used to test here. Include unit and integration test steps!
+
+## Documentaion
+
+- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.

--- a/bcipy/helpers/language_model.py
+++ b/bcipy/helpers/language_model.py
@@ -103,9 +103,18 @@ def equally_probable(alphabet: List[str],
     # override specified values
     return [overrides[sym] if sym in overrides else prob for sym in alphabet]
 
+
 def histogram(letter_prior: List[Tuple[str, float]]) -> str:
     """Given a list of letter, prob tuples, generate a histogram that can be
-    output to the console."""
+    output to the console.
+    
+    Parameters:
+    -----------
+        letter_prior - list of letter, probability pairs
+    Returns:
+    --------
+        printable string which contains a histogram with the letter and probability as the label.
+    """
     margin = "\t"
     star = '*'
     lines = []

--- a/bcipy/helpers/language_model.py
+++ b/bcipy/helpers/language_model.py
@@ -102,3 +102,14 @@ def equally_probable(alphabet: List[str],
     prob = (1 - sum(overrides.values())) / (n_letters - len(overrides))
     # override specified values
     return [overrides[sym] if sym in overrides else prob for sym in alphabet]
+
+def histogram(letter_prior: List[Tuple[str, float]]) -> str:
+    """Given a list of letter, prob tuples, generate a histogram that can be
+    output to the console."""
+    margin = "\t"
+    star = '*'
+    lines = []
+    for letter, prob in sorted(letter_prior):
+        units = int(round(prob * 100))
+        lines.append(letter + ' (' + "%03.2f"%(prob) + ") :" + margin + (units * star))
+    return '\n'.join(lines)

--- a/bcipy/helpers/signal_model.py
+++ b/bcipy/helpers/signal_model.py
@@ -9,7 +9,7 @@ from bcipy.signal.model.inference import inference
 from bcipy.signal.process.filter import bandpass, notch, downsample
 from bcipy.tasks.rsvp.main_frame import EvidenceFusion, DecisionMaker
 from bcipy.helpers.language_model import norm_domain, sym_appended, \
-    equally_probable
+    equally_probable, histogram
 
 
 class CopyPhraseWrapper:
@@ -199,6 +199,10 @@ class CopyPhraseWrapper:
                          for alp_letter in self.alp
                          for prior_sym, prior_prob in lm_letter_prior
                          if alp_letter == prior_sym]
+
+                # display histogram of LM probabilities
+                print(f"Printed letters: '{self.decision_maker.displayed_state}'")
+                print(histogram(lm_letter_prior))
 
             # Try fusing the lmodel evidence
             try:

--- a/bcipy/helpers/tests/test_language_model.py
+++ b/bcipy/helpers/tests/test_language_model.py
@@ -1,8 +1,8 @@
 import unittest
 
+from collections import Counter
 from bcipy.helpers.language_model import norm_domain, sym_appended, \
-    equally_probable
-
+    equally_probable, histogram
 
 class TestLanguageModelRelated(unittest.TestCase):
     def test_norm_domain(self):
@@ -172,3 +172,39 @@ class TestLanguageModelRelated(unittest.TestCase):
         self.assertAlmostEqual(1.0, sum([sym[1] for sym in syms]))
         for sym in syms:
             self.assertTrue(sym[1] >= 0)
+
+    def test_histogram(self):
+        """Test histogram visualization."""
+
+        probs = [('_', 0.8137718053286306), ('R', 0.04917114015944412),
+                 ('Y', 0.04375449276342169), ('I', 0.03125895356629575),
+                 ('M', 0.023673042636520744), ('S', 0.018415576386909806),
+                 ('N', 0.014673750822550981), ('O', 0.003311888694636908),
+                 ('A', 0.0015325727808248953), ('E', 0.00020663161460758318),
+                 ('F', 0.0001271103705188304), ('L', 7.17785373200501e-05),
+                 ('T', 1.9445808941289728e-05), ('V', 8.947029414950125e-06),
+                 ('D', 1.3287314209822164e-06), ('W', 5.781802939202195e-07),
+                 ('C', 4.956713702874677e-07), ('U', 1.3950738615826266e-07),
+                 ('J', 6.925441151532328e-08), ('H', 6.067034614011934e-08),
+                 ('B', 4.83364892878174e-08), ('K', 4.424005264637171e-08),
+                 ('P', 3.319195566216423e-08), ('Z', 2.9048107858874575e-08),
+                 ('X', 1.904356496190087e-08), ('Q', 1.0477572781302604e-08),
+                 ('G', 7.146978265955833e-09)]
+
+        hist = histogram(probs)
+        lines = hist.split("\n")
+        self.assertEqual(len(lines), len(probs))
+        self.assertTrue(
+            all(lines[i] <= lines[i + 1] for i in range(len(lines) - 1)),
+            "Should be sorted")
+
+        self.assertTrue(lines[-1].startswith('_'))
+        c = Counter(lines[-1])
+        self.assertEqual(81, c['*'],
+                         "Should be 81 stars, indicating the percentage")
+
+        total_stars = Counter(hist)['*']
+        self.assertTrue(
+            total_stars <= 100 and total_stars >= 95,
+            "Total number of stars should almost equal 100; exact value depends on rounding"
+        )

--- a/bcipy/tasks/rsvp/main_frame.py
+++ b/bcipy/tasks/rsvp/main_frame.py
@@ -92,7 +92,12 @@ class MinIterationsCriteria(DecisionCriteria):
     """Returns true if the minimum number of iterations have not yet been reached."""
 
     def apply(self, epoch, commit_params):
-        current_seq = len(epoch['list_distribution'])
+        # Note: we use 'list_sti' parameter since this is the number of
+        # sequences displayed. The length of 'list_distribution' is 1 greater
+        # than this, since the language model distribution is added before
+        # the first sequence is displayed.
+        current_seq = len(epoch['list_sti'])
+        log.debug(f"Checking min iterations; current iteration is {current_seq}")
         return current_seq < commit_params['min_num_seq']
 
 
@@ -113,7 +118,9 @@ class MaxIterationsCriteria(DecisionCriteria):
     """Returns true if the max iterations have been reached."""
 
     def apply(self, epoch, commit_params):
-        current_seq = len(epoch['list_distribution'])
+        # Note: len(epoch['list_sti']) != len(epoch['list_distribution'])
+        # see MinIterationsCriteria comment
+        current_seq = len(epoch['list_sti'])
         if current_seq >= commit_params['max_num_seq']:
             log.debug(
                 "Committing to decision: max iterations have been reached.")


### PR DESCRIPTION
# Overview

Tooling to output the language model probabilities while the participant is typing to allow clinicians to determine the difficulty of spelling the current letter.

## Ticket

https://www.pivotaltracker.com/story/show/169822844

## Contributions

- Utility method for generating a histogram from the normalized language model output
- Code within the copy phrase wrapper to output the histogram for each new epoch.

## Test

- `python bcipy/helpers/tests/test_language_model.py`
- Integration: run a Copy Phrase task with the Language Model enabled. For every new epoch, the language model probabilities should output to the console along with a textual histogram.
