### PR TITLE
Gui refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ htmlcov/
 bcipy.egg-info/
 build/
 dist/
+
+bcipy/parameters/parameters_*

--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -37,6 +37,11 @@ class BCInterface(BCIGui):
     def build_text(self):
         self.add_static_text(text='Brain Computer Interface', position=[250, 0], size=[250, 100], background_color='black', text_color='white')
 
+    def build_assets(self):
+        self.build_buttons()
+        self.build_images()
+        self.build_text()
+
 
 def start_app():
     """Start BCIGui."""
@@ -46,11 +51,6 @@ def start_app():
         height=500,
         width=700,
         background_color='black')
-
-    ex.build_buttons()
-    ex.build_images()
-    ex.build_text()
-
 
     ex.show_gui()
 

--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -35,7 +35,7 @@ class BCInterface(BCIGui):
             path='bcipy/static/images/gui_images/neu.png', position=[550, 0], size=200)
 
     def build_text(self):
-        self.add_static_text(text='Brain Computer Interface', position=[250, 0], size=[250, 100], background_color='black', text_color='white')
+        self.add_static_textbox(text='Brain Computer Interface', position=[250, 0], size=[250, 100], background_color='black', text_color='white')
 
     def build_assets(self):
         self.build_buttons()

--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -1,7 +1,6 @@
 import subprocess
-import wx
 import sys
-from bcipy.gui.gui_main import BCIGui, app, PushButton
+from bcipy.gui.gui_main import BCIGui, app
 
 
 class BCInterface(BCIGui):
@@ -15,7 +14,7 @@ class BCInterface(BCIGui):
 
     def build_buttons(self) -> None:
         """Build buttons.
-        
+
         Construct all buttons needed for BCInterface.
         """
         self.add_button(
@@ -34,21 +33,27 @@ class BCInterface(BCIGui):
 
     def build_images(self) -> None:
         """Build Images.
-        
+
         Add all images needed for the BCInterface.
         """
         self.add_image(
-            path='bcipy/static/images/gui_images/ohsu.png', position=[5, 0], size=200)
+            path='bcipy/static/images/gui_images/ohsu.png', position=[5, 0], size=100)
         self.add_image(
-            path='bcipy/static/images/gui_images/neu.png', position=[550, 0], size=200)
+            path='bcipy/static/images/gui_images/neu.png', position=[self.width - 100, 0], size=100)
 
     def build_text(self) -> None:
         """Build Text.
-        
-        Add all static text needed for RSVPKeyboard. Note: these are textboxes and require that you 
+
+        Add all static text needed for RSVPKeyboard. Note: these are textboxes and require that you
             shape the size of the box as well as the text size.
         """
-        self.add_static_textbox(text='Brain Computer Interface', position=[250, 0], size=[250, 100], background_color='black', text_color='white')
+        self.add_static_textbox(
+            text='Brain Computer Interface',
+            position=[175, 0],
+            size=[325, 100],
+            background_color='black',
+            text_color='white',
+            font_size=30)
 
     def build_assets(self) -> None:
         self.build_buttons()
@@ -61,13 +66,14 @@ def start_app():
     bcipy_gui = app(sys.argv)
     ex = BCInterface(
         title="Brain Computer Interface",
-        height=500,
+        height=400,
         width=700,
         background_color='black')
 
     ex.show_gui()
 
     sys.exit(bcipy_gui.exec_())
+
 
 if __name__ == '__main__':
     start_app()

--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -1,57 +1,60 @@
 import subprocess
 import wx
-from bcipy.gui.gui_main import BCIGui
+import sys
+from bcipy.gui.gui_main import BCIGui, app, PushButton
 
 
 # Make a custom GUI class with the events we want
 class BCInterface(BCIGui):
-    def bind_action(self, action: str, btn: wx.Button) -> None:
-        if action == 'launch_mode':
-            self.Bind(wx.EVT_BUTTON, self.launch_mode, btn)
-        else:
-            self.Bind(wx.EVT_BUTTON, self.on_clicked, btn)
 
-    def launch_mode(self, event) -> None:
-        mode_label = event.GetEventObject().GetLabel()
-        if mode_label == 'RSVP':
-            subprocess.Popen(
-                'python bcipy/gui/mode/RSVPKeyboard.py',
-                shell=True)
+    def launch_rsvp(self) -> None:
+        print('launching')
+        subprocess.Popen(
+            'python bcipy/gui/mode/RSVPKeyboard.py',
+            shell=True)
 
+    def build_buttons(self):
+        self.add_button(
+            message="RSVP",
+            position=[155, 200], size=[100, 100],
+            background_color='red',
+            action=self.launch_rsvp)
+        self.add_button(
+            message="Matrix", position=[280, 200],
+            size=[100, 100],
+            background_color='blue')
+        self.add_button(
+            message="Shuffle", position=[405, 200],
+            size=[100, 100],
+            background_color='green')
 
-app = wx.App(False)
-gui = BCInterface(
-    title="Brain Computer Interface",
-    size=(700, 400), background_color='black')
+    def build_images(self):
+        self.add_image(
+            path='bcipy/static/images/gui_images/ohsu.png', position=[5, 0], size=125)
+        self.add_image(
+            path='bcipy/static/images/gui_images/neu.png', position=[550, 0], size=125)
 
-# STATIC TEXT!
-gui.add_static_text(
-    text='Brain Computer Interface', position=(150, 0), size=25, color='white')
-
-# BUTTONS!
-gui.add_button(
-    message="RSVP",
-    position=(155, 200), size=(100, 100),
-    color=wx.Colour(221, 37, 56),
-    action='launch_mode')
-gui.add_button(
-    message="Matrix", position=(280, 200),
-    size=(100, 100),
-    color=wx.Colour(62, 161, 232),
-    action='launch_mode')
-gui.add_button(
-    message="Shuffle", position=(405, 200),
-    size=(100, 100),
-    color=wx.Colour(117, 173, 48),
-    action='launch_mode')
-
-# Images
-gui.add_image(
-    path='bcipy/static/images/gui_images/ohsu.png', position=(5, 0), size=125)
-gui.add_image(
-    path='bcipy/static/images/gui_images/neu.png', position=(550, 0), size=125)
+    def build_text(self):
+        self.add_static_text(text='Brain Computer Interface', position=[150, 0], size=[25, 25], background_color='white')
 
 
-# Make the GUI Show now
-gui.show_gui()
-app.MainLoop()
+def start_app():
+    """Start BCIGui."""
+    bcipy_gui = app(sys.argv)
+    ex = BCInterface(
+        title="Brain Computer Interface",
+        height=700,
+        width=700,
+        background_color='black')
+
+    ex.build_buttons()
+    ex.build_images()
+    ex.build_text()
+
+
+    ex.show_gui()
+
+    sys.exit(bcipy_gui.exec_())
+
+if __name__ == '__main__':
+    start_app()

--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -7,7 +7,7 @@ class BCInterface(BCIGui):
     """BCInterface. Main GUI to select different modes."""
 
     def launch_rsvp(self) -> None:
-        print('launching')
+        self.logger.debug('Launching RSVPKeyboard')
         subprocess.Popen(
             'python bcipy/gui/mode/RSVPKeyboard.py',
             shell=True)

--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -4,8 +4,8 @@ import sys
 from bcipy.gui.gui_main import BCIGui, app, PushButton
 
 
-# Make a custom GUI class with the events we want
 class BCInterface(BCIGui):
+    """BCInterface. Main GUI to select different modes."""
 
     def launch_rsvp(self) -> None:
         print('launching')
@@ -13,7 +13,11 @@ class BCInterface(BCIGui):
             'python bcipy/gui/mode/RSVPKeyboard.py',
             shell=True)
 
-    def build_buttons(self):
+    def build_buttons(self) -> None:
+        """Build buttons.
+        
+        Construct all buttons needed for BCInterface.
+        """
         self.add_button(
             message="RSVP",
             position=[155, 200], size=[100, 100],
@@ -28,16 +32,25 @@ class BCInterface(BCIGui):
             size=[100, 100],
             background_color='green')
 
-    def build_images(self):
+    def build_images(self) -> None:
+        """Build Images.
+        
+        Add all images needed for the BCInterface.
+        """
         self.add_image(
             path='bcipy/static/images/gui_images/ohsu.png', position=[5, 0], size=200)
         self.add_image(
             path='bcipy/static/images/gui_images/neu.png', position=[550, 0], size=200)
 
-    def build_text(self):
+    def build_text(self) -> None:
+        """Build Text.
+        
+        Add all static text needed for RSVPKeyboard. Note: these are textboxes and require that you 
+            shape the size of the box as well as the text size.
+        """
         self.add_static_textbox(text='Brain Computer Interface', position=[250, 0], size=[250, 100], background_color='black', text_color='white')
 
-    def build_assets(self):
+    def build_assets(self) -> None:
         self.build_buttons()
         self.build_images()
         self.build_text()

--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -30,12 +30,12 @@ class BCInterface(BCIGui):
 
     def build_images(self):
         self.add_image(
-            path='bcipy/static/images/gui_images/ohsu.png', position=[5, 0], size=125)
+            path='bcipy/static/images/gui_images/ohsu.png', position=[5, 0], size=200)
         self.add_image(
-            path='bcipy/static/images/gui_images/neu.png', position=[550, 0], size=125)
+            path='bcipy/static/images/gui_images/neu.png', position=[550, 0], size=200)
 
     def build_text(self):
-        self.add_static_text(text='Brain Computer Interface', position=[150, 0], size=[25, 25], background_color='white')
+        self.add_static_text(text='Brain Computer Interface', position=[250, 0], size=[250, 100], background_color='black', text_color='white')
 
 
 def start_app():
@@ -43,7 +43,7 @@ def start_app():
     bcipy_gui = app(sys.argv)
     ex = BCInterface(
         title="Brain Computer Interface",
-        height=700,
+        height=500,
         width=700,
         background_color='black')
 

--- a/bcipy/gui/gui_main.py
+++ b/bcipy/gui/gui_main.py
@@ -13,15 +13,15 @@ from PyQt5.QtWidgets import (
     QLabel,
     QLineEdit,
     QComboBox,
-    QMessageBox,
     QGridLayout,
     QMessageBox)
 from PyQt5.QtGui import QPixmap, QFont
 from PyQt5.QtCore import pyqtSlot
 
+
 class AlertMessageType(Enum):
     """Alert Message Type.
-    
+
     Custom enum used to abstract PyQT message types from downstream users.
     """
     WARN = QMessageBox.Warning
@@ -32,7 +32,7 @@ class AlertMessageType(Enum):
 
 class AlertResponse(Enum):
     """Alert Response.
-    
+
     Custom enum used to abstract PyQT alert responses from downstream users.
     """
     OK = QMessageBox.Ok
@@ -43,11 +43,11 @@ class AlertResponse(Enum):
 
 class PushButton(QPushButton):
     """PushButton.
-    
+
     Custom Button to store unique identifiers which are required for coordinating
     events across multiple buttons."""
     id = None
-    
+
     def get_id(self):
         if not self.id:
             raise Exception('No ID set on PushButton')
@@ -72,7 +72,7 @@ class BCIGui(QMainWindow):
         self.static_text = []
         self.images = []
         self.comboboxes = []
-        
+
         # set window properties
         self.window.setStyleSheet(f'background-color: {background_color};')
 
@@ -88,7 +88,7 @@ class BCIGui(QMainWindow):
 
     def show_gui(self) -> None:
         """Show GUI.
-        
+
         Build all registered assets and initialize the interface.
         """
         self.build_assets()
@@ -97,7 +97,7 @@ class BCIGui(QMainWindow):
     def build_buttons(self) -> None:
         """Build Buttons."""
         ...
-    
+
     def build_images(self) -> None:
         """Build Images."""
         ...
@@ -112,17 +112,17 @@ class BCIGui(QMainWindow):
 
     def build_assets(self) -> None:
         """Build Assets.
-        
+
         Build add registered asset types.
         """
         self.build_text()
         self.build_inputs()
         self.build_buttons()
         self.build_images()
-    
+
     def init_ui(self) -> None:
         """Initalize UI.
-        
+
         This method sets up the grid and window. Finally, it calls the show method to make
             the window visible.
         """
@@ -149,18 +149,18 @@ class BCIGui(QMainWindow):
     @pyqtSlot()
     def default_button_clicked(self) -> None:
         """Default button clikced.
-        
+
         The default action for buttons if none are registed.
         """
         sender = self.sender()
         self.logger.debug(sender.text() + ' was pressed')
         self.logger.debug(sender.get_id())
-    
+
     def add_button(self, message: str, position: list, size: list, id=-1,
                    background_color: str = 'white',
                    text_color: str = 'default',
                    button_type: str = None,
-                   action = None) -> PushButton:
+                   action=None) -> PushButton:
         """Add Button."""
         btn = PushButton(message, self.window)
         btn.id = id
@@ -168,7 +168,6 @@ class BCIGui(QMainWindow):
         btn.resize(size[0], size[1])
 
         btn.setStyleSheet(f'background-color: {background_color}; color: {text_color};')
-
 
         if action:
             btn.clicked.connect(action)
@@ -227,12 +226,12 @@ class BCIGui(QMainWindow):
         raise Exception('Invalid path to image provided')
 
     def add_static_textbox(self, text: str, position: list,
-                        background_color: str = 'white',
-                        text_color: str = 'default',
-                        size: list = None,
-                        font_family="Times",
-                        font_size=12,
-                        wrap_text=False) -> QLabel:
+                           background_color: str = 'white',
+                           text_color: str = 'default',
+                           size: list = None,
+                           font_family="Times",
+                           font_size=12,
+                           wrap_text=False) -> QLabel:
         """Add Static Text."""
 
         static_text = QLabel(self.window)
@@ -250,7 +249,6 @@ class BCIGui(QMainWindow):
         self.static_text.append(static_text)
         return static_text
 
-
     def add_text_input(self, position: list, size: list) -> QLineEdit:
         """Add Text Input."""
         textbox = QLineEdit(self.window)
@@ -261,11 +259,11 @@ class BCIGui(QMainWindow):
         return textbox
 
     def throw_alert_message(self,
-            title:str,
-            message:str,
-            message_type:AlertMessageType = AlertMessageType.INFO,
-            okay_to_exit: bool=False,
-            okay_or_cancel: bool=False) -> QMessageBox:
+                            title: str,
+                            message: str,
+                            message_type: AlertMessageType = AlertMessageType.INFO,
+                            okay_to_exit: bool = False,
+                            okay_or_cancel: bool = False) -> QMessageBox:
         """Throw Alert Message."""
 
         msg = QMessageBox()
@@ -282,9 +280,9 @@ class BCIGui(QMainWindow):
 
     def get_filename_dialog(
             self,
-            message:str='Open File',
+            message: str = 'Open File',
             file_type: str = 'All Files (*)',
-            location:str= "") -> str:
+            location: str = "") -> str:
         """Get Filename Dialog."""
         file_name, _ = QFileDialog.getOpenFileName(self.window, message, location, file_type)
         return file_name
@@ -307,12 +305,18 @@ def start_app() -> None:
     ex.get_filename_dialog()
     ex.add_button(message='Test Button', position=[200, 300], size=[100, 100], id=1)
     # ex.add_image(path='../static/images/gui_images/bci_cas_logo.png', position=[50, 50], size=200)
-    # ex.add_static_textbox(text='Test static text', background_color='black', text_color='white', position=[100, 20], wrap_text=True)
+    # ex.add_static_textbox(
+    #   text='Test static text',
+    #   background_color='black',
+    #   text_color='white',
+    #   position=[100, 20],
+    #   wrap_text=True)
     # ex.add_combobox(position=[100, 100], size=[100, 100], items=['first', 'second', 'third'], editable=True)
     # ex.add_text_input(position=[100, 100], size=[100, 100])
     ex.show_gui()
 
     sys.exit(bcipy_gui.exec_())
+
 
 if __name__ == '__main__':
     start_app()

--- a/bcipy/gui/gui_main.py
+++ b/bcipy/gui/gui_main.py
@@ -12,6 +12,7 @@ from PyQt5.QtWidgets import (
     QAction,
     QLabel,
     QLineEdit,
+    QComboBox,
     QMessageBox,
     QGridLayout,
     QSpinBox,
@@ -21,6 +22,20 @@ from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5.QtCore import pyqtSlot
 
 
+class PushButton(QPushButton):
+    """PushButton.
+    
+    Custom Button to store unique identifiers which are required for coordinating
+    events across multiple buttons."""
+    id = None
+    
+    def get_id(self):
+        if not self.id:
+            raise Exception('No ID set on PushButton')
+
+        return self.id
+
+
 class BCIGui(QtWidgets.QMainWindow):
     """GUI for BCIGui."""
 
@@ -28,19 +43,21 @@ class BCIGui(QtWidgets.QMainWindow):
 
     def __init__(self, title: str, width: int, height: int, background_color: str):
         super(BCIGui, self).__init__()
+        logging.basicConfig(
+            level=logging.DEBUG,
+            format='%(name)s - %(levelname)s - %(message)s')
+        self.logger = logging
 
-        
         self.window = QWidget()
+
         self.buttons = []
         self.input_text = []
         self.static_text = []
         self.images = []
         self.comboboxes = []
-
-        logging.basicConfig(
-            level=logging.DEBUG,
-            format='%(name)s - %(levelname)s - %(message)s')
-        self.logger = logging
+        
+        # set window properties
+        self.window.setStyleSheet(f'background-color: {background_color};')
 
         # determines where on the screen the gui first appears
         self.x = 500
@@ -58,43 +75,80 @@ class BCIGui(QtWidgets.QMainWindow):
 
     def close_gui(self):
         pass
-
+    
     def init_ui(self):
         """Init UI."""
         # create a grid system to keep everythin aligned
         self.grid = QGridLayout()
         self.grid.setSpacing(2)
+        self.window.setLayout(self.grid)
 
         # main window setup
         self.window.setWindowTitle(self.title)
         self.window.setGeometry(self.x, self.y, self.width, self.height)
-
-        # inputs and buttons
-        # self.create_inputs((100, 50), 'button')
-        self.window.setLayout(self.grid)
 
         # show the window
         self.window.show()
 
     @pyqtSlot()
     def default_on_clicked(self):
-        print('clicked!')
+        self.logger.debug('Button clicked!')
+
+    @pyqtSlot()
+    def default_on_dropdown(self):
+        """on_dropdown.
+
+        Default event to bind to comboboxes
+        """
+        self.logger.debug('Dropdown selected!')
+
+    @pyqtSlot()
+    def buttonClicked(self):
+        sender = self.sender()
+        self.logger.debug(sender.text() + ' was pressed')
+        self.logger.debug(sender.get_id())
     
-    def add_button(self, message: str, position: list, size: list,
-                   button_type: str = None, color: str = None,
-                   action = default_on_clicked, id=-1) -> None:
+    def add_button(self, message: str, position: list, size: list, id=-1,
+                   background_color: str = 'white',
+                   text_color: str = 'default',
+                   button_type: str = None,
+                   action = None) -> PushButton:
         """Add Button.
         
         Size : width and height in pixels
         """
-        btn = QPushButton(message, self.window)
+        btn = PushButton(message, self.window)
+        btn.id = id
         btn.move(position[0], position[1])
         btn.resize(size[0], size[1])
-        btn.clicked.connect(action)
+
+        btn.setStyleSheet(f'background-color: {background_color}; color: {text_color};')
+
+
+        if not action:
+            btn.clicked.connect(self.buttonClicked)
 
         self.buttons.append(btn)
+        return btn
 
-    def add_image(self, path: str, position: list, size: int) -> None:
+    def add_combobox(self, position: list, size: list, items: list,
+                     action=default_on_dropdown) -> QComboBox:
+        """Add combobox."""
+
+        combobox = QComboBox(self.window)
+        combobox.move(position[0], position[1])
+        combobox.resize(size[0], size[1])
+
+        combobox.currentTextChanged.connect(action)
+
+        # add all the items to appear in the dropdown
+        for item in items:
+            combobox.addItem(item)
+
+        self.comboboxes.append(combobox)
+        return combobox
+
+    def add_image(self, path: str, position: list, size: int) -> QLabel:
         """Add Image."""
         if os.path.isfile(path):
             labelImage = QLabel(self.window)
@@ -114,26 +168,35 @@ class BCIGui(QtWidgets.QMainWindow):
             labelImage.move(position[0], position[1])
 
             self.images.append(labelImage)
-        else:
-            raise Exception('Invalid path to image provided')
+            return labelImage
+        raise Exception('Invalid path to image provided')
 
-    def add_static_text(self, text: str, position: str,
-                        color: str, size: int,
-                        font_family=None) -> None:
-        """Add Text."""
+    def add_static_text(self, text: str, position: list,
+                        background_color: str = 'white',
+                        text_color: str = 'default',
+                        size: list = [50, 50],
+                        font_family=None, wrap_text=False) -> QLabel:
+        """Add Static Text."""
 
-        static_text = wx.StaticText(
-            self.panel, pos=position,
-            label=text)
-        static_text.SetForegroundColour(color)
-        font = wx.Font(
-            size,
-            font_family,
-            wx.FONTSTYLE_NORMAL,
-            wx.FONTWEIGHT_LIGHT)
-        static_text.SetFont(font)
+        static_text = QLabel(self.window)
+        static_text.setText(text)
+        if wrap_text:
+            static_text.setWordWrap(True)
+        static_text.setStyleSheet(f'background-color: {background_color}; color: {text_color};')
+        static_text.move(position[0], position[1])
+        static_text.resize(size[0], size[1])
 
         self.static_text.append(static_text)
+        return static_text
+
+
+    def add_text_input(self, position: list, size: list) -> QLineEdit:
+        textbox = QLineEdit(self.window)
+        textbox.move(position[0], position[1])
+        textbox.resize(size[0], size[1])
+
+        self.input_text.append(textbox)
+        return textbox
 
 def app(args):
     """Main app registry.
@@ -146,10 +209,13 @@ def app(args):
 def start_app():
     """Start BCIGui."""
     bcipy_gui = app(sys.argv)
-    ex = BCIGui('title', 400, 400, 'blue')
+    ex = BCIGui(title='BCI GUI', height=650, width=650, background_color='white')
 
-    ex.add_button(message='test', position=[200, 300], size=[100, 100], id=1)
-    ex.add_image(path='../static/images/gui_images/bci_cas_logo.png', position=[50, 50], size=200)
+    ex.add_button(message='Test Button', position=[200, 300], size=[100, 100], id=1)
+    # ex.add_image(path='../static/images/gui_images/bci_cas_logo.png', position=[50, 50], size=200)
+    # ex.add_static_text(text='Test static text', background_color='black', text_color='white', position=[100, 20], wrap_text=True)
+    # ex.add_combobox(position=[100, 100], size=[100, 100], items=['first', 'second', 'third'])
+    # ex.add_text_input(position=[100, 100], size=[100, 100])
     ex.show_gui()
 
     sys.exit(bcipy_gui.exec_())

--- a/bcipy/gui/gui_main.py
+++ b/bcipy/gui/gui_main.py
@@ -155,6 +155,8 @@ class BCIGui(QtWidgets.QMainWindow):
         if os.path.isfile(path):
             labelImage = QLabel(self.window)
             pixmap = QPixmap(path)
+            # ensures the new label size will scale the image itself
+            labelImage.setScaledContents(True)
             labelImage.setPixmap(pixmap)
             width = pixmap.width()
             height = pixmap.height()

--- a/bcipy/gui/gui_main.py
+++ b/bcipy/gui/gui_main.py
@@ -125,7 +125,9 @@ class BCIGui(QtWidgets.QMainWindow):
         btn.setStyleSheet(f'background-color: {background_color}; color: {text_color};')
 
 
-        if not action:
+        if action:
+            btn.clicked.connect(action)
+        else:
             btn.clicked.connect(self.buttonClicked)
 
         self.buttons.append(btn)

--- a/bcipy/gui/gui_main.py
+++ b/bcipy/gui/gui_main.py
@@ -71,9 +71,13 @@ class BCIGui(QtWidgets.QMainWindow):
 
     def show_gui(self):
         """Show GUI."""
+        self.build_assets()
         self.init_ui()
 
     def close_gui(self):
+        pass
+
+    def build_assets(self):
         pass
     
     def init_ui(self):

--- a/bcipy/gui/gui_main.py
+++ b/bcipy/gui/gui_main.py
@@ -1,29 +1,29 @@
 import os
 import sys
-import json
-from time import localtime, strftime
 import logging
 
 from enum import Enum
 
-from PyQt5 import QtWidgets
 from PyQt5.QtWidgets import (
+    QMainWindow,
     QApplication,
+    QFileDialog,
     QWidget,
     QPushButton,
-    QAction,
     QLabel,
     QLineEdit,
     QComboBox,
     QMessageBox,
     QGridLayout,
-    QSpinBox,
-    QDoubleSpinBox,
     QMessageBox)
-from PyQt5.QtGui import QIcon, QPixmap, QFont
+from PyQt5.QtGui import QPixmap, QFont
 from PyQt5.QtCore import pyqtSlot
 
 class AlertMessageType(Enum):
+    """Alert Message Type.
+    
+    Custom enum used to abstract PyQT message types from downstream users.
+    """
     WARN = QMessageBox.Warning
     QUESTION = QMessageBox.Question
     INFO = QMessageBox.Information
@@ -31,6 +31,10 @@ class AlertMessageType(Enum):
 
 
 class AlertResponse(Enum):
+    """Alert Response.
+    
+    Custom enum used to abstract PyQT alert responses from downstream users.
+    """
     OK = QMessageBox.Ok
     CANCEL = QMessageBox.Cancel
     YES = QMessageBox.Yes
@@ -51,10 +55,8 @@ class PushButton(QPushButton):
         return self.id
 
 
-class BCIGui(QtWidgets.QMainWindow):
+class BCIGui(QMainWindow):
     """GUI for BCIGui."""
-
-    title = 'BciPy Main GUI'
 
     def __init__(self, title: str, width: int, height: int, background_color: str):
         super(BCIGui, self).__init__()
@@ -84,19 +86,46 @@ class BCIGui(QtWidgets.QMainWindow):
         self.width = width
         self.height = height
 
-    def show_gui(self):
-        """Show GUI."""
+    def show_gui(self) -> None:
+        """Show GUI.
+        
+        Build all registered assets and initialize the interface.
+        """
         self.build_assets()
         self.init_ui()
 
-    def close_gui(self):
-        pass
-
-    def build_assets(self):
-        pass
+    def build_buttons(self) -> None:
+        """Build Buttons."""
+        ...
     
-    def init_ui(self):
-        """Init UI."""
+    def build_images(self) -> None:
+        """Build Images."""
+        ...
+
+    def build_text(self) -> None:
+        """Build Text."""
+        ...
+
+    def build_inputs(self) -> None:
+        """Build Inputs."""
+        ...
+
+    def build_assets(self) -> None:
+        """Build Assets.
+        
+        Build add registered asset types.
+        """
+        self.build_text()
+        self.build_inputs()
+        self.build_buttons()
+        self.build_images()
+    
+    def init_ui(self) -> None:
+        """Initalize UI.
+        
+        This method sets up the grid and window. Finally, it calls the show method to make
+            the window visible.
+        """
         # create a grid system to keep everythin aligned
         self.grid = QGridLayout()
         self.grid.setSpacing(2)
@@ -110,19 +139,19 @@ class BCIGui(QtWidgets.QMainWindow):
         self.window.show()
 
     @pyqtSlot()
-    def default_on_clicked(self):
-        self.logger.debug('Button clicked!')
-
-    @pyqtSlot()
-    def default_on_dropdown(self):
-        """on_dropdown.
+    def default_on_dropdown(self) -> None:
+        """Default on dropdown.
 
         Default event to bind to comboboxes
         """
         self.logger.debug('Dropdown selected!')
 
     @pyqtSlot()
-    def buttonClicked(self):
+    def default_button_clicked(self) -> None:
+        """Default button clikced.
+        
+        The default action for buttons if none are registed.
+        """
         sender = self.sender()
         self.logger.debug(sender.text() + ' was pressed')
         self.logger.debug(sender.get_id())
@@ -132,10 +161,7 @@ class BCIGui(QtWidgets.QMainWindow):
                    text_color: str = 'default',
                    button_type: str = None,
                    action = None) -> PushButton:
-        """Add Button.
-        
-        Size : width and height in pixels
-        """
+        """Add Button."""
         btn = PushButton(message, self.window)
         btn.id = id
         btn.move(position[0], position[1])
@@ -147,7 +173,7 @@ class BCIGui(QtWidgets.QMainWindow):
         if action:
             btn.clicked.connect(action)
         else:
-            btn.clicked.connect(self.buttonClicked)
+            btn.clicked.connect(self.default_button_clicked)
 
         self.buttons.append(btn)
         return btn
@@ -226,6 +252,7 @@ class BCIGui(QtWidgets.QMainWindow):
 
 
     def add_text_input(self, position: list, size: list) -> QLineEdit:
+        """Add Text Input."""
         textbox = QLineEdit(self.window)
         textbox.move(position[0], position[1])
         textbox.resize(size[0], size[1])
@@ -239,6 +266,7 @@ class BCIGui(QtWidgets.QMainWindow):
             message_type:AlertMessageType = AlertMessageType.INFO,
             okay_to_exit: bool=False,
             okay_or_cancel: bool=False) -> QMessageBox:
+        """Throw Alert Message."""
 
         msg = QMessageBox()
         msg.setWindowTitle(title)
@@ -252,7 +280,17 @@ class BCIGui(QtWidgets.QMainWindow):
 
         return msg.exec_()
 
-def app(args):
+    def get_filename_dialog(
+            self,
+            message:str='Open File',
+            file_type: str = 'All Files (*)',
+            location:str= "") -> str:
+        """Get Filename Dialog."""
+        file_name, _ = QFileDialog.getOpenFileName(self.window, message, location, file_type)
+        return file_name
+
+
+def app(args) -> QApplication:
     """Main app registry.
 
     Passes args from main and initializes the app
@@ -260,12 +298,13 @@ def app(args):
     return QApplication(args)
 
 
-def start_app():
+def start_app() -> None:
     """Start BCIGui."""
     bcipy_gui = app(sys.argv)
     ex = BCIGui(title='BCI GUI', height=650, width=650, background_color='white')
 
-    ex.throw_alert_message('title', 'test', okay_to_exit=True)
+    # ex.throw_alert_message(title='title', message='test', okay_to_exit=True)
+    ex.get_filename_dialog()
     ex.add_button(message='Test Button', position=[200, 300], size=[100, 100], id=1)
     # ex.add_image(path='../static/images/gui_images/bci_cas_logo.png', position=[50, 50], size=200)
     # ex.add_static_textbox(text='Test static text', background_color='black', text_color='white', position=[100, 20], wrap_text=True)

--- a/bcipy/gui/mode/RSVPKeyboard.py
+++ b/bcipy/gui/mode/RSVPKeyboard.py
@@ -1,27 +1,27 @@
 # pylint: disable=no-member
 """GUI for running RSVP tasks"""
-import datetime
 import itertools
 import os
 import subprocess
 import sys
-import wx
+
+from typing import List
 
 from bcipy.gui.gui_main import BCIGui, app, AlertMessageType, AlertResponse
 from bcipy.helpers.load import load_json_parameters, copy_parameters
 from bcipy.helpers.parameters import DEFAULT_PARAMETERS_PATH
-
 from bcipy.tasks.task_registry import ExperimentType
 
-tasks = ExperimentType.by_mode()['RSVP']
-# TODO load from config?
-side_padding = 15
-btn_width_apart = 105
-btn_padding = 20
-DEFAULT_TEXT = '...'
 
 class RSVPKeyboard(BCIGui):
-    """GUI for launching the RSVP tasks."""
+    """GUI for launching the RSVP tasks and editing parameters."""
+
+    tasks = ExperimentType.by_mode()['RSVP']
+
+    default_text = '...'
+    padding = 15
+    btn_width_apart = 105
+    btn_padding = 20
 
     def __init__(self, *args, **kwargs):
         super(RSVPKeyboard, self).__init__(*args, **kwargs)
@@ -35,21 +35,22 @@ class RSVPKeyboard(BCIGui):
             ['blue', 'green', 'yellow', 'red', 'limegreen', 'gray', 'pink'])
 
     def select_parameters(self) -> None:
-        """Dialog to select the parameters.json configuration to use."""
-        with wx.FileDialog(self,
-                           'Select parameters file',
-                           wildcard='JSON files (*.json)|*.json',
-                           style=wx.FD_OPEN | wx.FD_FILE_MUST_EXIST) as fd:
-            if fd.ShowModal() != wx.ID_CANCEL:
-                self.parameter_location = fd.GetPath()
+        """Select Parameters.
+        
+        Opens a dialog to select the parameters.json configuration to use.
+        """
+
+        response = self.get_filename_dialog(message='Select parameters file', file_type='JSON files (*.json)')
+        if response:
+            self.parameter_location = response
 
     def edit_parameters(self) -> None:
-        """Edit Parameters. Prompts for a parameters.json file to use. If the default parameters
-        are selected a copy is used.
+        """Edit Parameters. 
+        
+        Prompts for a parameters.json file to use. If the default parameters are selected, a copy is used.
         """
         if self.parameter_location == DEFAULT_PARAMETERS_PATH:
             # Don't allow the user to overwrite the defaults
-
             response = self.throw_alert_message(
                 title='BciPy Alert',
                 message='The default parameters.json cannot be overridden. A copy will be used.',
@@ -59,18 +60,22 @@ class RSVPKeyboard(BCIGui):
             if response == AlertResponse.OK.value:
                     self.parameter_location = copy_parameters()
             else:
-                return
+                return None
 
         subprocess.call(
             f'python bcipy/gui/params_form.py -p {self.parameter_location}',
             shell=True)
 
     def launch_bci_main(self) -> None:
-        """Launch BCI MAIN"""
+        """Launch BCI main.
+        
+        If a user id has been selected, get the id set on the task button and execute
+            the task in a new shell. 
+        """
         if self.check_input():
             self.event_started = True
             username = self.user_input.currentText()
-            experiment_type = 1
+            experiment_type = self.sender().get_id()
             mode = 'RSVP'
             cmd = 'python bci_main.py -m {} -t {} -u {} -p {}'.format(
                 mode, experiment_type, username, self.parameter_location)
@@ -78,16 +83,18 @@ class RSVPKeyboard(BCIGui):
             subprocess.Popen(cmd, shell=True)
 
     def check_input(self) -> bool:
-        """Check Input."""
+        """Check Input.
+        
+        Checks to make sure user has input all required fields. Currently, only user id is required.
+        """
         try:
-            if self.user_input.currentText() == DEFAULT_TEXT:
+            if self.user_input.currentText() == RSVPKeyboard.default_text:
                 self.throw_alert_message(
                     title='BciPy Alert',
                     message='Please input a User ID',
                     message_type=AlertMessageType.INFO,
                     okay_to_exit=True)
                 return False
-            # TODO add timer instead of using state / refresh
             if self.event_started:
                 return False
         except Exception as e:
@@ -106,12 +113,18 @@ class RSVPKeyboard(BCIGui):
         subprocess.Popen(cmd, shell=True)
 
     def refresh(self) -> None:
+        """Refresh.
+        
+        Reset event_started to False to allow a new task to be selected.
+        """
         self.event_started = False
 
-    def load_items_from_txt(self):
-        """Loads user directory names from the data path defined in
-        parameters.json, and adds those directory names as items to the user id
-        selection combobox."""
+    def load_items_from_txt(self) -> List[str]:
+        """Load Items From Text.
+        
+        Loads user directory names below experiments from the data path defined in parameters.json
+        and returns them as a list.
+        """
         saved_users = []
         data_save_loc = self.parameters['data_save_loc']
 
@@ -135,24 +148,28 @@ class RSVPKeyboard(BCIGui):
 
         return saved_users
 
-    def fast_scandir(self, dirname, return_path=True):
+    def fast_scandir(self, directory_name: str, return_path: bool=True) -> List[str]:
         """Fast Scan Directory.
         
-        dirname: name of the directory to be scanned
-        return_path: whether or not to return the scanned directories as a relative path
+        directory_name: name of the directory to be scanned
+        return_path: whether or not to return the scanned directories as a relative path or name.
             False will return the directory name only.
         """
         if return_path:
-            return [ f.path for f in os.scandir(dirname) if f.is_dir() ]
+            return [ f.path for f in os.scandir(directory_name) if f.is_dir() ]
 
-        return [ f.name for f in os.scandir(dirname) if f.is_dir()]
+        return [ f.name for f in os.scandir(directory_name) if f.is_dir()]
 
-    def build_buttons(self):
+    def build_buttons(self) -> None:
+        """Build buttons.
+        
+        Construct all buttons needed for RSVPKeyboard.
+        """
         btn_size = [85, 80]
-        btn_pos_x = side_padding
+        btn_pos_x = self.padding
         btn_pos_y = 300
 
-        for task in tasks:
+        for task in RSVPKeyboard.tasks:
             self.add_button(
                 message=task.label,
                 position=[btn_pos_x, btn_pos_y],
@@ -160,38 +177,42 @@ class RSVPKeyboard(BCIGui):
                 background_color=next(self.task_colors),
                 action=self.launch_bci_main,
                 id=task.value)
-            btn_pos_x += btn_width_apart
+            btn_pos_x += self.btn_width_apart
 
         command_btn_height = 40
         self.add_button(
-            message='Load Parameters', position=[side_padding, 450],
+            message='Load Parameters', position=[self.padding, 450],
             size=[105, command_btn_height], background_color='white',
             action=self.select_parameters)
 
         self.add_button(
-            message='Edit', position=[side_padding + 110, 450],
+            message='Edit', position=[self.padding + 110, 450],
             size=[50, command_btn_height], background_color='white',
             action=self.edit_parameters)
 
         btn_auc_width = 100
-        btn_auc_x = self.width - (2 * side_padding + btn_auc_width)
+        btn_auc_x = self.width - (2 * self.padding + btn_auc_width)
         self.add_button(
             message='Calculate AUC', position=(btn_auc_x, 450),
             size=(btn_auc_width, command_btn_height), background_color='white',
             action=self.offline_analysis)
 
         btn_refresh_width = 50
-        btn_refresh_x = self.width - (2 * side_padding + btn_refresh_width)
+        btn_refresh_x = self.width - (2 * self.padding + btn_refresh_width)
         self.add_button(
             message='Refresh', position=[btn_refresh_x, 230],
             size=[btn_refresh_width, command_btn_height], background_color='white',
             action=self.refresh)
 
-    def build_inputs(self):
+    def build_inputs(self) -> None:
+        """Build Inputs.
+        
+        Build all inputs needed for RSVPKeyboard.
+        """
         items = self.load_items_from_txt()
 
         # add default text for editting at the beginning
-        items.insert(0, DEFAULT_TEXT)
+        items.insert(0, RSVPKeyboard.default_text)
 
         self.user_input = self.add_combobox(
                 position=[75, 150],
@@ -201,13 +222,22 @@ class RSVPKeyboard(BCIGui):
                 background_color='white',
                 text_color='black')
 
-    def build_images(self):
+    def build_images(self) -> None:
+        """Build Images.
+        
+        Add all images needed for the RSVPKeyboard GUI.
+        """
         self.add_image(
-            path='bcipy/static/images/gui_images/ohsu.png', position=[side_padding, 0], size=100)
+            path='bcipy/static/images/gui_images/ohsu.png', position=[self.padding, 0], size=100)
         self.add_image(
             path='bcipy/static/images/gui_images/neu.png', position=[530, 0], size=100)
 
-    def build_text(self):
+    def build_text(self) -> None:
+        """Build Text.
+        
+        Add all static text needed for RSVPKeyboard. Note: these are textboxes and require that you 
+            shape the size of the box as well as the text size.
+        """
         self.add_static_textbox(
             text='RSVPKeyboard', position=[185, 0], size=[100, 50], background_color='black', text_color='white')
         self.add_static_textbox(
@@ -216,18 +246,11 @@ class RSVPKeyboard(BCIGui):
             text='2.) Choose your experiment type:',
             position=[75, 250], size=[300, 50], background_color='black', text_color='white')
 
-    def build_assets(self):
 
-        self.build_text()
-        self.build_inputs()
-        self.build_buttons()
-        self.build_images()
-
-
-def run_rsvp_gui():
+def run_rsvp_gui() -> None:
     """Create the GUI and run"""
     bcipy_gui = app(sys.argv)
-    window_width = (len(tasks) * btn_width_apart) + btn_padding
+    window_width = (len(RSVPKeyboard.tasks) * RSVPKeyboard.btn_width_apart) + RSVPKeyboard.btn_padding
     # Start the app and init the main GUI
     gui = RSVPKeyboard(
         title="RSVPKeyboard",

--- a/bcipy/gui/mode/RSVPKeyboard.py
+++ b/bcipy/gui/mode/RSVPKeyboard.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import wx
 
-from bcipy.gui.gui_main import BCIGui, app, PushButton
+from bcipy.gui.gui_main import BCIGui, app, AlertMessageType, AlertResponse
 from bcipy.helpers.load import load_json_parameters, copy_parameters
 from bcipy.helpers.parameters import DEFAULT_PARAMETERS_PATH
 
@@ -18,6 +18,7 @@ tasks = ExperimentType.by_mode()['RSVP']
 side_padding = 15
 btn_width_apart = 105
 btn_padding = 20
+DEFAULT_TEXT = '...'
 
 class RSVPKeyboard(BCIGui):
     """GUI for launching the RSVP tasks."""
@@ -26,6 +27,9 @@ class RSVPKeyboard(BCIGui):
         super(RSVPKeyboard, self).__init__(*args, **kwargs)
         self.event_started = False
         self.parameter_location = DEFAULT_PARAMETERS_PATH
+
+        self.parameters = load_json_parameters(
+            self.parameter_location, value_cast=True)
 
         self.task_colors = itertools.cycle(
             ['blue', 'green', 'yellow', 'red', 'limegreen', 'gray', 'pink'])
@@ -45,15 +49,17 @@ class RSVPKeyboard(BCIGui):
         """
         if self.parameter_location == DEFAULT_PARAMETERS_PATH:
             # Don't allow the user to overwrite the defaults
-            with wx.MessageDialog(
-                    self,
-                    "The default parameters.json can't be overridden. A copy will be used.",
-                    'Info', wx.OK | wx.CANCEL) as confirm_dialog:
-                response = confirm_dialog.ShowModal()
-                if response == wx.ID_OK:
+
+            response = self.throw_alert_message(
+                title='BciPy Alert',
+                message='The default parameters.json cannot be overridden. A copy will be used.',
+                message_type=AlertMessageType.INFO,
+                okay_or_cancel=True)
+
+            if response == AlertResponse.OK.value:
                     self.parameter_location = copy_parameters()
-                else:
-                    return
+            else:
+                return
 
         subprocess.call(
             f'python bcipy/gui/params_form.py -p {self.parameter_location}',
@@ -63,8 +69,8 @@ class RSVPKeyboard(BCIGui):
         """Launch BCI MAIN"""
         if self.check_input():
             self.event_started = True
-            username = self.comboboxes[0].GetValue().replace(" ", "_")
-            experiment_type = event.GetEventObject().GetId()
+            username = self.user_input.currentText()
+            experiment_type = 1
             mode = 'RSVP'
             cmd = 'python bci_main.py -m {} -t {} -u {} -p {}'.format(
                 mode, experiment_type, username, self.parameter_location)
@@ -74,21 +80,22 @@ class RSVPKeyboard(BCIGui):
     def check_input(self) -> bool:
         """Check Input."""
         try:
-            if self.comboboxes[0].GetValue() == '':
-                dialog = wx.MessageDialog(
-                    self, "Please Input User ID", 'Info',
-                    wx.OK | wx.ICON_WARNING)
-                dialog.ShowModal()
-                dialog.Destroy()
+            if self.user_input.currentText() == DEFAULT_TEXT:
+                self.throw_alert_message(
+                    title='BciPy Alert',
+                    message='Please input a User ID',
+                    message_type=AlertMessageType.INFO,
+                    okay_to_exit=True)
                 return False
+            # TODO add timer instead of using state / refresh
             if self.event_started:
                 return False
         except Exception as e:
-            dialog = wx.MessageDialog(
-                self, f'Error, {e}',
-                'Info', wx.OK | wx.ICON_WARNING)
-            dialog.ShowModal()
-            dialog.Destroy()
+            self.throw_alert_message(
+                    title='BciPy Alert',
+                    message=f'Error, {e}',
+                    message_type=AlertMessageType.CRIT,
+                    okay_to_exit=True)
             return False
         return True
 
@@ -105,22 +112,46 @@ class RSVPKeyboard(BCIGui):
         """Loads user directory names from the data path defined in
         parameters.json, and adds those directory names as items to the user id
         selection combobox."""
-        saved_users = None
-        parameters = load_json_parameters(
-            self.parameter_location, value_cast=True)
-        data_save_loc = parameters['data_save_loc']
+        saved_users = []
+        data_save_loc = self.parameters['data_save_loc']
+
+        # check the directory is valid
         if os.path.isdir(data_save_loc):
-            saved_users = os.listdir(data_save_loc)
-        elif os.path.isdir('bcipy/' + data_save_loc):
-            saved_users = os.listdir('bcipy/' + data_save_loc)
+            path = data_save_loc
+
+        elif os.path.isdir(f'bcipy/{data_save_loc}'):
+            path = f'bcipy/{data_save_loc}'
+
         else:
-            raise IOError('User data save location not found')
+            self.logger.info('User data save location not found! Please enter a new user id.')
+            return saved_users
+
+        # grab all experiments in the directory and iterate over them to get the users
+        experiments = self.fast_scandir(path, return_path=True)
+
+        for experiment in experiments:
+            users = self.fast_scandir(experiment, return_path=False)
+            saved_users.extend(users)
+
         return saved_users
+
+    def fast_scandir(self, dirname, return_path=True):
+        """Fast Scan Directory.
+        
+        dirname: name of the directory to be scanned
+        return_path: whether or not to return the scanned directories as a relative path
+            False will return the directory name only.
+        """
+        if return_path:
+            return [ f.path for f in os.scandir(dirname) if f.is_dir() ]
+
+        return [ f.name for f in os.scandir(dirname) if f.is_dir()]
 
     def build_buttons(self):
         btn_size = [85, 80]
         btn_pos_x = side_padding
         btn_pos_y = 300
+
         for task in tasks:
             self.add_button(
                 message=task.label,
@@ -136,6 +167,7 @@ class RSVPKeyboard(BCIGui):
             message='Load Parameters', position=[side_padding, 450],
             size=[105, command_btn_height], background_color='white',
             action=self.select_parameters)
+
         self.add_button(
             message='Edit', position=[side_padding + 110, 450],
             size=[50, command_btn_height], background_color='white',
@@ -157,7 +189,17 @@ class RSVPKeyboard(BCIGui):
 
     def build_inputs(self):
         items = self.load_items_from_txt()
-        self.add_combobox(position=[75, 150], size=[250, 25], items=items)
+
+        # add default text for editting at the beginning
+        items.insert(0, DEFAULT_TEXT)
+
+        self.user_input = self.add_combobox(
+                position=[75, 150],
+                size=[280, 40],
+                items=items,
+                editable=True,
+                background_color='white',
+                text_color='black')
 
     def build_images(self):
         self.add_image(
@@ -166,19 +208,20 @@ class RSVPKeyboard(BCIGui):
             path='bcipy/static/images/gui_images/neu.png', position=[530, 0], size=100)
 
     def build_text(self):
-        self.add_static_text(
-            text='RSVPKeyboard', position=[185, 0], size=[25, 25], text_color='white')
-        self.add_static_text(
-            text='1.) Enter a User ID:', position=[75, 110], size=[15, 15], text_color='white')
-        self.add_static_text(
+        self.add_static_textbox(
+            text='RSVPKeyboard', position=[185, 0], size=[100, 50], background_color='black', text_color='white')
+        self.add_static_textbox(
+            text='1.) Enter a User ID:', position=[75, 110], size=[200, 50], background_color='black', text_color='white')
+        self.add_static_textbox(
             text='2.) Choose your experiment type:',
-            position=[75, 250], size=[15, 15], text_color='white')
+            position=[75, 250], size=[300, 50], background_color='black', text_color='white')
 
     def build_assets(self):
 
+        self.build_text()
+        self.build_inputs()
         self.build_buttons()
         self.build_images()
-        self.build_text()
 
 
 def run_rsvp_gui():
@@ -192,8 +235,7 @@ def run_rsvp_gui():
         height=550,
         background_color='black')
 
-
-    # Make the GUI Show now
+    # Make the GUI display
     gui.show_gui()
 
     sys.exit(bcipy_gui.exec_())

--- a/bcipy/gui/mode/RSVPKeyboard.py
+++ b/bcipy/gui/mode/RSVPKeyboard.py
@@ -30,9 +30,11 @@ class RSVPKeyboard(BCIGui):
 
         self.parameters = load_json_parameters(
             self.parameter_location, value_cast=True)
-
         self.task_colors = itertools.cycle(
-            ['blue', 'green', 'yellow', 'red', 'limegreen', 'gray', 'pink'])
+            ['Tomato', 'orange', 'MediumTurquoise', 'MediumSeaGreen', 'MediumPurple', 'Moccasin'])
+
+        # This is set in the build_inputs method that is called automatically when using show_gui
+        self.user_input = None
 
     def select_parameters(self) -> None:
         """Select Parameters.

--- a/bcipy/gui/mode/RSVPKeyboard.py
+++ b/bcipy/gui/mode/RSVPKeyboard.py
@@ -36,7 +36,7 @@ class RSVPKeyboard(BCIGui):
 
     def select_parameters(self) -> None:
         """Select Parameters.
-        
+
         Opens a dialog to select the parameters.json configuration to use.
         """
 
@@ -45,8 +45,8 @@ class RSVPKeyboard(BCIGui):
             self.parameter_location = response
 
     def edit_parameters(self) -> None:
-        """Edit Parameters. 
-        
+        """Edit Parameters.
+
         Prompts for a parameters.json file to use. If the default parameters are selected, a copy is used.
         """
         if self.parameter_location == DEFAULT_PARAMETERS_PATH:
@@ -58,7 +58,7 @@ class RSVPKeyboard(BCIGui):
                 okay_or_cancel=True)
 
             if response == AlertResponse.OK.value:
-                    self.parameter_location = copy_parameters()
+                self.parameter_location = copy_parameters()
             else:
                 return None
 
@@ -68,9 +68,9 @@ class RSVPKeyboard(BCIGui):
 
     def launch_bci_main(self) -> None:
         """Launch BCI main.
-        
+
         If a user id has been selected, get the id set on the task button and execute
-            the task in a new shell. 
+            the task in a new shell.
         """
         if self.check_input():
             self.event_started = True
@@ -84,7 +84,7 @@ class RSVPKeyboard(BCIGui):
 
     def check_input(self) -> bool:
         """Check Input.
-        
+
         Checks to make sure user has input all required fields. Currently, only user id is required.
         """
         try:
@@ -99,10 +99,10 @@ class RSVPKeyboard(BCIGui):
                 return False
         except Exception as e:
             self.throw_alert_message(
-                    title='BciPy Alert',
-                    message=f'Error, {e}',
-                    message_type=AlertMessageType.CRIT,
-                    okay_to_exit=True)
+                title='BciPy Alert',
+                message=f'Error, {e}',
+                message_type=AlertMessageType.CRIT,
+                okay_to_exit=True)
             return False
         return True
 
@@ -114,14 +114,14 @@ class RSVPKeyboard(BCIGui):
 
     def refresh(self) -> None:
         """Refresh.
-        
+
         Reset event_started to False to allow a new task to be selected.
         """
         self.event_started = False
 
     def load_items_from_txt(self) -> List[str]:
         """Load Items From Text.
-        
+
         Loads user directory names below experiments from the data path defined in parameters.json
         and returns them as a list.
         """
@@ -148,21 +148,21 @@ class RSVPKeyboard(BCIGui):
 
         return saved_users
 
-    def fast_scandir(self, directory_name: str, return_path: bool=True) -> List[str]:
+    def fast_scandir(self, directory_name: str, return_path: bool = True) -> List[str]:
         """Fast Scan Directory.
-        
+
         directory_name: name of the directory to be scanned
         return_path: whether or not to return the scanned directories as a relative path or name.
             False will return the directory name only.
         """
         if return_path:
-            return [ f.path for f in os.scandir(directory_name) if f.is_dir() ]
+            return [f.path for f in os.scandir(directory_name) if f.is_dir()]
 
-        return [ f.name for f in os.scandir(directory_name) if f.is_dir()]
+        return [f.name for f in os.scandir(directory_name) if f.is_dir()]
 
     def build_buttons(self) -> None:
         """Build buttons.
-        
+
         Construct all buttons needed for RSVPKeyboard.
         """
         btn_size = [85, 80]
@@ -206,7 +206,7 @@ class RSVPKeyboard(BCIGui):
 
     def build_inputs(self) -> None:
         """Build Inputs.
-        
+
         Build all inputs needed for RSVPKeyboard.
         """
         items = self.load_items_from_txt()
@@ -215,36 +215,50 @@ class RSVPKeyboard(BCIGui):
         items.insert(0, RSVPKeyboard.default_text)
 
         self.user_input = self.add_combobox(
-                position=[75, 150],
-                size=[280, 40],
-                items=items,
-                editable=True,
-                background_color='white',
-                text_color='black')
+            position=[75, 150],
+            size=[280, 40],
+            items=items,
+            editable=True,
+            background_color='white',
+            text_color='black')
 
     def build_images(self) -> None:
         """Build Images.
-        
+
         Add all images needed for the RSVPKeyboard GUI.
         """
         self.add_image(
             path='bcipy/static/images/gui_images/ohsu.png', position=[self.padding, 0], size=100)
         self.add_image(
-            path='bcipy/static/images/gui_images/neu.png', position=[530, 0], size=100)
+            path='bcipy/static/images/gui_images/neu.png', position=[self.width - self.padding - 100, 0], size=100)
 
     def build_text(self) -> None:
         """Build Text.
-        
-        Add all static text needed for RSVPKeyboard. Note: these are textboxes and require that you 
+
+        Add all static text needed for RSVPKeyboard. Note: these are textboxes and require that you
             shape the size of the box as well as the text size.
         """
         self.add_static_textbox(
-            text='RSVPKeyboard', position=[185, 0], size=[100, 50], background_color='black', text_color='white')
+            text='RSVPKeyboard',
+            position=[275, 0],
+            size=[200, 50],
+            background_color='black',
+            text_color='white',
+            font_size=30)
         self.add_static_textbox(
-            text='1.) Enter a User ID:', position=[75, 110], size=[200, 50], background_color='black', text_color='white')
+            text='1.) Enter a User ID:',
+            position=[75, 110],
+            size=[200, 50],
+            background_color='black',
+            text_color='white',
+            font_size=14)
         self.add_static_textbox(
             text='2.) Choose your experiment type:',
-            position=[75, 250], size=[300, 50], background_color='black', text_color='white')
+            position=[75, 250],
+            size=[300, 50],
+            background_color='black',
+            text_color='white',
+            font_size=14)
 
 
 def run_rsvp_gui() -> None:

--- a/bcipy/gui/params_form.py
+++ b/bcipy/gui/params_form.py
@@ -38,11 +38,11 @@ Parameter = namedtuple('Parameter', ['value', 'section', 'readableName',
 class Form(wx.Panel):
     """The Form class is a wx.Panel that creates controls/inputs for each
     parameter in the provided json file.
-    
+
     Parameters:
     -----------
       json_file - path of parameters file to be edited.
-      load_file - optional path of parameters file to load; 
+      load_file - optional path of parameters file to load;
           parameters from this file will be copied over to the json_file.
       control_width - optional; used to set the size of the form controls.
       control_height - optional; used to set the size of the form controls.
@@ -74,7 +74,7 @@ class Form(wx.Panel):
     def createControls(self):
         """Create controls (inputs, labels, etc) for each item in the
         parameters file.
-        
+
         TODO: include a search box for finding an input
         """
 

--- a/bcipy/helpers/load.py
+++ b/bcipy/helpers/load.py
@@ -1,7 +1,5 @@
 import logging
 import pickle
-from codecs import open as codecsopen
-from json import load as jsonload
 from pathlib import Path
 from shutil import copyfile
 from time import localtime, strftime

--- a/bcipy/helpers/system_utils.py
+++ b/bcipy/helpers/system_utils.py
@@ -92,8 +92,8 @@ def get_system_info() -> dict:
 
     Returns
     -------
-        dict of system-related properties, including ['os', 'py_version', 'resolution', 
-          'memory', 'bcipy_version', 'platform', 'platform-release', 'platform-version', 
+        dict of system-related properties, including ['os', 'py_version', 'resolution',
+          'memory', 'bcipy_version', 'platform', 'platform-release', 'platform-version',
           'architecture', 'processor', 'cpu_count', 'hz', 'ram']
     """
     screen_width, screen_height = get_screen_resolution()

--- a/bcipy/helpers/tests/test_load.py
+++ b/bcipy/helpers/tests/test_load.py
@@ -9,6 +9,7 @@ from bcipy.helpers.load import (load_json_parameters, load_signal_model,
                                 copy_parameters)
 from bcipy.helpers.parameters import Parameters
 
+
 class TestLoad(unittest.TestCase):
     """This is Test Case for Loading BCI data."""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pandas==1.1.3
 psutil==5.7.2
 Pillow==8.0.0
 py-cpuinfo==7.0.0
+PyQt5==5.15.1


### PR DESCRIPTION
# Overview

Refactored base GUI to use PyQT5 instead of WxPython. This required `gui_main`, `BCInterface` and `RSVPKeyboard` to be redone.

## Ticket

https://www.pivotaltracker.com/story/show/175194654

## Contributions

- Refactored `gui_main`. I kept many of the same methods and updated them to use PyQt5 functionality. I added more default methods (ex. `build_assests`) and abstractions (`AlertResponse`, `AlertMessageType`) to help isolate the downstream GUIS from the knowledge of PyQT5. 
- Refactored `RSVPKeyboard` and `BCInterface` to use new base class and methods (`build_*`)
- Ignore non-default parameters. 

## Test

- Run `python bcipy/gui/gui_main.py`
- Run `python bcipy/gui/BCInterface.py`. Select RSVP.
- Run `python bcipy/gui/mode/RSVPKeyboard.py`. Input a user_id, run a task. Edit and load parameters.

## Documentaion

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.
