### PR TITLE
Scrollable fields (add toggle for required and remove)

### DIFF
--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -20,7 +20,7 @@ class BCInterface(BCIGui):
     tasks = TaskType.list()
 
     default_text = '...'
-    padding = 15
+    padding = 30
     btn_height = 40
 
     def __init__(self, *args, **kwargs):
@@ -212,7 +212,7 @@ class BCInterface(BCIGui):
         self.add_image(
             path='bcipy/static/images/gui_images/ohsu.png', position=[self.padding, 0], size=100)
         self.add_image(
-            path='bcipy/static/images/gui_images/neu.png', position=[self.width - self.padding - 100, 0], size=100)
+            path='bcipy/static/images/gui_images/neu.png', position=[self.width - self.padding - 110, 0], size=100)
 
     def build_assets(self) -> None:
         """Build Assets.
@@ -392,8 +392,8 @@ def start_app() -> None:
     bcipy_gui = app(sys.argv)
     ex = BCInterface(
         title='Brain Computer Interface',
-        height=500,
-        width=700,
+        height=550,
+        width=750,
         background_color='black')
 
     ex.show_gui()

--- a/bcipy/gui/experiments/FieldRegistry.py
+++ b/bcipy/gui/experiments/FieldRegistry.py
@@ -124,8 +124,8 @@ class FieldRegistry(BCIGui):
 
         Build all buttons necessary for the UI. Define their action on click using the named argument action.
         """
-        btn_create_x = self.width - self.padding
-        btn_create_y = self.height - 75
+        btn_create_x = self.width - self.padding - 10
+        btn_create_y = self.height - 100
         size = 150
         self.add_button(
             message='Create Field', position=[btn_create_x - (size / 2), btn_create_y],

--- a/bcipy/helpers/session.py
+++ b/bcipy/helpers/session.py
@@ -74,7 +74,10 @@ def collect_experiment_field_data(experiment_name, save_path, file_name='experim
     experiment_fields = load_experiment_fields(experiment)
 
     if experiment_fields:
-        cmd = f'python bcipy/gui/experiments/ExperimentField.py -e {experiment_name} -p {save_path} -f {file_name}'
+        cmd = (
+            'python bcipy/gui/experiments/ExperimentField.py -e'
+            f' "{experiment_name}" -p "{save_path}" -f "{file_name}"'
+        )
         subprocess.check_call(cmd, shell=True)
         # verify data was written before moving on
         if not validate_field_data_written(save_path, file_name):


### PR DESCRIPTION
# Overview

Refactor BCIGui into a Widget that can accept other widgets. Add ScrollableFrame and LineItems. Implemented a scrollable area with line items for registered fields (can toggle required and remove). 

## Ticket

https://www.pivotaltracker.com/story/show/176044412

## Contributions

- `ExperimentRegistry`: methods to construct a scrollable area and render registered fields and LineItems. Functionality to remove and toggle registered fields added. 
- `gui_main`: BCIGui refactor into a widget, allows more widgets to be added. Use QV / QH Layouts (instead of grid). Add ScrollableFrame and LineItems: two classes of QWidgets.  
- `BCInterface`: changes to support the refactored BCIGui
- `session.py`: changes to prevent issues with names containing space characters

## Test

- Run `BCInterface`, create new experiment using +, add a field and toggle requirement, attempt to remove, create a new experiment, select it in BCInterface, ensure the fields were collected as expected once start experiment is selected.
- Run `make test-all` and `make lint`

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? In-line documentation updated... I don't believe more are needed... 
