### PR TITLE
#177171927 ; Signal Viewer Filter

### DIFF
--- a/bcipy/gui/viewer/demo/viewer_demo.py
+++ b/bcipy/gui/viewer/demo/viewer_demo.py
@@ -20,7 +20,6 @@ def main():
         server.start()
         data_viewer.main(data_file=None,
                          seconds=5,
-                         downsample_factor=2,
                          refresh=500,
                          yscale=150,
                          display_screen=0)

--- a/bcipy/helpers/acquisition.py
+++ b/bcipy/helpers/acquisition.py
@@ -79,7 +79,8 @@ def init_eeg_acquisition(parameters: dict,
 
     if parameters['acq_show_viewer']:
         viewer_screen = 1 if int(parameters['stim_screen']) == 0 else 0
-        start_viewer(display_screen=viewer_screen)
+        start_viewer(display_screen=viewer_screen,
+                     parameter_location=parameters['parameter_location'])
 
     # If we're using a server or data generator, there is no reason to
     # calibrate data.
@@ -157,9 +158,9 @@ def analysis_channel_names_by_pos(channels: List[str],
     return {i: ch for i, ch in enumerate(selected_channels)}
 
 
-def start_viewer(display_screen):
+def start_viewer(display_screen, parameter_location):
     viewer = 'bcipy/gui/viewer/data_viewer.py'
-    cmd = f'python {viewer} -m {display_screen}'
+    cmd = f'python {viewer} -m {display_screen} -p {parameter_location}'
     subprocess.Popen(cmd, shell=True)
 
     # hack: wait for window to open, so it doesn't error out when the main


### PR DESCRIPTION
# Overview

Modified signal viewer to use filter settings defined in the params file.

## Ticket

https://www.pivotaltracker.com/story/show/177171927

## Contributions

- Updated data viewer to accept the params location as a new parameter. Extracted the filter-related parameters from here to set the values when filtering the data.
- Updated the viewer GUI to display the current configured parameters.

## Test

- Ran the demo viewer code with and without the new parameter `python bcipy/gui/viewer/demo/viewer_demo.py`; confirmed that the default params location was used when none was provided and that when provided the filter settings were applied.
- Ran a calibration session with custom filtering parameters. Confirmed that the displayed settings in the viewer matched those in the custom parameters file.

