### PR TITLE
#176151285 ; use stim_length parameter

### DIFF
--- a/bcipy/helpers/copy_phrase_wrapper.py
+++ b/bcipy/helpers/copy_phrase_wrapper.py
@@ -40,6 +40,7 @@ class CopyPhraseWrapper:
             backspace character.
         backspace_always_shown(bool): whether or not the backspace should
             always be presented.
+        stim_length: the number of stimuli to present in each inquiry
     """
 
     def __init__(self, min_num_inq, max_num_inq, signal_model=None, fs=300, k=2,
@@ -53,7 +54,8 @@ class CopyPhraseWrapper:
                  filter_high=45,
                  filter_low=2,
                  filter_order=2,
-                 notch_filter_frequency=60):
+                 notch_filter_frequency=60,
+                 stim_length=10):
 
         self.conjugator = EvidenceFusion(evidence_names, len_dist=len(alp))
 
@@ -67,9 +69,8 @@ class CopyPhraseWrapper:
             commit_criteria=[MaxIterationsCriteria(max_num_inq),
                              ProbThresholdCriteria(decision_threshold)])
 
-        # TODO: Parametrize len_query in the future releases!
         stimuli_agent = NBestStimuliAgent(alphabet=alp,
-                                          len_query=10)
+                                          len_query=stim_length)
 
         self.decision_maker = DecisionMaker(
             stimuli_agent=stimuli_agent,

--- a/bcipy/tasks/rsvp/copy_phrase.py
+++ b/bcipy/tasks/rsvp/copy_phrase.py
@@ -153,7 +153,8 @@ class RSVPCopyPhraseTask(Task):
             filter_high=self.filter_high,
             filter_low=self.filter_low,
             filter_order=self.filter_order,
-            notch_filter_frequency=self.notch_filter_frequency)
+            notch_filter_frequency=self.notch_filter_frequency,
+            stim_length=self.stim_length)
 
         # Set new series (whether to present a new series),
         #   run (whether to cont. session),


### PR DESCRIPTION
# Overview

Use stim_length parameter rather than hard-coded values for the Copy Phrase task.

## Ticket

https://www.pivotaltracker.com/story/show/176151285

## Contributions

- Added a parameter to the Copy Phrase Wrapper to accept a stim_length parameter; used this parameter to initialize the Agent which selects the next stimuli to present.
- Modified Copy Phrase task to pass the stim_length parameter to CopyPhraseWrapper

## Test

Note that the model used for a Copy Phrase task must be generated using a Calibration session with the same stim_length value.

- ran calibration with the stim_length param set to non-default value.
- ran offline_analysis to general a model
- ran copy phrase with custom stim_length parameter to confirm that the correct number of stimulus were presented for each inquiry.
