### PR TITLE
library changes to support Windows 10 / python3.7

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,4 +6,3 @@ mockito==1.1.0
 pylint==2.3.1
 pytest==3.1.3
 twine==3.2.0
-wheel==0.30.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,10 @@
-wxPython==4.0.1
+wheel==0.30.0
+wxPython==4.1.1
 docker==2.6.1
 construct==2.8.14
 mne==0.17.0
 opencv_python==4.1.0.25
-PsychoPy==2020.2.5
+PsychoPy==2020.2.10
 pyglet==1.5.8
 numpy==1.19.2
 sounddevice==0.4.1
@@ -11,7 +12,7 @@ SoundFile==0.10.3.post1
 scipy==1.5.2
 scikit-learn==0.23.2
 seaborn==0.9.0
-matplotlib==2.1.1
+matplotlib==3.1.1
 pylsl==1.13.1
 pandas==1.1.3
 psutil==5.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wheel==0.30.0
-wxPython==4.1.1
+wxPython==4.0.4
 docker==2.6.1
 construct==2.8.14
 mne==0.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ construct==2.8.14
 mne==0.17.0
 opencv_python==4.1.0.25
 PsychoPy==2020.2.10
-pyglet==1.5.8
+pyglet==1.4.10
 numpy==1.19.2
 sounddevice==0.4.1
 SoundFile==0.10.3.post1


### PR DESCRIPTION
# Overview

Upgraded dependencies to work with Windows 10 installs. This helps with issues installing pywinhook, which requires python 3.7+ or manual installation. Downgraded pyglet to address this issue: https://github.com/psychopy/psychopy/issues/2876

Pip must also be updated to the latest.

## Ticket

N/A

## Contributions

- updated requirements.txt to include wheel (helps with installs), matlplotlib==3.1.1 which allows for more easy 3.7 + installs, PsychoPy minor bump. Downgraded pyglet to more functional version across OS. 

## Test

- Installed in a virtualenv (and globally) in Windows. Ran pytest and experiment from gui. 
- Installed in a virtualenv (and globally) in MacOs High Sierra. Ran pytest and experiment from gui. 

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here. No
