### PR TITLE
Field creation UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ This a list of the major modules and their functionality. Each module will conta
 - `acquisition`: acquires data, gives back desired time series, saves to file at end of session.
 - `display`: handles display of stimuli on screen and passes back stimuli timing.
 - `signal`: eeg signal models, filters, processing, evaluators and viewers. 
-- `gui`: end-user interface into registered bci tasks and parameter editing. See BCInterface.py.
+- `gui`: end-user interfaces which allow running of registered bci experiments, field collection and parameter editing.
 - `helpers`: helpful functions needed for interactions between modules, basic I/O, and data visualization. 
 - `language_model`: gives probabilities of next letters during typing.
 - `parameters`: location of json parameters.

--- a/bcipy/acquisition/tests/datastream/test_generator.py
+++ b/bcipy/acquisition/tests/datastream/test_generator.py
@@ -2,7 +2,6 @@
 """Tests for datastream generator module"""
 from builtins import next
 import unittest
-import pytest
 from past.builtins import map, range
 from mock import mock_open, patch
 from bcipy.acquisition.datastream.generator import random_data, file_data
@@ -96,7 +95,8 @@ class TestGenerator(unittest.TestCase):
             for _ in range(row_count):
                 next(gen)
 
-            with pytest.raises(StopIteration):
+            with self.assertRaises(RuntimeError):
+                # a runtime error catches the StopIteration?
                 data.append(next(gen))
 
     def test_file_with_custom_encoder(self):

--- a/bcipy/acquisition/tests/datastream/test_generator.py
+++ b/bcipy/acquisition/tests/datastream/test_generator.py
@@ -95,8 +95,7 @@ class TestGenerator(unittest.TestCase):
             for _ in range(row_count):
                 next(gen)
 
-            with self.assertRaises(RuntimeError):
-                # a runtime error catches the StopIteration?
+            with self.assertRaises(StopIteration):
                 data.append(next(gen))
 
     def test_file_with_custom_encoder(self):

--- a/bcipy/gui/README.md
+++ b/bcipy/gui/README.md
@@ -1,17 +1,11 @@
 # RSVP Keyboard GUI
 ======================================
 
-This is the GUI for BciPy. The base window class, BCIGui, is contained in gui_main.py, and contains methods for easily adding widgets to a given window. BCInterface.py launches the main GUI window. 
-
-## Features
------------
-
--Buttons, text boxes, drop-down menus, and other GUI elements are easy to add  
--Read/write framework for JSON files  
+This module contains all GUI code used in BciPy. The base window class, BCIGui, is contained in gui_main.py, and contains methods for easily adding widgets to a given window. BCInterface.py launches the main GUI window. There are also interfaces for collecting and editing data (parameters and field data for experiments.)
 
 ## Dependencies
 -------------
-This project was written in wxPython version 4.0.0 and PyQt5. We are deprecating the wxPython UIs in future releases.
+This project was written in wxPython version 4.0.4 and PyQt5 5.15.1. We are deprecating the wxPython UIs in future releases.
 
 ## Project structure
 ---------------
@@ -19,8 +13,10 @@ Name | Description
 ------------- | -------------
 BCInterface.py | Defines main GUI window. Selection of user, experiment and task.
 gui_main.py | BCIGui containing methods for adding buttons, images, etc. to GUI window
-params_form.py | Defines window for setting BCInterface parameters
+parameters/params_form.py | Defines window for setting BCInterface parameters
 experiments/ExperimentRegistry.py | GUI for creating new experiments to select in BCInterface.
+experiments/FieldRegistry.py | GUI for creating new fields for experiment data collection.
+experiments/ExperimentField.py | GUI for collecting a registered experiment's field data.
 
 
 The folder 'bcipy/static/images/gui_images' contains images for the GUI.

--- a/bcipy/gui/experiments/ExperimentField.py
+++ b/bcipy/gui/experiments/ExperimentField.py
@@ -77,7 +77,7 @@ class ExperimentFieldCollection(QWidget):
 
     def build_form(self) -> None:
         """Build Form.
-        
+
         Loop over the field data and create UI field inputs for data collection.
         """
         for field_name, field_type, required, help_text in self.field_data:
@@ -85,7 +85,7 @@ class ExperimentFieldCollection(QWidget):
 
     def field_input(self, field_name: str, field_type: str, help_tip: str, required: bool) -> FormInput:
         """Field Input.
-        
+
         Construct a FormInput for the given field based on its python type and other
         attributes.
         """
@@ -102,7 +102,7 @@ class ExperimentFieldCollection(QWidget):
 
     def build_assets(self) -> None:
         """Build Assets.
-        
+
         Build any needed assests for the Experiment Field Widget. Currently, only a form is needed.
         """
         self.build_form()

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -5,7 +5,7 @@ from bcipy.gui.gui_main import BCIGui, app, AlertMessageType
 
 from bcipy.helpers.load import load_experiments, load_fields
 from bcipy.helpers.save import save_experiment_data
-from bcipy.helpers.system_utils import DEFAULT_EXPERIMENT_PATH, DEFAULT_FIELD_PATH, FIELD_FILENAME, EXPERIMENT_FILENAME
+from bcipy.helpers.system_utils import DEFAULT_EXPERIMENT_PATH, EXPERIMENT_FILENAME
 
 
 class ExperimentRegistry(BCIGui):
@@ -25,8 +25,7 @@ class ExperimentRegistry(BCIGui):
 
         # Structure of an experiment:
         #   { name: { fields : {name: '', required: bool}, summary: '' } }
-        self.experiments = load_experiments()
-        self.experiment_names = self.experiments.keys()
+        self.update_experiment_data()
 
         # These are set in the build_inputs and represent text inputs from the user
         self.name_input = None
@@ -39,7 +38,6 @@ class ExperimentRegistry(BCIGui):
 
         self.show_gui()
         self.update_field_list()
-
 
     def build_text(self) -> None:
         """Build Text.
@@ -177,6 +175,15 @@ class ExperimentRegistry(BCIGui):
                 message_type=AlertMessageType.INFO,
                 okay_to_exit=True
             )
+            self.update_experiment_data()
+
+    def update_experiment_data(self):
+        """Update Experiment Data.
+
+        Fetches the experiments and extracts the registered names.
+        """
+        self.experiments = load_experiments()
+        self.experiment_names = self.experiments.keys()
 
     def add_experiment(self) -> None:
         """Add Experiment:
@@ -207,7 +214,6 @@ class ExperimentRegistry(BCIGui):
             shell=True)
 
         self.update_field_list()
-        
 
     def add_field(self) -> None:
         """Add Field.
@@ -272,26 +278,26 @@ class ExperimentRegistry(BCIGui):
             if self.name == ExperimentRegistry.default_text:
                 self.throw_alert_message(
                     title=self.alert_title,
-                    message='Please add an Experiment Name',
-                    message_type=AlertMessageType.INFO,
+                    message='Please add an Experiment Name!',
+                    message_type=AlertMessageType.WARN,
                     okay_to_exit=True)
                 return False
             if self.name in self.experiment_names:
                 self.throw_alert_message(
                     title=self.alert_title,
                     message=(
-                        'Experiment name already registered. '
-                        'Please use a unique Experiment name! '
+                        'Experiment name already registered. \n'
+                        'Please use a unique Experiment name! \n'
                         f'Registed names: {self.experiment_names}'
                     ),
-                    message_type=AlertMessageType.INFO,
+                    message_type=AlertMessageType.WARN,
                     okay_to_exit=True)
                 return False
             if self.summary == ExperimentRegistry.default_text:
                 self.throw_alert_message(
                     title=self.alert_title,
-                    message='Please add an Experiment Summary',
-                    message_type=AlertMessageType.INFO,
+                    message='Please add an Experiment Summary!',
+                    message_type=AlertMessageType.WARN,
                     okay_to_exit=True)
                 return False
         except Exception as e:

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -1,4 +1,6 @@
 import sys
+import subprocess
+
 from bcipy.gui.gui_main import BCIGui, app, AlertMessageType
 
 from bcipy.helpers.load import load_experiments, load_fields
@@ -25,15 +27,19 @@ class ExperimentRegistry(BCIGui):
         #   { name: { fields : {name: '', required: bool}, summary: '' } }
         self.experiments = load_experiments()
         self.experiment_names = self.experiments.keys()
-        self.fields = [item for item in load_fields()]
 
         # These are set in the build_inputs and represent text inputs from the user
         self.name_input = None
         self.summary_input = None
         self.field_input = None
 
+        self.fields = []
         self.name = None
         self.summary = None
+
+        self.show_gui()
+        self.update_field_list()
+
 
     def build_text(self) -> None:
         """Build Text.
@@ -165,6 +171,12 @@ class ExperimentRegistry(BCIGui):
         if self.check_input():
             self.add_experiment()
             self.save_experiments()
+            self.throw_alert_message(
+                title=self.alert_title,
+                message='Experiment saved successfully! Please exit window or create another experiment!',
+                message_type=AlertMessageType.INFO,
+                okay_to_exit=True
+            )
 
     def add_experiment(self) -> None:
         """Add Experiment:
@@ -188,15 +200,14 @@ class ExperimentRegistry(BCIGui):
     def create_field(self) -> None:
         """Create Field.
 
-        Not implemented.
+        Launch to FieldRegistry to create a new field for experiments.
         """
-        self.throw_alert_message(
-            title=self.alert_title,
-            message=(
-                f'Create Field UI not available yet! Please add fields manually to '
-                f'{DEFAULT_FIELD_PATH}{FIELD_FILENAME}'),
-            message_type=AlertMessageType.INFO,
-            okay_to_exit=True)
+        subprocess.call(
+            f'python bcipy/gui/experiments/FieldRegistry.py',
+            shell=True)
+
+        self.update_field_list()
+        
 
     def add_field(self) -> None:
         """Add Field.
@@ -232,6 +243,14 @@ class ExperimentRegistry(BCIGui):
     def update_registered_fields(self) -> None:
         # TODO
         pass
+
+    def update_field_list(self) -> None:
+        """Updates the field_input combo box with a list of fields. """
+
+        self.field_input.clear()
+        self.field_input.addItem(ExperimentRegistry.default_text)
+        self.fields = [item for item in load_fields()]
+        self.field_input.addItems(self.fields)
 
     def build_assets(self) -> None:
         """Build Assets.
@@ -293,8 +312,6 @@ def start_app() -> None:
         height=600,
         width=550,
         background_color='black')
-
-    ex.show_gui()
 
     sys.exit(bcipy_gui.exec_())
 

--- a/bcipy/gui/experiments/FieldRegistry.py
+++ b/bcipy/gui/experiments/FieldRegistry.py
@@ -31,8 +31,7 @@ class FieldRegistry(BCIGui):
 
         # Structure of an field:
         #   { name: { help_text: '', type: int} }
-        self.fields = load_fields()
-        self.field_names = list(self.fields.keys())
+        self.update_field_data()
 
         # These are set in the build_inputs and represent text inputs from the user
         self.name_input = None
@@ -113,10 +112,12 @@ class FieldRegistry(BCIGui):
         self.type_input = self.add_combobox(
             position=[input_x, input_y],
             size=input_size,
-            items=list(self.field_types.keys()),
+            items=[],
             editable=False,
             background_color=self.input_color,
             text_color=self.input_text_color)
+
+        self.update_type_list()
 
     def build_buttons(self):
         """Build Buttons.
@@ -147,6 +148,36 @@ class FieldRegistry(BCIGui):
                 message_type=AlertMessageType.INFO,
                 okay_to_exit=True
             )
+            self.refresh_inputs()
+
+    def refresh_inputs(self):
+        """Refresh Inputs.
+
+        Clear and resets all inputs and related data.
+        """
+        self.name_input.clear()
+        self.name_input.addItem(FieldRegistry.default_text)
+        self.update_field_data()
+        self.helptext_input.clear()
+        self.helptext_input.addItem(FieldRegistry.default_text)
+        self.update_type_list()
+
+    def update_field_data(self):
+        """Update Field Data.
+
+        Fetches the fields and extracts the registered names.
+        """
+        self.fields = load_fields()
+        self.field_names = list(self.fields.keys())
+
+    def update_type_list(self):
+        """Update Type List.
+
+        Update the supported type list, reseting to default_text.
+        """
+        self.type_input.clear()
+        self.type_input.addItem(FieldRegistry.default_text)
+        self.type_input.addItems(list(self.field_types.keys()))
 
     def add_field(self) -> None:
         """Add field:
@@ -190,8 +221,8 @@ class FieldRegistry(BCIGui):
                     self.name == '':
                 self.throw_alert_message(
                     title=self.alert_title,
-                    message='Please add a Field name!',
-                    message_type=AlertMessageType.INFO,
+                    message='Please add a field name!',
+                    message_type=AlertMessageType.WARN,
                     okay_to_exit=True)
                 return False
             if self.name in self.field_names:
@@ -202,15 +233,22 @@ class FieldRegistry(BCIGui):
                         'Please use a unique field name! \n'
                         f'Registed names: {self.field_names}'
                     ),
-                    message_type=AlertMessageType.INFO,
+                    message_type=AlertMessageType.WARN,
                     okay_to_exit=True)
                 return False
             if self.helptext == FieldRegistry.default_text or \
                     self.helptext == '':
                 self.throw_alert_message(
                     title=self.alert_title,
-                    message='Please add help text to field. \n This will present when collecting experiment data!',
-                    message_type=AlertMessageType.INFO,
+                    message='Please add help text to field. \nThis will present when collecting experiment data!',
+                    message_type=AlertMessageType.WARN,
+                    okay_to_exit=True)
+                return False
+            if self.type == FieldRegistry.default_text:
+                self.throw_alert_message(
+                    title=self.alert_title,
+                    message='Please select a valid field type!',
+                    message_type=AlertMessageType.WARN,
                     okay_to_exit=True)
                 return False
         except Exception as e:

--- a/bcipy/gui/experiments/FieldRegistry.py
+++ b/bcipy/gui/experiments/FieldRegistry.py
@@ -1,0 +1,241 @@
+import sys
+from bcipy.gui.gui_main import BCIGui, app, AlertMessageType
+
+from bcipy.helpers.load import load_fields
+from bcipy.helpers.save import save_field_data
+from bcipy.helpers.system_utils import DEFAULT_FIELD_PATH, FIELD_FILENAME
+
+
+class FieldRegistry(BCIGui):
+    """Field Registry.
+
+    User interface for creating new fields for use in BCInterface.py.
+    """
+
+    padding = 100
+    btn_height = 50
+    default_text = '...'
+    txt_color = 'white'
+    input_text_color = 'gray'
+    input_color = 'white'
+    alert_title = 'Field Registry Alert'
+    field_types = {
+        'Text': 'str',
+        'True/False or Yes/No': 'bool',
+        'Whole Number': 'int',
+        'Decimal Point Number': 'float'
+    }
+
+    def __init__(self, *args, **kwargs):
+        super(FieldRegistry, self).__init__(*args, **kwargs)
+
+        # Structure of an field:
+        #   { name: { help_text: '', type: int} }
+        self.fields = load_fields()
+        self.field_names = list(self.fields.keys())
+
+        # These are set in the build_inputs and represent text inputs from the user
+        self.name_input = None
+        self.helptext_input = None
+        self.type_input = None
+
+        self.name = None
+        self.helptext = None
+        self.type = None
+
+    def build_text(self) -> None:
+        """Build Text.
+
+        Build all static text needed for the UI.
+        Positions are relative to the height / width of the UI defined in start_app.
+        """
+        text_x = 25
+        text_y = 70
+        font_size = 18
+        self.add_static_textbox(
+            text='Create BciPy Field',
+            position=[self.width / 2 - self.padding, 0],
+            size=[300, 100],
+            background_color=self.background_color,
+            text_color=self.txt_color,
+            font_size=22
+        )
+        self.add_static_textbox(
+            text='Name',
+            position=[text_x, text_y],
+            size=[200, 50],
+            background_color=self.background_color,
+            text_color=self.txt_color,
+            font_size=font_size)
+        text_y += self.padding
+        self.add_static_textbox(
+            text='Help Text',
+            position=[text_x, text_y],
+            size=[300, 50],
+            background_color=self.background_color,
+            text_color=self.txt_color,
+            font_size=font_size)
+        text_y += self.padding
+        self.add_static_textbox(
+            text='Type',
+            position=[text_x, text_y],
+            size=[300, 50],
+            background_color=self.background_color,
+            text_color=self.txt_color,
+            font_size=font_size)
+
+    def build_inputs(self) -> None:
+        """Build Inputs.
+
+        Build all text entry inputs for the UI.
+        """
+        input_x = 50
+        input_y = 120
+        input_size = [280, 25]
+        self.name_input = self.add_combobox(
+            position=[input_x, input_y],
+            size=input_size,
+            items=[self.default_text],
+            editable=True,
+            background_color=self.input_color,
+            text_color=self.input_text_color)
+
+        input_y += self.padding
+        self.helptext_input = self.add_combobox(
+            position=[input_x, input_y],
+            size=input_size,
+            items=[self.default_text],
+            editable=True,
+            background_color=self.input_color,
+            text_color=self.input_text_color)
+
+        input_y += self.padding
+        self.type_input = self.add_combobox(
+            position=[input_x, input_y],
+            size=input_size,
+            items=list(self.field_types.keys()),
+            editable=False,
+            background_color=self.input_color,
+            text_color=self.input_text_color)
+
+    def build_buttons(self):
+        """Build Buttons.
+
+        Build all buttons necessary for the UI. Define their action on click using the named argument action.
+        """
+        btn_create_x = self.width - self.padding
+        btn_create_y = self.height - 75
+        size = 150
+        self.add_button(
+            message='Create Field', position=[btn_create_x - (size / 2), btn_create_y],
+            size=[size, self.btn_height],
+            background_color='green',
+            action=self.create_field,
+            text_color='white')
+
+    def create_field(self) -> None:
+        """Create field.
+
+        After inputing all required fields, verified by check_input, add it to the field list and save it.
+        """
+        if self.check_input():
+            self.add_field()
+            self.save_fields()
+            self.throw_alert_message(
+                title=self.alert_title,
+                message='Field saved successfully! Please exit window or create another field!',
+                message_type=AlertMessageType.INFO,
+                okay_to_exit=True
+            )
+
+    def add_field(self) -> None:
+        """Add field:
+
+        Add a new field to the dict of fields. It follows the format:
+             { name: { help_text: '', type: int} }
+        """
+        self.fields[self.name] = {
+            'help_text': self.helptext,
+            'type': self.field_types[self.type]
+        }
+
+    def save_fields(self) -> None:
+        """Save field.
+
+        Save the fields registered to the correct path as pulled from system_utils.
+        """
+        # add fields to the field
+        save_field_data(self.fields, DEFAULT_FIELD_PATH, FIELD_FILENAME)
+
+    def build_assets(self) -> None:
+        """Build Assets.
+
+        Define the assets to build in the UI.
+        """
+        self.build_inputs()
+        self.build_text()
+        self.build_buttons()
+
+    def check_input(self) -> bool:
+        """Check Input.
+
+        Checks to make sure user has input all required fields. Currently, only name and summary are required.
+        """
+        self.name = self.name_input.currentText()
+        self.helptext = self.helptext_input.currentText()
+        self.type = self.type_input.currentText()
+
+        try:
+            if self.name == FieldRegistry.default_text or \
+                    self.name == '':
+                self.throw_alert_message(
+                    title=self.alert_title,
+                    message='Please add a Field name!',
+                    message_type=AlertMessageType.INFO,
+                    okay_to_exit=True)
+                return False
+            if self.name in self.field_names:
+                self.throw_alert_message(
+                    title=self.alert_title,
+                    message=(
+                        'Field name already registered. \n'
+                        'Please use a unique field name! \n'
+                        f'Registed names: {self.field_names}'
+                    ),
+                    message_type=AlertMessageType.INFO,
+                    okay_to_exit=True)
+                return False
+            if self.helptext == FieldRegistry.default_text or \
+                    self.helptext == '':
+                self.throw_alert_message(
+                    title=self.alert_title,
+                    message='Please add help text to field. \n This will present when collecting experiment data!',
+                    message_type=AlertMessageType.INFO,
+                    okay_to_exit=True)
+                return False
+        except Exception as e:
+            self.throw_alert_message(
+                title=self.alert_title,
+                message=f'Error, {e}',
+                message_type=AlertMessageType.CRIT,
+                okay_to_exit=True)
+            return False
+        return True
+
+
+def start_app() -> None:
+    """Start Field Registry."""
+    bcipy_gui = app(sys.argv)
+    ex = FieldRegistry(
+        title='Field Registry',
+        height=500,
+        width=550,
+        background_color='black')
+
+    ex.show_gui()
+
+    sys.exit(bcipy_gui.exec_())
+
+
+if __name__ == '__main__':
+    start_app()

--- a/bcipy/gui/gui_main.py
+++ b/bcipy/gui/gui_main.py
@@ -404,7 +404,8 @@ class BCIGui(QMainWindow):
         self.comboboxes = []
 
         # set window properties
-        self.window.setStyleSheet(f'background-color: {background_color};')
+        self.background_color = background_color
+        self.window.setStyleSheet(f'background-color: {self.background_color};')
 
         # determines where on the screen the gui first appears
         self.x = 500
@@ -474,7 +475,7 @@ class BCIGui(QMainWindow):
 
         Default event to bind to comboboxes
         """
-        self.logger.debug('Dropdown selected!')
+        pass
 
     @pyqtSlot()
     def default_button_clicked(self) -> None:

--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -93,9 +93,9 @@ def best_selection(selection_elements: list,
     best = sorted(selection_elements, key=elem_val.get, reverse=True)[0:n]
 
     replacements = [
-                       item for item in always_included
-                       if item not in best and item in selection_elements
-                   ][0:n]
+        item for item in always_included
+        if item not in best and item in selection_elements
+    ][0:n]
 
     if replacements:
         best[-len(replacements):] = replacements
@@ -135,7 +135,7 @@ def best_case_rsvp_seq_gen(alp: list,
     if len(alp) != len(session_stimuli):
         raise Exception('Missing information about alphabet. len(alp):{}, '
                         'len(session_stimuli):{}, should be same!'.format(
-            len(alp), len(session_stimuli)))
+                            len(alp), len(session_stimuli)))
 
     if seq_constants and not set(seq_constants).issubset(alp):
         raise Exception('Sequence constants must be alphabet items.')
@@ -257,7 +257,7 @@ def target_rsvp_sequence_generator(alp, target_letter, parameters,
     else:
         sample = ['bcipy/static/images/bci_main_images/PLUS.png']
         target_letter = parameters['path_to_presentation_images'] + \
-                        target_letter + '.png'
+            target_letter + '.png'
     sample += [alp[i] for i in rand_smp]
 
     # if the target isn't in the array, replace it with some random index that
@@ -411,7 +411,7 @@ def generate_icon_match_images(
 
         # Add target image to sequence, if it is not already there
         if not target_image_numbers[sequence] in random_number_array[
-                                                 2:experiment_length]:
+                2:experiment_length]:
             random_number_array[np.random.randint(
                 2, experiment_length)] = target_image_numbers[sequence]
 

--- a/bcipy/tasks/rsvp/main_frame.py
+++ b/bcipy/tasks/rsvp/main_frame.py
@@ -127,7 +127,7 @@ class DecisionMaker:
                                                               threshold=0.8),
                  stimuli_agent=RandomStimuliAgent(
                      alphabet=list(string.ascii_uppercase) +
-                              ['<'] + [SPACE_CHAR])):
+                     ['<'] + [SPACE_CHAR])):
         self.state = state
         self.displayed_state = self.form_display_state(state)
         self.stimuli_timing = stimuli_timing

--- a/bcipy/tasks/rsvp/query_mechanisms.py
+++ b/bcipy/tasks/rsvp/query_mechanisms.py
@@ -84,12 +84,12 @@ class NBestStimuliAgent(StimuliAgent):
 class MomentumStimuliAgent(StimuliAgent):
     """ A query agent that utilizes the observed evidence so far at each step.
         This agent is specifically designed to overcome the adversary effect of
-        the prior information to the system. 
+        the prior information to the system.
         There are two competing terms;
             I: mutual information, this utilizes the current posterior
             M: momentum, this utilizes all likelihoods so far
         and the queries are selected by linearly combining these two.
-        This agent, in the beginning of the epoch, explores utilizing M and 
+        This agent, in the beginning of the epoch, explores utilizing M and
         eventually exploits the knowledge using I  """
 
     def __init__(self, alphabet: List[str],
@@ -128,7 +128,7 @@ class MomentumStimuliAgent(StimuliAgent):
 
         # conditional entropy as a surrogate for mutual information
         entropy_term = np.array(tmp) * np.log(tmp + eps) + (
-                1.01 - np.array(tmp)) * (np.log(1.01 - np.array(tmp)))
+            1.01 - np.array(tmp)) * (np.log(1.01 - np.array(tmp)))
         entropy_term[np.isnan(entropy_term)] = 0
 
         # update the momentum term using likelihoods
@@ -138,7 +138,7 @@ class MomentumStimuliAgent(StimuliAgent):
         # if there are no sequences shown yet, the momentum cannot be computed
         if num_passed_sequences > 1:
             reward = (self.lam_ - 1) * entropy_term + (
-                    self.lam_ / num_passed_sequences) * momentum
+                self.lam_ / num_passed_sequences) * momentum
         else:
             reward = -entropy_term
 

--- a/bcipy/tasks/rsvp/stopping_criteria.py
+++ b/bcipy/tasks/rsvp/stopping_criteria.py
@@ -167,7 +167,7 @@ class MomentumCommitCriteria(DecisionCriteria):
 
         tmp_ = np.array(prob_history)
         mom_ = tmp_[1:] * (
-                np.log(tmp_[1:] + eps) - np.log(tmp_[:-1] + eps))
+            np.log(tmp_[1:] + eps) - np.log(tmp_[:-1] + eps))
         momentum = np.linalg.norm(mom_) / len(prob_history)
 
         if len(prob_history) > 1:
@@ -203,7 +203,7 @@ class CriteriaEvaluator():
                    commit_criteria=[
                        MaxIterationsCriteria(max_num_seq),
                        ProbThresholdCriteria(threshold)
-                   ])
+        ])
 
     def do_epoch(self):
         for el_ in self.continue_criteria:


### PR DESCRIPTION
# Overview

Added a GUI for creation of new BciPy experiment fields. Small updates for ExperimentRegistry to allow creation of multiple experiments per session.

## Ticket

https://www.pivotaltracker.com/story/show/175194521

## Contributions

linting

### Updated

- `gui/README`: with new GUI information
- `README`: with new GUI information
- `test_generator`: assert raises a Runtime error, which encapsulates the StopIteration. Not 100% on this one...
- `ExperimentRegistry`: to use WARN instead of INFO on check_input. To call new `FieldRegistry` instead of throwing not implemented alert.
- `gui_main`: to store background_color and pass instead of logging for dropdown action.

### Added

- `FieldRegistry`: GUI for creating new Fields. It should not create duplicates and require all field be input before creation.

## Test

- Run `BCInterface.py`, create a new experiment, create a new field, close the window. Ensure new field is written and viewable in the experiment creation window. Try creating invalid fields (missing values, names already registered) and verify alerts are thrown and no data is written. Run `make test-all`

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? READMEs were updated.
