### PR TITLE
Add experiment-field ui

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,8 +12,8 @@ Link a pivotal ticket here
 
 ## Test
 
-- Define steps used to test here. Include unit and integration test steps!
+- Define the steps used to test your code here. Include unit and integration test steps!
 
-## Documentaion
+## Documentation
 
 - Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+install:
+	pip install -e .
+
+dev-install:
+	pip install -r dev_requirements.txt
+	pip install -e .
+
+test-all:
+	coverage run --branch --source=bcipy -m pytest
+	flake8 bcipy
+	coverage report
+
+coverage-html:
+	coverage run --branch --source=bcipy -m pytest
+	coverage html
+
+lint:
+	autopep8 --in-place --aggressive -r bcipy
+	flake8 bcipy
+
+clean:
+	find . -name "*.py[co]" -o -name __pycache__ -exec rm -rf {} +
+	find . -path "*/*.pyo"  -delete
+	find . -path "*/*.pyc"  -delete

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ To use all the goodies locally (including the GUI and demo scripts)
 If wanting the latest version from PyPi:
 1. `pip install bcipy`
 
+Alternatley, if [Make](http://www.mingw.org/) is installed, you may run the follow command to run install:
+
+```sh
+# install in development mode
+make dev-install
+```
+
 ## Usage Locally
 
 Start by running `python bcipy/gui/BCInterface.py` in your command prompt or terminal. You may also invoke the experiment directly using command line tools for bci_main.py.
@@ -159,6 +166,12 @@ coverage report
 coverage html
 ```
 
+Alternatley, if Make is installed, you may run the follow command to run coverage and generate the html:
+
+```sh
+make coverage-html
+```
+
 ## Linting
 
 This project enforces `PEP` style guidelines using [flake8](http://flake8.pycqa.org/en/latest/).
@@ -174,6 +187,12 @@ autopep8 --in-place --aggressive bcipy/acquisition/processor.py
 ```
 
 Finally, run the lint check: `flake8 bcipy`.
+
+Alternatley, if Make is installed, you may run the follow command to run autopep8 and flake8:
+
+```sh
+make lint
+```
 
 ## Authorship
 --------------

--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 import subprocess
 import sys
@@ -13,8 +12,8 @@ from bcipy.tasks.task_registry import TaskType
 
 class BCInterface(BCIGui):
     """BCI Interface.
-    
-    Main interface for execution of BciPy experiments and tasks. Additionally, quick access to parameter 
+
+    Main interface for execution of BciPy experiments and tasks. Additionally, quick access to parameter
         editing and loading, and offline analysis execution.
     """
 
@@ -43,7 +42,7 @@ class BCInterface(BCIGui):
 
     def build_buttons(self) -> None:
         """Build Buttons.
-        
+
         Build all buttons necessary for the UI. Define their action on click using the named argument action.
         """
         self.add_button(
@@ -170,8 +169,9 @@ class BCInterface(BCIGui):
 
     def build_text(self) -> None:
         """Build Text.
-        
-        Build all static text needed for the UI. Positions are relative to the height / width of the UI defined in start_app.
+
+        Build all static text needed for the UI.
+        Positions are relative to the height / width of the UI defined in start_app.
         """
         self.add_static_textbox(
             text='BCInterface',
@@ -206,7 +206,7 @@ class BCInterface(BCIGui):
 
     def build_images(self) -> None:
         """Build Images.
-        
+
         Build add images needed for the UI. In this case, the OHSU and NEU logos.
         """
         self.add_image(
@@ -216,7 +216,7 @@ class BCInterface(BCIGui):
 
     def build_assets(self) -> None:
         """Build Assets.
-        
+
         Define the assets to build in the UI.
         """
         self.build_buttons()
@@ -250,7 +250,8 @@ class BCInterface(BCIGui):
             if self.parameters.add_missing_items(default_parameters):
                 save_response = self.throw_alert_message(
                     title='BciPy Alert',
-                    message='The selected parameters file is out of date. Would you like to update it with the latest options?',
+                    message='The selected parameters file is out of date.'
+                            'Would you like to update it with the latest options?',
                     message_type=AlertMessageType.INFO,
                     okay_or_cancel=True)
 
@@ -370,12 +371,15 @@ class BCInterface(BCIGui):
         """
         if self.check_input():
             self.event_started = True
-            cmd = f'python bci_main.py -e "{self.experiment}" -u "{self.user}" -t "{self.task}" -p "{self.parameter_location}"'
+            cmd = (
+                f'python bci_main.py -e "{self.experiment}" '
+                f'-u "{self.user}" -t "{self.task}" -p "{self.parameter_location}"'
+            )
             subprocess.Popen(cmd, shell=True)
 
     def offline_analysis(self) -> None:
         """Offline Analysis.
-        
+
         Run offline analysis as a script in a new process.
         """
         cmd = 'python bcipy/signal/model/offline_analysis.py'

--- a/bcipy/gui/experiments/ExperimentField.py
+++ b/bcipy/gui/experiments/ExperimentField.py
@@ -1,0 +1,301 @@
+"""GUI form for collecting experimental field data."""
+# pylint: disable=E0611
+
+import sys
+
+from typing import List
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QHBoxLayout,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from bcipy.gui.gui_main import (
+    AlertMessageType,
+    AlertResponse,
+    app,
+    BoolInput,
+    DirectoryInput,
+    FileInput,
+    FormInput,
+    TextInput
+)
+from bcipy.helpers.load import load_experiments, load_fields
+from bcipy.helpers.save import save_experiment_field_data
+
+
+class ExperimentFieldCollection(QWidget):
+    """Experiment Field Collection.
+
+    Given an experiment with fields to be collected, this UI can be used to collect data in the correct format
+        and require fields which are noted as such in the experiment.
+    """
+    field_data: List[tuple] = []
+    field_inputs: List[FormInput] = []
+    type_inputs = {
+        'bool': BoolInput,
+        'filepath': FileInput,
+        'directorypath': DirectoryInput
+    }
+    require_mark = '*'
+    save_data = {}
+
+    def __init__(self, title: str, width: int, height: int, experiment_name: str, save_path: str, file_name: str):
+        super().__init__()
+
+        self.experiment_name = experiment_name
+        self.experiment = load_experiments()[experiment_name]
+        self.save_path = save_path
+        self.file_name = file_name
+        self.help_size = 12
+        self.help_color = 'darkgray'
+        self.width = width
+        self.height = height
+        self.title = title
+
+        self.fields = load_fields()
+        self.build_field_data()
+        self.build_assets()
+        self.do_layout()
+
+    def do_layout(self) -> None:
+        """Layout the form controls."""
+        vbox = QVBoxLayout()
+
+        # Add the controls to the grid:
+        for form_input in self.field_inputs:
+            vbox.addWidget(form_input)
+
+        self.setLayout(vbox)
+        self.setFixedWidth(self.width)
+        self.show()
+
+    def build_form(self) -> None:
+        """Build Form.
+        
+        Loop over the field data and create UI field inputs for data collection.
+        """
+        for field_name, field_type, required, help_text in self.field_data:
+            self.field_inputs.append(self.field_input(field_name, field_type, help_text, required))
+
+    def field_input(self, field_name: str, field_type: str, help_tip: str, required: bool) -> FormInput:
+        """Field Input.
+        
+        Construct a FormInput for the given field based on its python type and other
+        attributes.
+        """
+
+        form_input = self.type_inputs.get(field_type, TextInput)
+        if required:
+            field_name += self.require_mark
+        return form_input(
+            label=field_name,
+            value='',
+            help_tip=help_tip,
+            help_size=self.help_size,
+            help_color=self.help_color)
+
+    def build_assets(self) -> None:
+        """Build Assets.
+        
+        Build any needed assests for the Experiment Field Widget. Currently, only a form is needed.
+        """
+        self.build_form()
+
+    def check_input(self) -> bool:
+        """Check Input.
+
+        Ensure that any fields that require input have data!
+        """
+        for field in self.field_inputs:
+            _input = field.value()
+            name = field.label
+            if self.require_mark in field.label and not _input:
+                self.throw_alert_message(
+                    title='BciPy Alert',
+                    message=f'Required field {name.strip(self.require_mark)} must be filled out!',
+                    message_type=AlertMessageType.CRIT,
+                    okay_or_cancel=True)
+                return False
+        return True
+
+    def build_field_data(self) -> None:
+        """Build Field Data.
+
+        Using the fields defined in the experiment, fetch the other attributes of the field. It will be stored in
+            self.field_data as a list of tuples (name, field type, required, help text).
+        """
+        for field in self.experiment['fields']:
+            # the field name and requirement
+            for name, required in field.items():
+                # help text and type
+                field_data = self.fields[name]
+                self.field_data.append(
+                    (name.title(), field_data['type'], self.map_to_bool(required['required']), field_data['help_text'])
+                )
+
+    def map_to_bool(self, string_boolean: str) -> bool:
+        """Map To Boolean.
+
+        All data is loaded from json ("true"/"false"). This method will return a python boolean (True/False).
+        """
+        if string_boolean == 'true':
+            return True
+        elif string_boolean == 'false':
+            return False
+        raise Exception(f'Unsupported boolean value {string_boolean}')
+
+    def save(self) -> None:
+        if self.check_input():
+            self.build_save_data()
+            self.write_save_data()
+
+    def build_save_data(self) -> None:
+        """Build Save Data."""
+        for field in self.field_inputs:
+            _input = field.value()
+            name = field.label.strip(self.require_mark)
+            self.save_data[name] = _input
+
+    def write_save_data(self) -> None:
+        save_experiment_field_data(self.save_data, self.save_path, self.file_name)
+        self.throw_alert_message(
+            title='Success',
+            message=f'Data written to {self.save_path}/{self.file_name}',
+            message_type=AlertMessageType.INFO,
+            okay_or_cancel=True
+        )
+
+    def throw_alert_message(self,
+                            title: str,
+                            message: str,
+                            message_type: AlertMessageType = AlertMessageType.INFO,
+                            okay_to_exit: bool = False,
+                            okay_or_cancel: bool = False) -> QMessageBox:
+        """Throw Alert Message."""
+
+        msg = QMessageBox()
+        msg.setWindowTitle(title)
+        msg.setText(message)
+        msg.setIcon(message_type.value)
+
+        if okay_to_exit:
+            msg.setStandardButtons(AlertResponse.OK.value)
+        elif okay_or_cancel:
+            msg.setStandardButtons(AlertResponse.OK.value | AlertResponse.CANCEL.value)
+
+        return msg.exec_()
+
+
+class MainPanel(QWidget):
+    """Main GUI window.
+
+    Parameters:
+    -----------
+      title: window title
+      width: window width
+      height: window height
+      experiment_name: name of the experiment to collect field data for
+      save_path: where to save the collected field data
+      file_name: name of the file to write with collected field_data
+    """
+
+    def __init__(self, title: str, width: int, height: int, experiment_name: str, save_path: str, file_name: str):
+        super().__init__()
+        self.title = title
+        self.width = width
+        self.height = height
+
+        self.form = ExperimentFieldCollection(title, width, height, experiment_name, save_path, file_name)
+        self.initUI()
+
+    def initUI(self):
+        """Initialize the UI"""
+        vbox = QVBoxLayout()
+
+        self.form_panel = QScrollArea()
+        self.form_panel.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
+        self.form_panel.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+        self.form_panel.setWidgetResizable(True)
+        self.form_panel.setFixedWidth(self.width)
+        self.form_panel.setWidget(self.form)
+
+        vbox.addWidget(self.form_panel)
+        vbox.addSpacing(5)
+
+        self.setLayout(vbox)
+        self.setFixedHeight(self.height)
+        self.setWindowTitle(self.title)
+
+        control_box = QHBoxLayout()
+        control_box.addStretch()
+        save_button = QPushButton('Save')
+        save_button.setFixedWidth(80)
+        save_button.clicked.connect(self.save)
+        control_box.addWidget(save_button)
+        vbox.addLayout(control_box)
+        self.show()
+
+    def save(self):
+        self.form.save()
+
+
+def start_app() -> None:
+    """Start Experiment Field Collection."""
+    import argparse
+    from bcipy.helpers.validate import validate_experiment, validate_field_data_written
+    from bcipy.helpers.system_utils import DEFAULT_EXPERIMENT_ID
+
+    parser = argparse.ArgumentParser()
+    # save path
+
+    # experiment_name
+    parser.add_argument('-p', '--path', default='.',
+                        help='Path to save collected field data to in json format')
+    parser.add_argument('-e', '--experiment', default=DEFAULT_EXPERIMENT_ID,
+                        help='Select a valid experiment to run the task for this user')
+    parser.add_argument('-f', '--filename', default='experiment_data.json',
+                        help='Provide a json filename to write the field data to. Ex, experiment_data.json')
+    parser.add_argument('-v', '--validate', default=False,
+                        help='Whether or not to validate the experiment before proceeding to data collection.')
+
+    args = parser.parse_args()
+
+    experiment_name = args.experiment
+    validate = args.validate
+
+    if validate:
+        validate_experiment(experiment_name)
+        print('Experiment valid!')
+
+    save_path = args.path
+    file_name = args.filename
+
+    bcipy_gui = app(sys.argv)
+    # todo change height based on field #?
+    ex = MainPanel(
+        title='Experiment Field Collection',
+        height=250,
+        width=600,
+        experiment_name=experiment_name,
+        save_path=save_path,
+        file_name=file_name
+    )
+    bcipy_gui.exec_()
+
+    if validate:
+        if validate_field_data_written(save_path, file_name):
+            print('Field data successfully written!')
+        else:
+            raise Exception(f'Field data not written to {save_path}/{file_name}')
+
+    sys.exit()
+
+
+if __name__ == '__main__':
+    start_app()

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -1,14 +1,14 @@
 import sys
-from bcipy.gui.gui_main import BCIGui, app, AlertMessageType, AlertResponse
+from bcipy.gui.gui_main import BCIGui, app, AlertMessageType
 
 from bcipy.helpers.load import load_experiments, load_fields
-from bcipy.helpers.save import save_experiment_data, save_field_data
+from bcipy.helpers.save import save_experiment_data
 from bcipy.helpers.system_utils import DEFAULT_EXPERIMENT_PATH, DEFAULT_FIELD_PATH, FIELD_FILENAME, EXPERIMENT_FILENAME
 
 
 class ExperimentRegistry(BCIGui):
     """Experiment Registry.
-    
+
     User interface for creating new experiments for use in BCInterface.py.
     """
 
@@ -37,8 +37,9 @@ class ExperimentRegistry(BCIGui):
 
     def build_text(self) -> None:
         """Build Text.
-        
-        Build all static text needed for the UI. Positions are relative to the height / width of the UI defined in start_app.
+
+        Build all static text needed for the UI.
+        Positions are relative to the height / width of the UI defined in start_app.
         """
         text_x = 25
         text_y = 70
@@ -85,7 +86,7 @@ class ExperimentRegistry(BCIGui):
 
     def build_inputs(self) -> None:
         """Build Inputs.
-        
+
         Build all text entry inputs for the UI.
         """
         input_x = 50
@@ -119,7 +120,7 @@ class ExperimentRegistry(BCIGui):
 
     def build_buttons(self):
         """Build Buttons.
-        
+
         Build all buttons necessary for the UI. Define their action on click using the named argument action.
         """
         btn_create_x = self.width - self.padding
@@ -158,7 +159,7 @@ class ExperimentRegistry(BCIGui):
 
     def create_experiment(self) -> None:
         """Create Experiment.
-        
+
         After inputing all required fields, verified by check_input, add it to the experiment list and save it.
         """
         if self.check_input():
@@ -167,7 +168,7 @@ class ExperimentRegistry(BCIGui):
 
     def add_experiment(self) -> None:
         """Add Experiment:
-        
+
         Add a new experiment to the dict of experiments. It follows the format:
              { name: { fields : {name: '', required: bool}, summary: '' } }
         """
@@ -178,7 +179,7 @@ class ExperimentRegistry(BCIGui):
 
     def save_experiments(self) -> None:
         """Save Experiment.
-        
+
         Save the experiments registered to the correct path as pulled from system_utils.
         """
         # add fields to the experiment
@@ -186,18 +187,20 @@ class ExperimentRegistry(BCIGui):
 
     def create_field(self) -> None:
         """Create Field.
-        
+
         Not implemented.
         """
         self.throw_alert_message(
             title=self.alert_title,
-            message=f'Create Field UI not available yet! Please add fields manually to {DEFAULT_FIELD_PATH}{FIELD_FILENAME}',
+            message=(
+                f'Create Field UI not available yet! Please add fields manually to '
+                f'{DEFAULT_FIELD_PATH}{FIELD_FILENAME}'),
             message_type=AlertMessageType.INFO,
             okay_to_exit=True)
 
     def add_field(self) -> None:
         """Add Field.
-        
+
         Functionality to add fields to the newly created experiment. It will ensure no duplicates are addded.
         """
         # get the current field value and compute a list of field names already added
@@ -232,7 +235,7 @@ class ExperimentRegistry(BCIGui):
 
     def build_assets(self) -> None:
         """Build Assets.
-        
+
         Define the assets to build in the UI.
         """
         self.build_inputs()
@@ -257,7 +260,11 @@ class ExperimentRegistry(BCIGui):
             if self.name in self.experiment_names:
                 self.throw_alert_message(
                     title=self.alert_title,
-                    message=f'Experiment name already registered. Please use a unique Experiment name! Registed names: {self.experiment_names}',
+                    message=(
+                        'Experiment name already registered. '
+                        'Please use a unique Experiment name! '
+                        f'Registed names: {self.experiment_names}'
+                    ),
                     message_type=AlertMessageType.INFO,
                     okay_to_exit=True)
                 return False

--- a/bcipy/gui/experiments/demo/demo_experiment_field_collection.py
+++ b/bcipy/gui/experiments/demo/demo_experiment_field_collection.py
@@ -1,0 +1,8 @@
+from bcipy.helpers.session import collect_experiment_field_data
+from bcipy.helpers.system_utils import DEFAULT_EXPERIMENT_ID
+
+
+experiment_name = DEFAULT_EXPERIMENT_ID
+# this will save the data at the location you've run the demo from!
+save_folder = '.'
+collect_experiment_field_data(experiment_name, save_folder)

--- a/bcipy/gui/gui_main.py
+++ b/bcipy/gui/gui_main.py
@@ -142,7 +142,7 @@ class FormInput(QWidget):
         """Initialize the help text widget."""
         if self.help_tip and self.label != self.help_tip:
             return static_text_control(None,
-                                       label=self.label,
+                                       label=self.help_tip,
                                        size=font_size,
                                        color=color)
         return None

--- a/bcipy/helpers/convert.py
+++ b/bcipy/helpers/convert.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Tuple
 

--- a/bcipy/helpers/exceptions.py
+++ b/bcipy/helpers/exceptions.py
@@ -1,0 +1,43 @@
+
+class UnregisteredExperimentException(Exception):
+    """Unregistered Experiment.
+
+    Thrown when experiment is not registered in the provided experiment path.
+    """
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class FieldException(Exception):
+    """Field Exception.
+
+    Thrown when there is an exception relating to experimental fields.
+    """
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class UnregisteredFieldException(FieldException):
+    """Unregistered Field.
+
+    Thrown when field is not registered in the provided field path.
+    """
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
+class InvalidExperimentException(Exception):
+    """Invalid Experiment Exception.
+
+    Thrown when providing experiment data in the incorrect format.
+    """
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors

--- a/bcipy/helpers/load.py
+++ b/bcipy/helpers/load.py
@@ -12,6 +12,7 @@ import pandas as pd
 
 from bcipy.helpers.parameters import DEFAULT_PARAMETERS_PATH, Parameters
 from bcipy.helpers.system_utils import DEFAULT_EXPERIMENT_PATH, DEFAULT_FIELD_PATH, EXPERIMENT_FILENAME, FIELD_FILENAME
+from bcipy.helpers.exceptions import InvalidExperimentException
 
 
 log = logging.getLogger(__name__)
@@ -41,7 +42,7 @@ def copy_parameters(path: str = DEFAULT_PARAMETERS_PATH,
     return path
 
 
-def load_experiments(path: str=f'{DEFAULT_EXPERIMENT_PATH}{EXPERIMENT_FILENAME}') -> dict:
+def load_experiments(path: str = f'{DEFAULT_EXPERIMENT_PATH}{EXPERIMENT_FILENAME}') -> dict:
     """Load Experiments.
 
     PARAMETERS
@@ -52,15 +53,15 @@ def load_experiments(path: str=f'{DEFAULT_EXPERIMENT_PATH}{EXPERIMENT_FILENAME}'
     -------
         A dictionary of experiments, with the following format:
             { name: { fields : {name: '', required: bool}, summary: '' } }
-    
+
     """
     with open(path, 'r') as json_file:
         return json.load(json_file)
 
 
-def load_fields(path: str=f'{DEFAULT_FIELD_PATH}{FIELD_FILENAME}') -> dict:
+def load_fields(path: str = f'{DEFAULT_FIELD_PATH}{FIELD_FILENAME}') -> dict:
     """Load Fields.
-    
+
     PARAMETERS
     ----------
     :param: path: string path to the fields file.
@@ -73,10 +74,30 @@ def load_fields(path: str=f'{DEFAULT_FIELD_PATH}{FIELD_FILENAME}') -> dict:
                     "help_text": "",
                     "type": ""
             }
-    
+
     """
     with open(path, 'r') as json_file:
         return json.load(json_file)
+
+
+def load_experiment_fields(experiment: dict) -> list:
+    """Load Experiment Fields.
+
+    {
+        'fields': [{}, {}],
+        'summary': ''
+    }
+
+    Using the experiment dictionary, loop over the field keys and put them in a list.
+    """
+    if isinstance(experiment, dict):
+        try:
+            return [name for field in experiment['fields'] for name in field.keys()]
+        except KeyError:
+            raise InvalidExperimentException(
+                'Experiment is not formatted correctly. It should be passed as a dictionary with the fields and'
+                f' summary keys. Fields is a list of dictionaries. Summary is a string. \n experiment=[{experiment}]')
+    raise TypeError('Unsupported experiment type. It should be passed as a dictionary with the fields and summary keys')
 
 
 def load_json_parameters(path: str, value_cast: bool = False) -> Parameters:

--- a/bcipy/helpers/parameters.py
+++ b/bcipy/helpers/parameters.py
@@ -12,6 +12,7 @@ Parameter = namedtuple('Parameter', [
     'value', 'section', 'readableName', 'helpTip', 'recommended_values', 'type'
 ])
 
+
 class Parameters(dict):
     """Configuration parameters for BciPy.
 

--- a/bcipy/helpers/save.py
+++ b/bcipy/helpers/save.py
@@ -5,7 +5,7 @@ from shutil import copyfile
 from pathlib import Path
 import json
 
-from bcipy.helpers.system_utils import DEFAULT_EXPERIMENT_ID, DEFAULT_EXPERIMENT_PATH, DEFAULT_FIELD_PATH
+from bcipy.helpers.system_utils import DEFAULT_EXPERIMENT_ID
 
 
 def save_json_data(data: dict, location: str, name: str) -> str:
@@ -29,6 +29,10 @@ def save_experiment_data(data, location, name) -> str:
 
 
 def save_field_data(data, location, name) -> str:
+    return save_json_data(data, location, name)
+
+
+def save_experiment_field_data(data, location, name) -> str:
     return save_json_data(data, location, name)
 
 

--- a/bcipy/helpers/tests/test_save.py
+++ b/bcipy/helpers/tests/test_save.py
@@ -60,7 +60,10 @@ class TestSave(unittest.TestCase):
             self.task,
             experiment_id=experiment_id)
         task = self.task.replace(' ', '_')
-        expected = f'{self.data_save_path}{experiment_id}/{self.user_information}/{self.user_information}_{task}_{self.dt}'
+        expected = (
+            f'{self.data_save_path}{experiment_id}'
+            f'/{self.user_information}/{self.user_information}_{task}_{self.dt}'
+        )
 
         self.assertEqual(response, expected)
 

--- a/bcipy/helpers/tests/test_validate.py
+++ b/bcipy/helpers/tests/test_validate.py
@@ -1,0 +1,59 @@
+import os
+import unittest
+
+from bcipy.helpers.validate import validate_experiment
+from bcipy.helpers.save import save_experiment_data
+from bcipy.helpers.exceptions import (
+    UnregisteredExperimentException,
+    UnregisteredFieldException,
+)
+from bcipy.helpers.system_utils import DEFAULT_EXPERIMENT_ID
+
+
+class TestValidateExperiment(unittest.TestCase):
+
+    def test_validate_experiment_returns_true_on_default(self):
+        experiment_name = DEFAULT_EXPERIMENT_ID
+
+        # rely on the default experiment and field path kwargs, pass the experiment_name for validation
+        response = validate_experiment(experiment_name)
+
+        self.assertTrue(response)
+
+    def test_validate_experiment_throws_unregistered_expection_on_unregistered_experiment(self):
+        experiment_name = 'doesnotexist'
+        with self.assertRaises(UnregisteredExperimentException):
+            validate_experiment(experiment_name)
+
+    def test_validate_experiment_throws_unregistered_exception_on_unregistered_fields(self):
+        # create a fake experiment to load
+        experiment_name = 'test'
+        experiment = {
+            experiment_name: {
+                'fields': [{'does_not_exist': {'required': 'false'}}], 'summary': ''}
+        }
+
+        # save it to a custom path (away from default)
+        path = save_experiment_data(experiment, '.', 'test_experiment.json')
+
+        # assert it raises the expected exception
+        with self.assertRaises(UnregisteredFieldException):
+            validate_experiment(experiment_name, experiment_path=path)
+
+        os.remove(path)
+
+    def test_validate_experiment_throws_file_not_found_with_incorrect_experiment_path(self):
+        # define an invalid path
+        path = 'does/not/exist'
+
+        # assert it raises the expected exception for an invalid experiment_path kwarg
+        with self.assertRaises(FileNotFoundError):
+            validate_experiment(DEFAULT_EXPERIMENT_ID, experiment_path=path)
+
+    def test_validate_experiment_throws_file_not_found_with_incorrect_field_path(self):
+        # define an invalid path
+        path = 'does/not/exist'
+
+        # assert it raises the expected exception for an invalid field_path kwarg
+        with self.assertRaises(FileNotFoundError):
+            validate_experiment(DEFAULT_EXPERIMENT_ID, field_path=path)

--- a/bcipy/helpers/triggers.py
+++ b/bcipy/helpers/triggers.py
@@ -5,7 +5,6 @@ import csv
 from typing import Dict, TextIO, List, Tuple
 
 from psychopy import visual, core
-from pathlib import Path
 
 NONE_VALUES = ['0', '0.0']
 SOUND_TYPE = 'sound'

--- a/bcipy/helpers/validate.py
+++ b/bcipy/helpers/validate.py
@@ -1,0 +1,52 @@
+import os
+
+from bcipy.helpers.load import load_experiments, load_fields, load_experiment_fields
+from bcipy.helpers.system_utils import DEFAULT_EXPERIMENT_PATH, DEFAULT_FIELD_PATH, EXPERIMENT_FILENAME, FIELD_FILENAME
+from bcipy.helpers.exceptions import (
+    FieldException,
+    UnregisteredExperimentException,
+    UnregisteredFieldException
+)
+
+
+def validate_experiment(
+        experiment_name,
+        experiment_path=f'{DEFAULT_EXPERIMENT_PATH}{EXPERIMENT_FILENAME}',
+        field_path=f'{DEFAULT_FIELD_PATH}{FIELD_FILENAME}',
+        fail_silent=False) -> bool:
+    """Validate Experiment.
+
+    Validate the experiment is in the correct format and the fields are properly registered.
+    """
+    experiments = load_experiments(experiment_path)
+    fields = load_fields(field_path)
+
+    # attempt to load the experiment by name
+    try:
+        experiment = experiments[experiment_name]
+    except KeyError:
+        raise UnregisteredExperimentException(
+            f'Experiment [{experiment_name}] is not registered at path [{experiment_path}]')
+
+    # grab all field names as a list of strings. This call will raise exceptions if formatted incorrectly.
+    experiment_fields = load_experiment_fields(experiment)
+
+    # loop over the experiment fields and attempt to load them by name
+    for field in experiment_fields:
+        try:
+            fields[field]
+        except KeyError:
+            raise UnregisteredFieldException(f'Field [{field}] is not registered at path [{field_path}]')
+
+    return True
+
+
+def validate_field_data_written(path: str, file_name: str) -> bool:
+    """Validate Field Data Written
+
+    Validate that a field data file was written after executing the experiment field collection.
+    """
+    experiment_data_path = f'{path}/{file_name}'
+    if os.path.isfile(experiment_data_path):
+        return True
+    raise FieldException(f'Experimental field data expected at path=[{experiment_data_path}] but not found.')

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -193,6 +193,14 @@
     "recommended_values": "",
     "type": "str"
   },
+  "experiment_data_name": {
+    "value": "experiment_data.json",
+    "section": "bci_config",
+    "readableName": "Experiment Data Filename",
+    "helpTip": "Specifies the filename for field data collected for your experiment",
+    "recommended_values": "",
+    "type": "str"
+  },
   "trigger_file_name": {
     "value": "triggers.txt",
     "section": "bci_config",

--- a/bcipy/tasks/exceptions.py
+++ b/bcipy/tasks/exceptions.py
@@ -2,7 +2,7 @@
 class InsufficientDataException(Exception):
     """Insufficient Data Exception.
 
-    Thrown when data requirments to execute task are violated.
+    Thrown when data requirements to execute task are violated.
     """
 
     def __init__(self, message, errors=None):

--- a/bcipy/tasks/task_registry.py
+++ b/bcipy/tasks/task_registry.py
@@ -14,8 +14,7 @@ tools. User defined tasks can be added to the Registry."""
 # which seems to prevent our other GUI code from working.
 
 from enum import Enum
-from itertools import groupby
-from typing import Dict, List
+from typing import List
 
 
 class TaskType(Enum):

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ construct==2.8.14
 mne==0.17.0
 opencv_python==4.1.0.25
 PsychoPy==2020.2.10
+openpyxl==2.6.3
 pyglet==1.4.10
 numpy==1.19.2
 sounddevice==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,8 @@ from setuptools import find_packages, setup, Command
 # Package meta-data.
 NAME = 'bcipy'
 DESCRIPTION = 'Python Software for Brain-Computer Interface.'
-URL = 'https://github.com/BciPy/BciPy'
-EMAIL = 'memmott@ohsu.com'
+URL = 'https://github.com/CAMBI-tech/BciPy'
+EMAIL = 'cambi_support@googlegroups.com'
 AUTHOR = 'CAMBI'
 REQUIRES_PYTHON = '~=3.6'
 


### PR DESCRIPTION
# Overview

Added an experiment field collection widget. Various refactors and cleanup work included. If not mentioned explicity in contributions, it was a linting update

## Ticket

https://www.pivotaltracker.com/story/show/176044196

## Contributions

### Added
- `Makefile`: convenient file to run the various install, testing, and linting commands
- `ExperimentField`: gui to collect registered field data by experiment name
- `gui/experiments/demo/demo_experiment_field_collection.py `: to demo the experiment field ui. This may not be needed...
- `helpers/exceptions`: Field and Experiment specific exceptions
- `validate`: validate experiments and field write

### Updated
- `README.md`: with makefile instructions
- `bci_main`: to validate experiments and collect experiment field data. Add better experiment options to help output.
- `gui_main`: to use help tip text for the helptip
- `load`: added the load_experiment_fields method
- `save`: add save experiment field
- `session`: added a collect_experiment_field_data method to call the `ExperimentField` GUI
- `requirements`: add back openpyxl version lock
- `parameters`: to include experiment filename for export
- `pull_request_template`: fix spelling / grammar errors

## Test

- make test-all
- run a session via bci_main defaults
- run experiment field gui via the demo
- run experiment field gui via argparse in `ExperimentField.py`

## Documentaion

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here. Updated README and docstrings
