### PR TITLE
Fixes issues with BIDS data conversion on Windows

### DIFF
--- a/bcipy/helpers/convert.py
+++ b/bcipy/helpers/convert.py
@@ -41,7 +41,7 @@ def convert_to_edf(data_dir: str,
         Path(data_dir, params['raw_data_name']))
     durations = trigger_durations(params) if use_event_durations else {}
 
-    with open(Path(data_dir, params['trigger_file_name']), 'r') as trg_file:
+    with open(Path(data_dir, params.get('trigger_file_name', 'triggers.txt')), 'r') as trg_file:
         triggers = read_triggers(trg_file)
     events = edf_annotations(triggers, durations)
 

--- a/bcipy/helpers/tests/test_convert.py
+++ b/bcipy/helpers/tests/test_convert.py
@@ -24,7 +24,7 @@ def sample_data(rows: int = 1000, ch_names: List[str] = None) -> str:
     if not ch_names:
         ch_names = ['c1', 'c2', 'c3']
     # Mock the raw_data file
-    sep = '\r\n'
+    sep = '\n'
     meta = sep.join([f'daq_type,LSL', 'sample_rate,256.0'])
     header = 'timestamp,' + ','.join(ch_names) + ',TRG'
 


### PR DESCRIPTION
# Overview

Fixed issues with the data conversion scripts in the Windows environment.

## Ticket

https://www.pivotaltracker.com/story/show/175193894

## Contributions

- Added default value for triggers file parameter to allow users to run data conversion on older data.
- Fixed tests to run successfully in Windows

## Test

- test_convert.py should run without error in all environments.

