### PR TITLE
Add abstract base class for SignalModel

### DIFF
--- a/bcipy/signal/model/__init__.py
+++ b/bcipy/signal/model/__init__.py
@@ -1,0 +1,5 @@
+from .model import SignalModel
+
+__all__ = [
+    "SignalModel",
+]

--- a/bcipy/signal/model/model.py
+++ b/bcipy/signal/model/model.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import List
+from dataclasses import dataclass
+
+import numpy as np
+
+
+class SignalModel(ABC):
+    @abstractmethod
+    def fit(self, training_data: np.array, training_labels: np.array) -> SignalModel:
+        """
+        Train the model using the provided data and labels.
+        Return self for convenience.
+        """
+        ...
+
+    @abstractmethod
+    def evaluate(self, test_data: np.array, test_labels: np.array) -> ModelEvaluationReport:
+        """Compute model performance characteristics on the provided test data and labels."""
+        ...
+
+    @abstractmethod
+    def predict(self, data: np.array, presented_symbols: List[str], all_symbols: List[str]) -> np.array:
+        """Using the provided data, compute log likelihoods over the entire symbol set."""
+        ...
+
+    @abstractmethod
+    def save(self, path: Path) -> None:
+        """Save model state to the provided checkpoint"""
+        ...
+
+    @abstractmethod
+    def load(self, path: Path) -> None:
+        """Restore model state from the provided checkpoint"""
+        ...
+
+    @abstractmethod
+    def __eq__(self, other) -> bool:
+        """Might be useful for confirming that model.load(model.save) == model"""
+        ...
+
+
+@dataclass
+class ModelEvaluationReport:
+    """
+    Describes model performance characteristics.
+
+    TODO - add more attributes as needed. Note that the model
+    may not know about how its outputs are applied to compute a decision rule,
+    so the model alone cannot compute AUC unless `model.evaluate` is also invoked
+    with a callback or something. (This would get a bit finnicky).
+    """
+
+    auc: float

--- a/bcipy/signal/model/model.py
+++ b/bcipy/signal/model/model.py
@@ -23,8 +23,13 @@ class SignalModel(ABC):
         ...
 
     @abstractmethod
-    def predict(self, data: np.array, presented_symbols: List[str], all_symbols: List[str]) -> np.array:
-        """Using the provided data, compute log likelihoods over the entire symbol set."""
+    def predict(self, data: np.array, inquiry: List[str], symbol_set: List[str]) -> np.array:
+        """
+        Using the provided data, compute log likelihoods over the entire symbol set.
+        Args:
+            inquiry - the subset of symbols presented
+            symbol_set - the entire alphabet of symbols
+        """
         ...
 
     @abstractmethod
@@ -37,21 +42,11 @@ class SignalModel(ABC):
         """Restore model state from the provided checkpoint"""
         ...
 
-    @abstractmethod
-    def __eq__(self, other) -> bool:
-        """Might be useful for confirming that model.load(model.save) == model"""
-        ...
-
 
 @dataclass
 class ModelEvaluationReport:
     """
     Describes model performance characteristics.
-
-    TODO - add more attributes as needed. Note that the model
-    may not know about how its outputs are applied to compute a decision rule,
-    so the model alone cannot compute AUC unless `model.evaluate` is also invoked
-    with a callback or something. (This would get a bit finnicky).
     """
 
     auc: float


### PR DESCRIPTION
# Overview

Added an abstract base class `SignalModel` in preparation for refactoring the current PCA/RDA/KDE model and then integrating a new neural network model.

## Ticket

https://www.pivotaltracker.com/story/show/177691543

## Contributions

`bcipy/signal/model/model.py` - Add abstract base class
`bcipy/signal/model/__init__.py` - Make abstract base class available using `from bcipy.signal.model import SignalModel`

## Test

No tests added for this abstract class.

## Documentation

The base class has simple descriptions of the purpose of each method. Once the PCA/RDA/KDE model is refactored to this structure, more documentation can be added if useful. Alternatively, a "dummy" example class could be added if that would be useful.