### PR TITLE
Task start indicator 

### DIFF
--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -25,7 +25,6 @@ class BCInterface(BCIGui):
 
     def __init__(self, *args, **kwargs):
         super(BCInterface, self).__init__(*args, **kwargs)
-        self.event_started = False
         self.parameter_location = DEFAULT_PARAMETERS_PATH
 
         self.parameters = load_json_parameters(self.parameter_location,
@@ -316,8 +315,6 @@ class BCInterface(BCIGui):
                     message_type=AlertMessageType.INFO,
                     okay_to_exit=True)
                 return False
-            if self.event_started:
-                return False
         except Exception as e:
             self.throw_alert_message(
                 title='BciPy Alert',
@@ -370,12 +367,17 @@ class BCInterface(BCIGui):
             command to bci_main.py and subprocess.
         """
         if self.check_input():
-            self.event_started = True
+            self.throw_alert_message(
+                    title='BciPy Alert',
+                    message='Task Starting ...',
+                    message_type=AlertMessageType.INFO,
+                    okay_to_exit=False)
             cmd = (
                 f'python bci_main.py -e "{self.experiment}" '
                 f'-u "{self.user}" -t "{self.task}" -p "{self.parameter_location}"'
             )
             subprocess.Popen(cmd, shell=True)
+            self.close()
 
     def offline_analysis(self) -> None:
         """Offline Analysis.
@@ -383,7 +385,6 @@ class BCInterface(BCIGui):
         Run offline analysis as a script in a new process.
         """
         cmd = 'python bcipy/signal/model/offline_analysis.py'
-        self.event_started = True
         subprocess.Popen(cmd, shell=True)
 
 

--- a/bcipy/gui/experiments/ExperimentField.py
+++ b/bcipy/gui/experiments/ExperimentField.py
@@ -257,6 +257,7 @@ class MainPanel(QWidget):
 
     def save(self):
         self.form.save()
+        self.close()
 
 
 def start_app() -> None:


### PR DESCRIPTION
# Overview

Add alert message when task starts from GUI. Add `self.close()` methods as opposed to `event_started`.

## Ticket

https://www.pivotaltracker.com/story/show/175519944

## Contributions

- `BCInterface`: add alert message before starting task... use `self.close()` and remove `event_started`
- `ExperimentField`: use `self.close()`

## Test

- Run BCInterface, start an experiment, ensure the alert displays. After exiting the alert, ensure the gui closes before the task starts. We could use a timeout, as opposed to click to exit, but we can ask for feedback next demo before doing that as it would require a custom QMessageBox. 

## Documentaion

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here. None
