### PR TITLE
#176581753 ; added timeout to acquisition connector

### DIFF
--- a/bcipy/acquisition/protocols/lsl/lsl_connector.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_connector.py
@@ -12,7 +12,7 @@ from bcipy.acquisition.devices import DeviceSpec
 log = logging.getLogger(__name__)
 
 LSL_TIMESTAMP = 'LSL_timestamp'
-
+LSL_TIMEOUT_SECONDS = 5.0
 
 class Marker():
     """Data class which wraps a LSL marker; data pulled from a marker stream is
@@ -116,7 +116,7 @@ class LslConnector(Connector):
         # There can be 1 current marker for each marker channel.
         self.current_markers = {}
         # seconds to wait for a data stream
-        self.timeout=5.0
+        self.timeout=LSL_TIMEOUT_SECONDS
 
     @classmethod
     def supports(cls, device_spec: DeviceSpec,


### PR DESCRIPTION
# Overview

Added a timeout to the acquisition module code that connects to the datasource.

## Ticket

https://www.pivotaltracker.com/story/show/176581753

## Contributions

- Modified the lsl_connector to use a connection method which supports a timeout parameter.

## Test

- Confirmed that existing unit tests still passed.
- With the fake_data parameter set to false, ran a calibration task without a separate data server to confirm that the exception would be thrown after the timeout period and that launching bcipy failed with a useful error message.
- Ran calibration task with fake data set to false and a running data server to confirm that bcipy still launched successfully when the expected data was present.
- Ran calibration task with fake data set to true to confirm that bcipy still worked as expected with mock data.
