### PR TITLE
remove display from unittests (mock) and lint

### DIFF
--- a/bcipy/display/tests/test_display.py
+++ b/bcipy/display/tests/test_display.py
@@ -2,7 +2,6 @@ import unittest
 
 from mockito import any, mock, when, unstub
 import psychopy
-from bcipy.helpers.load import load_json_parameters
 from bcipy.display.display_main import init_display_window
 
 
@@ -12,7 +11,6 @@ class TestInitializeDisplayWindow(unittest.TestCase):
     def setUp(self):
         """Set up needed items for test."""
 
-        parameters_used = 'bcipy/parameters/parameters.json'
         self.window = mock()
         when(psychopy.visual).Window(
             size=any(), screen=any(),
@@ -26,8 +24,13 @@ class TestInitializeDisplayWindow(unittest.TestCase):
             waitBlanking=False,
             color=any(str)).thenReturn(self.window)
 
-        self.parameters = load_json_parameters(parameters_used,
-                                               value_cast=True)
+        self.parameters = {
+            'full_screen': False,
+            'window_height': 500,
+            'window_width': 500,
+            'stim_screen': 1,
+            'background_color': 'black'
+        }
 
         self.display_window = init_display_window(self.parameters)
 
@@ -39,3 +42,7 @@ class TestInitializeDisplayWindow(unittest.TestCase):
         """Test display window is created."""
         self.assertIsInstance(self.display_window, type(self.window))
         self.assertEqual(self.display_window, self.window)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bcipy/feedback/demo/demo_visual_feedback.py
+++ b/bcipy/feedback/demo/demo_visual_feedback.py
@@ -13,11 +13,10 @@ clock = core.Clock()
 visual_feedback = VisualFeedback(
     display=display, parameters=parameters, clock=clock)
 stimulus = 'A'
-assertion = 'B'
-message = 'Incorrect:'
-visual_feedback.message_color = 'red'
+message = 'Selected:'
+visual_feedback.message_color = 'white'
 timing = visual_feedback.administer(
-    stimulus, compare_assertion=assertion, message=message)
+    stimulus, message=message)
 print(timing)
 print(visual_feedback._type())
 display.close()

--- a/bcipy/feedback/sound/auditory_feedback.py
+++ b/bcipy/feedback/sound/auditory_feedback.py
@@ -15,6 +15,9 @@ class AuditoryFeedback(Feedback):
 
         # Parameters Dictionary
         self.parameters = parameters
+        # this should not be changed. Needed to play sound correctly
+        self.sound_buffer_time = 1
+        self.feedback_timestamp_label = 'auditory_feedback'
 
         # Clock
         self.clock = clock
@@ -25,9 +28,9 @@ class AuditoryFeedback(Feedback):
         if assertion:
             pass
 
-        time = ['auditory_feedback', self.clock.getTime()]
+        time = [self.feedback_timestamp_label, self.clock.getTime()]
         sd.play(sound, fs, blocking=True)
-        core.wait(1)
+        core.wait(self.sound_buffer_time)
         timing.append(time)
 
         return timing

--- a/bcipy/feedback/tests/sound/test_sound_feedback.py
+++ b/bcipy/feedback/tests/sound/test_sound_feedback.py
@@ -1,10 +1,8 @@
-from psychopy import core
 import unittest
 
 from mockito import mock, when, unstub
 
 from bcipy.feedback.sound.auditory_feedback import AuditoryFeedback
-from bcipy.helpers.load import load_json_parameters
 
 import sounddevice as sd
 
@@ -13,13 +11,11 @@ class TestSoundFeedback(unittest.TestCase):
 
     def setUp(self):
         """set up the needed path for load functions."""
-
-        self.parameters_used = 'bcipy/parameters/parameters.json'
-        self.parameters = load_json_parameters(self.parameters_used)
+        self.parameters = {}
         self.data_save_path = 'data/'
         self.user_information = 'test_user_0010'
 
-        self.clock = core.Clock()
+        self.clock = mock()
         self.sound = mock()
         self.fs = mock()
         when(sd).play(self.sound, self.fs, blocking=True).thenReturn(None)
@@ -38,7 +34,14 @@ class TestSoundFeedback(unittest.TestCase):
         self.assertEqual(feedback_type, 'Auditory Feedback')
 
     def test_feedback_administer_sound(self):
+        timestamp = 100
+        when(self.clock).getTime().thenReturn(timestamp)
         resp = self.auditory_feedback.administer(
             self.sound, self.fs)
 
         self.assertTrue(isinstance(resp, list))
+        self.assertEqual(resp[0], [self.auditory_feedback.feedback_timestamp_label, timestamp])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bcipy/feedback/tests/visual/test_visual_feedback.py
+++ b/bcipy/feedback/tests/visual/test_visual_feedback.py
@@ -1,34 +1,29 @@
 from psychopy import core
-from psychopy import visual
 import psychopy
 import unittest
 
-from mockito import any, mock, when, unstub
+from mockito import any, mock, when, unstub, verify, verifyNoUnwantedInteractions, verifyStubbedInvocationsAreUsed
 
-from bcipy.feedback.visual.visual_feedback import VisualFeedback
-from bcipy.helpers.load import load_json_parameters
+from bcipy.feedback.visual.visual_feedback import VisualFeedback, FeedbackType
 
 
 class TestVisualFeedback(unittest.TestCase):
 
     def setUp(self):
-        """set up the needed path for load functions."""
+        self.parameters = {
+            'feedback_font': 'Arial',
+            'feedback_stim_height': 1,
+            'feedback_stim_width': 1,
+            'feedback_message_color': 'white',
+            'feedback_pos_x': 0,
+            'feedback_pos_y': 0,
+            'feedback_flash_time': 2,
+            'feedback_line_width': 1
+        }
 
-        self.parameters_used = 'bcipy/parameters/parameters.json'
-        self.parameters = load_json_parameters(
-            self.parameters_used,
-            value_cast=True)
-
-        self.display = visual.Window(
-            size=[1, 1],
-            screen=0,
-            allowGUI=False, useFBO=False, fullscr=False,
-            allowStencil=False, monitor='mainMonitor',
-            winType='pyglet', units='norm', waitBlanking=False,
-            color='black')
+        self.display = mock()
         self.text_mock = mock()
         self.image_mock = mock()
-        self.rect_mock = mock()
 
         self.clock = core.Clock()
 
@@ -36,76 +31,99 @@ class TestVisualFeedback(unittest.TestCase):
             display=self.display, parameters=self.parameters,
             clock=self.clock)
 
+    def tearDown(self):
+        verifyStubbedInvocationsAreUsed()
+        verifyNoUnwantedInteractions()
+        unstub()
+
+    def test_feedback_type(self):
+        feedback_type = self.visual_feedback._type()
+        self.assertEqual(feedback_type, 'Visual Feedback')
+
+    def test_construct_message_returns_text_stimuli(self):
+        message = 'test_message'
+        stim_mock = mock()
         when(psychopy.visual).TextStim(
             win=self.display,
-            font=any(),
-            text=any(),
-            height=any(),
-            pos=any(),
-            color=any()).thenReturn(self.text_mock)
+            font=self.visual_feedback.font_stim,
+            text=message,
+            height=self.visual_feedback.message_height,
+            pos=self.visual_feedback.message_pos,
+            color=self.visual_feedback.message_color
+        ).thenReturn(stim_mock)
 
-        when(psychopy.visual).TextStim(
-            win=self.display,
-            font=any(),
-            text=any(),
-            height=any(),
-            pos=any()).thenReturn(self.text_mock)
+        response = self.visual_feedback._construct_message(message)
+        self.assertEqual(stim_mock, response)
 
+    def test_construct_stimulus_image(self):
+        image_mock = mock()
+        image_mock.size = 0
         when(psychopy.visual).ImageStim(
             win=self.display,
             image=any(),
             mask=None,
             pos=any(),
             ori=any()
-        ).thenReturn(self.image_mock)
+        ).thenReturn(image_mock)
+        # mock the resize behavior for the image
+        when(self.visual_feedback)._resize_image(any(), any(), any()).thenReturn(0)
 
-        when(psychopy.visual).Rect(
+        response = self.visual_feedback._construct_stimulus(
+            'test_stim.png',
+            (0, 0),
+            None,
+            FeedbackType.IMAGE,
+        )
+
+        self.assertEqual(response, image_mock)
+
+    def test_construct_stimulus_text(self):
+        text_mock = mock()
+        stimulus = 'test'
+        when(psychopy.visual).TextStim(
             win=self.display,
-            width=any(),
-            height=any(),
-            lineColor=any(),
+            font=self.visual_feedback.font_stim,
+            text=stimulus,
+            height=self.visual_feedback.height_stim,
             pos=any(),
-            lineWidth=any(),
-            ori=any()
-        ).thenReturn(self.rect_mock)
+            color=any()).thenReturn(text_mock)
 
-    def tearDown(self):
-        # clean up by removing the data folder we used for testing
-        self.display.close()
-        unstub()
-
-    def test_feedback_type(self):
-
-        feedback_type = self.visual_feedback._type()
-        self.assertEqual(feedback_type, 'Visual Feedback')
-
-    def test_feedback_administer_text(self):
-        test_stimulus = 'A'
-        resp = self.visual_feedback.administer(
-            test_stimulus, message='Correct:')
-
-        self.assertTrue(isinstance(resp, list))
-
-    def test_feedback_assertion_text(self):
-        stimulus = 'B'
-        assertion = 'A'
-        self.visual_feedback.message_color = 'red'
-        resp = self.visual_feedback.administer(
+        response = self.visual_feedback._construct_stimulus(
             stimulus,
-            message='Incorrect:', compare_assertion=assertion)
-        self.assertTrue(isinstance(resp, list))
+            (0, 0),
+            None,
+            FeedbackType.TEXT,
+        )
 
-    def test_feedback_administer_image(self):
-        test_stimulus = 'bcipy/static/images/testing_images/white.png'
-        resp = self.visual_feedback.administer(
-            test_stimulus, message='Correct:')
+        self.assertEqual(response, text_mock)
 
-        self.assertTrue(isinstance(resp, list))
+    def test_show_stimuli(self):
+        stimuli_mock = mock()
+        when(stimuli_mock).draw().thenReturn(None)
+        when(self.display).flip().thenReturn(None)
 
-    def test_feedback_assertion_images(self):
-        test_stimulus = 'bcipy/static/images/testing_images/white.png'
-        assertion = 'bcipy/static/images/testing_images/white.png'
-        resp = self.visual_feedback.administer(
-            test_stimulus, message='Correct:', compare_assertion=assertion)
+        self.visual_feedback._show_stimuli(stimuli_mock)
 
-        self.assertTrue(isinstance(resp, list))
+        verify(stimuli_mock, times=1).draw()
+        verify(self.display, times=1).flip()
+
+    def test_administer_default(self):
+
+        stimulus = mock()
+        timestamp = 1000
+        when(self.visual_feedback)._construct_stimulus(
+            stimulus,
+            self.visual_feedback.pos_stim,
+            'blue',
+            FeedbackType.TEXT
+        ).thenReturn(stimulus)
+        when(self.visual_feedback)._show_stimuli(stimulus).thenReturn()
+        when(self.clock).getTime().thenReturn(timestamp)
+        when(psychopy.core).wait(self.visual_feedback.feedback_length).thenReturn()
+        response = self.visual_feedback.administer(stimulus)
+        expected = [[self.visual_feedback.feedback_timestamp_label, timestamp]]
+        self.assertEqual(response, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bcipy/feedback/visual/level_feedback.py
+++ b/bcipy/feedback/visual/level_feedback.py
@@ -8,7 +8,7 @@ class LevelFeedback(VisualFeedback):
     """Level Feedback.
 
     A progress bar like feedback to indicate current abilities in a BCI task. This could
-        be atteniveness, muscle or eye activity, etc.
+        be attentiveness, muscle or eye activity, etc.
 
     It does not return stimuli timing or allow for parameterized configuration of levels / color gradient
     at this time.

--- a/bcipy/helpers/demo/demo_convert.py
+++ b/bcipy/helpers/demo/demo_convert.py
@@ -6,7 +6,6 @@ To use at bcipy root,
 """
 from bcipy.helpers.convert import convert_to_edf
 from bcipy.helpers.vizualization import plot_edf
-from mne.io import read_raw_edf
 
 
 if __name__ == '__main__':
@@ -27,5 +26,5 @@ if __name__ == '__main__':
         write_targetness=False,
         overwrite=True,
         annotation_channels=None)
-    # plot_edf(edf_path) # uncomment in an iPython notebook to plot using MNE
+    plot_edf(edf_path)  # comment if not in an iPython notebook to plot using MNE
     print(f"\nWrote edf file to {edf_path}")

--- a/bcipy/tasks/rsvp/copy_phrase.py
+++ b/bcipy/tasks/rsvp/copy_phrase.py
@@ -294,7 +294,6 @@ class RSVPCopyPhraseTask(Task):
                 self.feedback.administer(
                     last_selection,
                     message='Selected:',
-                    line_color=self.feedback_color,
                     fill_color=self.feedback_color)
 
             if new_series:

--- a/bcipy/tasks/rsvp/icon_to_icon.py
+++ b/bcipy/tasks/rsvp/icon_to_icon.py
@@ -223,7 +223,6 @@ class RSVPIconToIconTask(Task):
                                   clock=self.experiment_clock)
         feedback.message_color = 'green' if correct else 'red'
         feedback.administer(self.img_path(selection),
-                            compare_assertion=None,
                             message='Decision: ',
                             stimuli_type=FeedbackType.IMAGE)
 


### PR DESCRIPTION
# Overview

Updated unittests using psychopy displays and refactored as needed to maintain coverage. Several args were removed from `VisualFeedback`, as they were unused in the codebase or in the methods themselves. Because this was easily mocked with existing libraries (mockito) no mock was created for additional use as each implementation may use different aspects.

## Ticket

https://www.pivotaltracker.com/story/show/177687754

## Contributions

- `display`: updated test_display to set parameters instead of loading and to allow running using `if __name__ in '__main__'`
- `auditory_feedback`: to allow for easier setting of relevant parameters and testing
-  `test_sound_feedback`: updated test_display to set parameters instead of loading and to allow running using `if __name__ in '__main__'`. Mocked the psychopy clock.
- `visual_feedback`: deprecate shape feedback type, line_color (in the administer method), and compare assertion as both were unused and added unneeded complexity. Set hard-coded values on the class instance for easier changing later. 
- `demo_visual_feedback`: to not use the compare assertion
- `test_visual_feedback`: refactored to not use a psychopy display instance. added coverage. Allow running using `if __name__ in '__main__'`.

## Test

- `coverage run --branch --source=bcipy -m pytest`
- `python bcipy/feedback/demo/demo_visual_feedback.py`
- `python bcipy/feedback/visual_feedback.py`
- BCInterface, run copy_phrase task with show_feedback set to true. We're deprecating Icon to Icon in a fast following PR (no assertion needed).

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? No obvious documentation changes needed
