### PR TITLE
#176018012 ; lang_model_enabled parameter

### DIFF
--- a/bci_main.py
+++ b/bci_main.py
@@ -102,7 +102,7 @@ def execute_task(task_type: dict, parameters: dict, save_folder: str) -> bool:
             raise e
 
         # if Language Model enabled init lm
-        if parameters['languagemodelenabled']:
+        if parameters['lang_model_enabled']:
             language_model = init_language_model(parameters)
 
     # Initialize DAQ


### PR DESCRIPTION
# Overview

The parameter for lang_model_enabled changed but bci_main was still referencing the old value, resulting in a KeyError. This PR fixes the error by using the correct parameter name.

## Ticket

https://www.pivotaltracker.com/story/show/176018012

## Contributions

- Fixes a bug in BCI main.

## Test

- Run the Copy Phrase task with the fake_data parameter set to false. It should not throw a KeyError.