### PR TITLE
EDF conversion fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,10 @@ make lint
 
 ***Series***: Each series contains at least one inquiry. A letter/icon decision is made after a series in a spelling task.
 
+***Task**: An experimental design with stimuli, trials, inquiries and series for use in BCI. For instance, "RSVP Calibration" is a task.
+
+***Mode***: Common design elements between task types. For instance, Calibration and Free Spelling are modes.
+
 
 ## Authorship
 --------------

--- a/bcipy/helpers/convert.py
+++ b/bcipy/helpers/convert.py
@@ -85,7 +85,7 @@ def validate_annotations(record_time: float, trigger_count: int, annotation_chan
 
     Using the pyedflib library, it is recommended the number of triggers (or annotations) not exceed the recording
         time in seconds. This may not result in an unsuccessful export, therefore, we advise users to increase
-        annotation channels incrementally as needed to avoid loosing information. If the number of annotation
+        annotation channels incrementally as needed to avoid losing information. If the number of annotation
         channels is too high and no annotations are written to all channels created, a read error may result.
     """
     if trigger_count > record_time and not annotation_channels:

--- a/bcipy/helpers/demo/demo_convert.py
+++ b/bcipy/helpers/demo/demo_convert.py
@@ -1,23 +1,12 @@
-"""Demonstrates converting raw_data output to other EEG formats"""
+"""Demonstrates converting BciPy data output to other EEG formats.
+
+To use at bcipy root,
+
+    `python bcipy/helpers/demo/demo_convert.py -p "path://to/bcipy/data/folder"`
+"""
 from bcipy.helpers.convert import convert_to_edf
+from bcipy.helpers.vizualization import plot_edf
 from mne.io import read_raw_edf
-
-
-def plot_edf(edf_path: str, auto_scale: bool = False):
-    """Plot data from the raw edf file. Note: this works from an iPython
-    session but seems to throw errors when provided in a script.
-
-    Parameters
-    ----------
-        edf_path - full path to the generated edf file
-        auto_scale - optional; if True will scale the EEG data; this is
-            useful for fake (random) data but makes real data hard to read.
-    """
-    edf = read_raw_edf(edf_path, preload=True)
-    if auto_scale:
-        edf.plot(scalings='auto')
-    else:
-        edf.plot()
 
 
 if __name__ == '__main__':
@@ -30,5 +19,13 @@ if __name__ == '__main__':
         help='Path to the directory with raw_data to be converted',
         required=True)
     args = parser.parse_args()
-    edf_path = convert_to_edf(args.path)
+
+    path = args.path
+    edf_path = convert_to_edf(
+        path,
+        use_event_durations=True,
+        write_targetness=False,
+        overwrite=True,
+        annotation_channels=None)
+    # plot_edf(edf_path) # uncomment in an iPython notebook to plot using MNE
     print(f"\nWrote edf file to {edf_path}")

--- a/bcipy/helpers/exceptions.py
+++ b/bcipy/helpers/exceptions.py
@@ -1,4 +1,16 @@
 
+
+class BciPyCoreException(Exception):
+    """BciPy Core Exception.
+
+    Thrown when an error occurs specific to BciPy core concepts.
+    """
+
+    def __init__(self, message, errors=None):
+        super().__init__(message)
+        self.errors = errors
+
+
 class UnregisteredExperimentException(Exception):
     """Unregistered Experiment.
 

--- a/bcipy/helpers/load.py
+++ b/bcipy/helpers/load.py
@@ -15,7 +15,7 @@ import pandas as pd
 
 from bcipy.helpers.parameters import DEFAULT_PARAMETERS_PATH, Parameters
 from bcipy.helpers.system_utils import DEFAULT_EXPERIMENT_PATH, DEFAULT_FIELD_PATH, EXPERIMENT_FILENAME, FIELD_FILENAME
-from bcipy.helpers.exceptions import InvalidExperimentException
+from bcipy.helpers.exceptions import BciPyCoreException, InvalidExperimentException
 
 
 log = logging.getLogger(__name__)
@@ -60,6 +60,29 @@ def load_experiments(path: str = f'{DEFAULT_EXPERIMENT_PATH}{EXPERIMENT_FILENAME
     """
     with open(path, 'r') as json_file:
         return json.load(json_file)
+
+
+def extract_mode(bcipy_data_directory: str) -> str:
+    """Extract Mode.
+
+    This method extracts the task mode from a BciPy data save directory. This is important for
+        trigger conversions and extracting targeteness.
+
+    *note*: this is not compatiable with older versions of BciPy (pre 1.5.0) where
+        the tasks and modes were considered together using integers (1, 2, 3).
+
+    PARAMETERS
+    ----------
+    :param: bcipy_data_directory: string path to the data directory
+    """
+    directory = bcipy_data_directory.lower()
+    if 'calibration' in directory:
+        return 'calibration'
+    elif 'copy' in directory:
+        return 'copy_phrase'
+    elif 'free_spell' in directory:
+        return 'free_spell'
+    raise BciPyCoreException(f'No valid mode could be extracted from [{directory}]')
 
 
 def load_fields(path: str = f'{DEFAULT_FIELD_PATH}{FIELD_FILENAME}') -> dict:

--- a/bcipy/helpers/tests/test_convert.py
+++ b/bcipy/helpers/tests/test_convert.py
@@ -15,6 +15,22 @@ from bcipy.helpers.parameters import Parameters
 from bcipy.signal.generator.generator import gen_random_data
 
 
+MOCK_TRIGGER_DATA = '''calibration_trigger calib 0.4748408449813724
+J first_pres_target 6.151848723005969
++ fixation 8.118640798988054
+F nontarget 8.586895030981395
+D nontarget 8.887798132986063
+J target 9.18974666899885
+T nontarget 9.496583286992973
+K nontarget 9.798354075988755
+Q nontarget 10.099591801001225
+O nontarget 10.401458177977474
+Z nontarget 10.70310750597855
+R nontarget 11.00485198898241
+_ nontarget 11.306160968990298
+offset offset_correction 1.23828125'''
+
+
 def sample_data(rows: int = 1000, ch_names: List[str] = None) -> str:
     """Creates sample data to be written as a raw_data.csv file
 
@@ -22,7 +38,7 @@ def sample_data(rows: int = 1000, ch_names: List[str] = None) -> str:
     ch_names - channel names
     """
     if not ch_names:
-        ch_names = ['c1', 'c2', 'c3']
+        ch_names = ['ch1', 'ch2', 'ch3']
     # Mock the raw_data file
     sep = '\n'
     meta = sep.join([f'daq_type,LSL', 'sample_rate,256.0'])
@@ -45,27 +61,16 @@ class TestConvert(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Initialize data once"""
-        cls.trg_data = '''calibration_trigger calib 0.4748408449813724
-J first_pres_target 6.151848723005969
-+ fixation 8.118640798988054
-F nontarget 8.586895030981395
-D nontarget 8.887798132986063
-J target 9.18974666899885
-T nontarget 9.496583286992973
-K nontarget 9.798354075988755
-Q nontarget 10.099591801001225
-O nontarget 10.401458177977474
-Z nontarget 10.70310750597855
-R nontarget 11.00485198898241
-_ nontarget 11.306160968990298
-offset offset_correction 1.23828125
-'''
-        cls.sample_data = sample_data(rows=3000, ch_names=['c1', 'c2', 'c3'])
+        cls.trg_data = MOCK_TRIGGER_DATA
+        cls.channels = ['ch1', 'ch2', 'ch3']
+        cls.sample_data = sample_data(rows=3000, ch_names=cls.channels)
 
     def setUp(self):
         """Override; set up the needed path for load functions."""
 
         self.temp_dir = tempfile.mkdtemp()
+
+        self.default_mode = 'calibration'
 
         with open(Path(self.temp_dir, 'triggers.txt'), 'w') as trg_file:
             trg_file.write(self.__class__.trg_data)
@@ -83,7 +88,7 @@ offset offset_correction 1.23828125
 
     def test_convert_defaults(self):
         """Test default behavior"""
-        path = convert_to_edf(self.temp_dir)
+        path = convert_to_edf(self.temp_dir, mode=self.default_mode)
         self.assertTrue(os.path.exists(path))
 
         with warnings.catch_warnings():
@@ -92,25 +97,63 @@ offset offset_correction 1.23828125
 
         self.assertTrue(len(edf.get_data()) > 0)
 
-        for ch_name in ['c1', 'c2', 'c3']:
+        for ch_name in self.channels:
             self.assertTrue(ch_name in edf.ch_names)
 
     def test_overwrite_false(self):
         """Test overwriting fails"""
 
-        convert_to_edf(self.temp_dir)
+        convert_to_edf(self.temp_dir, mode=self.default_mode)
         with self.assertRaises(OSError):
-            convert_to_edf(self.temp_dir, overwrite=False)
+            convert_to_edf(self.temp_dir, mode=self.default_mode, overwrite=False)
 
     def test_overwrite_true(self):
         """Test that overwriting can be configured"""
 
-        convert_to_edf(self.temp_dir)
-        convert_to_edf(self.temp_dir, overwrite=True)
+        convert_to_edf(self.temp_dir, mode=self.default_mode)
+        convert_to_edf(self.temp_dir, overwrite=True, mode=self.default_mode)
 
     def test_with_custom_path(self):
         """Test creating the EDF without event annotations"""
         path = convert_to_edf(self.temp_dir,
+                              mode=self.default_mode,
                               edf_path=Path(self.temp_dir, 'mydata.edf'))
 
         self.assertEqual(Path(path).name, 'mydata.edf')
+
+    def test_with_write_targetness(self):
+        """Test creating the EDF without event annotations"""
+        path = convert_to_edf(self.temp_dir,
+                              mode=self.default_mode,
+                              write_targetness=True,
+                              edf_path=Path(self.temp_dir, 'mydata.edf'))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            edf = read_raw_edf(path, preload=True)
+
+        self.assertIn('target', edf.annotations.description)
+        self.assertIn('nontarget', edf.annotations.description)
+
+    def test_with_annotation_channels(self):
+        """Test creating the EDF without event annotations"""
+        # Increase the number of annotation channels by 1
+        annotation_channels = 2
+        # The expected channels should be equal to the number of annotation channels +
+        #   channels defined in the class + a TRG channel
+        expected_channel_number = annotation_channels + len(self.channels) + 1
+        path = convert_to_edf(self.temp_dir,
+                              mode=self.default_mode,
+                              write_targetness=True,
+                              annotation_channels=annotation_channels,
+                              edf_path=Path(self.temp_dir, 'mydata.edf'))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            edf = read_raw_edf(path, preload=True)
+
+        self.assertEqual(len(edf.ch_names), expected_channel_number)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bcipy/helpers/tests/test_load.py
+++ b/bcipy/helpers/tests/test_load.py
@@ -11,6 +11,7 @@ import json
 from mockito import any, expect, unstub, when
 
 from bcipy.helpers.load import (
+    extract_mode,
     load_json_parameters,
     load_signal_model,
     load_experiments,
@@ -19,7 +20,7 @@ from bcipy.helpers.load import (
     load_users,
     copy_parameters)
 from bcipy.helpers.parameters import Parameters
-from bcipy.helpers.exceptions import InvalidExperimentException
+from bcipy.helpers.exceptions import BciPyCoreException, InvalidExperimentException
 from bcipy.helpers.system_utils import DEFAULT_EXPERIMENT_PATH, DEFAULT_FIELD_PATH, FIELD_FILENAME, EXPERIMENT_FILENAME
 
 
@@ -201,6 +202,32 @@ class TestUserLoad(unittest.TestCase):
         length_of_users = len(response)
         self.assertTrue(length_of_users == 0)
         os.rmdir(file_path)
+
+
+class TestExtractMode(unittest.TestCase):
+
+    def test_extract_mode_calibration(self):
+        data_save_path = 'data/default/user/user_RSVP_Calibration_Mon_01_Mar_2021_11hr19min49sec_-0800'
+        expected_mode = 'calibration'
+        response = extract_mode(data_save_path)
+        self.assertEqual(expected_mode, response)
+
+    def test_extract_mode_copy_phrase(self):
+        data_save_path = 'data/default/user/user_RSVP_Copy_Phrase_Mon_01_Mar_2021_11hr19min49sec_-0800'
+        expected_mode = 'copy_phrase'
+        response = extract_mode(data_save_path)
+        self.assertEqual(expected_mode, response)
+
+    def test_extract_mode_free_spell(self):
+        data_save_path = 'data/default/user/user_RSVP_Free_Spell_Mon_01_Mar_2021_11hr19min49sec_-0800'
+        expected_mode = 'free_spell'
+        response = extract_mode(data_save_path)
+        self.assertEqual(expected_mode, response)
+
+    def test_extract_mode_without_mode_defined(self):
+        invalid_data_save_dir = 'data/default/user/user_bad_dir'
+        with self.assertRaises(BciPyCoreException):
+            extract_mode(invalid_data_save_dir)
 
 
 if __name__ == '__main__':

--- a/bcipy/helpers/vizualization.py
+++ b/bcipy/helpers/vizualization.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import matplotlib.pyplot as plt
 from bcipy.helpers.load import load_csv_data, read_data_csv
+from mne.io import read_raw_edf
 
 import logging
 log = logging.getLogger(__name__)
@@ -140,6 +141,23 @@ def generate_offline_analysis_screen(
 
     if show_figure:
         plt.show()
+
+
+def plot_edf(edf_path: str, auto_scale: bool = False):
+    """Plot data from the raw edf file. Note: this works from an iPython
+    session but seems to throw errors when provided in a script.
+
+    Parameters
+    ----------
+        edf_path - full path to the generated edf file
+        auto_scale - optional; if True will scale the EEG data; this is
+            useful for fake (random) data but makes real data hard to read.
+    """
+    edf = read_raw_edf(edf_path, preload=True)
+    if auto_scale:
+        edf.plot(scalings='auto')
+    else:
+        edf.plot()
 
 
 def visualize_csv_eeg_triggers(trigger_col=None):

--- a/bcipy/tasks/task_registry.py
+++ b/bcipy/tasks/task_registry.py
@@ -34,9 +34,9 @@ class TaskType(Enum):
     RSVP_COPY_PHRASE = 'RSVP Copy Phrase'
     RSVP_ICON_TO_ICON = 'RSVP Icon to Icon'
     RSVP_ICON_TO_WORD = 'RSVP Icon to Word'
-    RSVP_ALERT_TONE_CALIBRATION = 'RSVP Alert Tone'
+    RSVP_ALERT_TONE_CALIBRATION = 'RSVP Alert Tone Calibration'
     RSVP_INTER_INQUIRY_FEEDBACK_CALIBRATION = 'RSVP Inter-Inquiry Feedback Calibration'
-    RSVP_TIMING_VERIFICATION_CALIBRATION = 'RSVP Time Test'
+    RSVP_TIMING_VERIFICATION_CALIBRATION = 'RSVP Time Test Calibration'
 
     def __new__(cls, *args, **kwds):
         """Autoincrements the value of each item added to the enum."""


### PR DESCRIPTION
# Overview

Updates to improve EDF data conversions. Applying trigger offsets, ability to write targetness, and handling cases where there are too many annotations. 

## Ticket

- https://www.pivotaltracker.com/story/show/176668858
- https://www.pivotaltracker.com/story/show/176650169

## Contributions

- `convert.py`: Add mode, write_targetness, and annotation_channels keyword arguments.
- `demo_convert.py`: Update to add new keywords
- `helpers/load.py`: add extract_mode method for determining the mode
- `helpers/triggers.py`: add an offset correction method
- `helpers/vizualization.py`: moved plot_edf function from demo to this module.
- `task_registry.py`: Update tasks to include the necessary mode

## Test

- Added unittest
- Converted several files and had @danielpklee confirm in BrainVision

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Yes. I added task/mode to the README dictionary. 
