### PR TITLE
sklearn Deprecation Warning has been fixed.

### DIFF
--- a/bcipy/signal/model/mach_learning/generative_mods/function_density_estimation.py
+++ b/bcipy/signal/model/mach_learning/generative_mods/function_density_estimation.py
@@ -1,4 +1,4 @@
-from sklearn.neighbors.kde import KernelDensity
+from sklearn.neighbors import KernelDensity
 import numpy as np
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ numpy==1.19.2
 sounddevice==0.4.1
 SoundFile==0.10.3.post1
 scipy==1.5.2
-sklearn==0.0
+scikit-learn==0.23.2
 seaborn==0.9.0
 matplotlib==2.1.1
 pylsl==1.13.1


### PR DESCRIPTION
# Overview

sklearn: Deprecation Warning has been fixed.
sklearn requirement has been updated to scikit-learn.

## Ticket

https://www.pivotaltracker.com/n/projects/2460065/stories/175322073

## Contributions

- KernelDensity class in function_density_estimation.py is imported from sklearn.neighbors instead of sklearn.neighbors.kde
- sklearn==0.0 requirement in requirements.txt has been updated to scikit-learn==0.23.2

## Test

- The above function/class call is run within demo_density_estimation.py
- Unit tests applied. Passed successfully.
