### PR TITLE
sklearn Deprecation Warning has been fixed.

### DIFF
--- a/bcipy/signal/model/mach_learning/generative_mods/function_density_estimation.py
+++ b/bcipy/signal/model/mach_learning/generative_mods/function_density_estimation.py
@@ -1,4 +1,4 @@
-from sklearn.neighbors.kde import KernelDensity
+from sklearn.neighbors import KernelDensity
 import numpy as np
 
 


### PR DESCRIPTION
# Overview

sklearn: Deprecation Warning has been fixed.

## Ticket

https://www.pivotaltracker.com/n/projects/2460065/stories/175322073

## Contributions

- KernelDensity class in function_density_estimation.py is imported from sklearn.neighbors instead of sklearn.neighbors.kde.

## Test

- The above function/class call is tested within demo_density_estimation.py
