### PR TITLE
Validate Field inputs

### DIFF
--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -279,7 +279,7 @@ class BCInterface(BCIGui):
                 return None
 
         subprocess.call(
-            f'python bcipy/gui/params_form.py -p {self.parameter_location}',
+            f'python bcipy/gui/parameters/params_form.py -p {self.parameter_location}',
             shell=True)
 
     def check_input(self) -> bool:

--- a/bcipy/gui/experiments/ExperimentField.py
+++ b/bcipy/gui/experiments/ExperimentField.py
@@ -163,7 +163,7 @@ class ExperimentFieldCollection(QWidget):
         """Build Save Data."""
         try:
             for field in self.field_inputs:
-                _input = field.value()
+                _input = field.cast_value()
                 name = field.label.strip(self.require_mark)
                 self.save_data[name] = _input
         except ValueError as e:

--- a/bcipy/gui/experiments/ExperimentField.py
+++ b/bcipy/gui/experiments/ExperimentField.py
@@ -22,7 +22,9 @@ from bcipy.gui.gui_main import (
     BoolInput,
     DirectoryInput,
     FileInput,
+    FloatInput,
     FormInput,
+    IntegerInput,
     TextInput
 )
 from bcipy.helpers.load import load_experiments, load_fields
@@ -38,6 +40,8 @@ class ExperimentFieldCollection(QWidget):
     field_data: List[tuple] = []
     field_inputs: List[FormInput] = []
     type_inputs = {
+        'int': IntegerInput,
+        'float': FloatInput,
         'bool': BoolInput,
         'filepath': FileInput,
         'directorypath': DirectoryInput
@@ -157,16 +161,26 @@ class ExperimentFieldCollection(QWidget):
 
     def build_save_data(self) -> None:
         """Build Save Data."""
-        for field in self.field_inputs:
-            _input = field.value()
-            name = field.label.strip(self.require_mark)
-            self.save_data[name] = _input
+        try:
+            for field in self.field_inputs:
+                _input = field.value()
+                name = field.label.strip(self.require_mark)
+                self.save_data[name] = _input
+        except ValueError as e:
+            self.throw_alert_message(
+                title='Error',
+                message=f'Error saving data. Invalid value provided. \n {e}',
+                message_type=AlertMessageType.WARN,
+                okay_or_cancel=True
+            )
 
     def write_save_data(self) -> None:
         save_experiment_field_data(self.save_data, self.save_path, self.file_name)
         self.throw_alert_message(
             title='Success',
-            message=f'Data written to {self.save_path}/{self.file_name}',
+            message=(
+                f'Data sucessfully written to: \n\n{self.save_path}/{self.file_name} \n\n\n'
+                'Please close this window to start the task!'),
             message_type=AlertMessageType.INFO,
             okay_or_cancel=True
         )

--- a/bcipy/gui/gui_main.py
+++ b/bcipy/gui/gui_main.py
@@ -3,7 +3,7 @@ import logging
 import os
 import sys
 from enum import Enum
-from typing import List
+from typing import Any, List
 
 from PyQt5.QtCore import pyqtSlot, Qt
 from PyQt5.QtGui import QFont, QPixmap
@@ -172,6 +172,13 @@ class FormInput(QWidget):
             return self.control.text()
         return None
 
+    def cast_value(self) -> Any:
+        """Returns the value associated with the form input, cast to the correct type.
+        
+        *If not defined by downstream classes, it will return the value.*
+        """
+        self.value()
+
     def matches(self, term: str) -> bool:
         """Returns True if the input matches the given text, otherwise False."""
         text = term.lower()
@@ -215,7 +222,7 @@ class IntegerInput(FormInput):
         spin_box.setMaximum(100000)
         return spin_box
 
-    def value(self) -> str:
+    def cast_value(self) -> str:
         """Override FormInput to return an integer value."""
         if self.control:
             return int(self.control.text())
@@ -241,7 +248,7 @@ class FloatInput(FormInput):
         spin_box.setMaximum(100000)
         return spin_box
 
-    def value(self) -> float:
+    def cast_value(self) -> float:
         """Override FormInput to return as a float."""
         if self.control:
             return float(self.control.text())

--- a/bcipy/gui/gui_main.py
+++ b/bcipy/gui/gui_main.py
@@ -7,8 +7,8 @@ from typing import List
 
 from PyQt5.QtCore import pyqtSlot, Qt
 from PyQt5.QtGui import QFont, QPixmap
-from PyQt5.QtWidgets import (QApplication, QCheckBox, QComboBox, QFileDialog,
-                             QHBoxLayout, QLabel, QLineEdit,
+from PyQt5.QtWidgets import (QApplication, QCheckBox, QComboBox, QDoubleSpinBox,
+                             QFileDialog, QHBoxLayout, QSpinBox, QLabel, QLineEdit,
                              QMessageBox, QPushButton, QScrollArea,
                              QVBoxLayout, QWidget)
 
@@ -194,6 +194,58 @@ class FormInput(QWidget):
     def widgets(self) -> List[QWidget]:
         """Returns a list of self and child widgets. List may contain None values."""
         return [self.label_widget, self.help_tip_widget, self.control, self]
+
+
+class IntegerInput(FormInput):
+    """FormInput to select a integer value using a spinbox for selection. Help text is not
+    displayed for spinbox items.
+
+    Parameters:
+    ----------
+        label - form label.
+        value - initial value.
+    """
+
+    def __init__(self, **kwargs):
+        super(IntegerInput, self).__init__(**kwargs)
+
+    def init_control(self, value):
+        """Override FormInput to create a spinbox."""
+        spin_box = QSpinBox()
+        spin_box.setMaximum(100000)
+        return spin_box
+
+    def value(self) -> str:
+        """Override FormInput to return an integer value."""
+        if self.control:
+            return int(self.control.text())
+        return None
+
+
+class FloatInput(FormInput):
+    """FormInput to select a float value using a spinbox for selection. Help text is not
+    displayed for spinbox items.
+
+    Parameters:
+    ----------
+        label - form label.
+        value - initial value.
+    """
+
+    def __init__(self, **kwargs):
+        super(FloatInput, self).__init__(**kwargs)
+
+    def init_control(self, value):
+        """Override FormInput to create a spinbox."""
+        spin_box = QDoubleSpinBox()
+        spin_box.setMaximum(100000)
+        return spin_box
+
+    def value(self) -> float:
+        """Override FormInput to return as a float."""
+        if self.control:
+            return float(self.control.text())
+        return None
 
 
 class BoolInput(FormInput):
@@ -426,7 +478,7 @@ class BCIGui(QWidget):
 
     def create_main_window(self) -> None:
         """Create Main Window.
-        
+
         Construct the main window for display of assets.
         """
         self.window_layout = QHBoxLayout()
@@ -436,7 +488,7 @@ class BCIGui(QWidget):
 
     def add_widget(self, widget: QWidget) -> None:
         """Add Widget.
-        
+
         Add a Widget to the main GUI, alongside the main window.
         """
         widget_layout = QHBoxLayout()

--- a/bcipy/gui/parameters/params_form.py
+++ b/bcipy/gui/parameters/params_form.py
@@ -9,9 +9,18 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QApplication, QFileDialog, QHBoxLayout,
                              QPushButton, QScrollArea, QVBoxLayout, QWidget)
 
-from bcipy.gui.gui_main import (SearchInput, FormInput, BoolInput, FileInput,
-                                DirectoryInput, SelectionInput, TextInput,
-                                static_text_control)
+from bcipy.gui.gui_main import (
+    BoolInput,
+    DirectoryInput,
+    FileInput,
+    FloatInput,
+    FormInput,
+    IntegerInput,
+    SearchInput,
+    SelectionInput,
+    static_text_control,
+    TextInput,
+)
 from bcipy.helpers.parameters import Parameters
 
 
@@ -54,6 +63,8 @@ class ParamsForm(QWidget):
         attributes."""
 
         type_inputs = {
+            'int': IntegerInput,
+            'float': FloatInput,
             'bool': BoolInput,
             'filepath': FileInput,
             'directorypath': DirectoryInput


### PR DESCRIPTION
# Overview

Add Integer and Float Form Inputs and apply in our form collection. Update alert messages in Experiment Field.

## Ticket

https://www.pivotaltracker.com/story/show/176210324

## Contributions

- `gui_main`: add `IntegerInput` and `FloatInput`. These use spinboxes which will prevent string or other data from being collected. It also casts the value from the form using `.value` to the appropriate type. 
- `ExperimentField`: Update to use new type inputs. Improve alert messages. Add alert message for a value error. 
- `param_form`: Update to use new type inputs

## Test

- Start BCInterface, Start Experiment, Fill in the Age information. Ensure it saves correctly. Update Age to be a float @ `.bcipy/fields/fields.json` and do the procedure above. 

## Documentaion

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here. No changes are necessary. 
