### PR TITLE
Python 3 7 generator end

### DIFF
--- a/bcipy/acquisition/tests/datastream/test_generator.py
+++ b/bcipy/acquisition/tests/datastream/test_generator.py
@@ -112,7 +112,7 @@ class TestGenerator(unittest.TestCase):
             for _ in range(row_count):
                 next(gen)
 
-            with self.assertRaises(StopIteration):
+            with self.assertRaises((StopIteration, RuntimeError)):
                 data.append(next(gen))
 
     def test_file_with_custom_encoder(self):

--- a/bcipy/acquisition/tests/datastream/test_producer.py
+++ b/bcipy/acquisition/tests/datastream/test_producer.py
@@ -64,3 +64,30 @@ class TestProducer(unittest.TestCase):
         self.assertTrue(expected_n - tolerance > maxiters)
         data_n = data_queue.qsize()
         self.assertEqual(data_n, maxiters)
+
+    def test_producer_end(self):
+        data_queue = queue.Queue()
+
+        def stopiteration_generator(n):
+            i = 0
+            while True:
+                yield i
+                i += 1
+                if i >= n:
+                    raise StopIteration
+
+        def simple_generator(n):
+            for i in range(n):
+                yield i
+
+        with self.assertRaises(Exception):
+            with Producer(data_queue, generator=stopiteration_generator(10)) as p:
+                p.run()
+
+        with self.assertRaises(Exception):
+            with Producer(data_queue, generator=simple_generator(10)) as p:
+                p.run()
+
+        with self.assertRaises(Exception):
+            with Producer(data_queue, generator=(1 for _ in range(10))) as p:
+                p.run()


### PR DESCRIPTION
# Overview

Fix broken test for python 3.7+.

See https://docs.python.org/3/whatsnew/3.7.html#changes-in-python-behavior, which mentions this is an intended change in behavior:

> PEP 479 is enabled for all code in Python 3.7, meaning that StopIteration exceptions raised directly or indirectly in coroutines and generators are transformed into RuntimeError exceptions.

The examples (and frankly the rationale!) given in that PEP confuse me. Also, this effect seems to not occur consistently.

---
_On the one hand_, in the REPL this distinction seems to have an effect. A generator that explicitly does `raise StopIteration` shows this behavior (the exception is converted into `RuntimeError`). A generator that simply exhausts its data without explicitly raising anything will in fact still return `StopIteration`. This suggests the correct pattern is to do `except (StopIteration, RuntimeError)` to be thorough.

Here, the generator chooses to raise `StopIteration` when exhausted, and we see it get converted to `RuntimeError`:
```
In [1]: def my_gen(n):
   ...:     for i in range(n):
   ...:         yield i
   ...:         if i >= 3:
   ...:             raise StopIteration
   ...:

In [2]: g = my_gen(5)

In [3]: [next(g) for _ in range(10)]
...
RuntimeError: generator raised StopIteration
```

Here, the generator just returns silently when empty, and we get `StopIteration`
```
In [4]: g = (1 for _ in range(5))

In [5]: [next(g) for _ in range(10)]
...
StopIteration:
```


---

_However on the other hand_:
I found one occurrence where `except StopIteration` was being performed on a generator: https://github.com/CAMBI-tech/BciPy/blob/1.5.1/bcipy/acquisition/datastream/producer.py#L59 (Note this line was previously untested). I added a test, thinking it was necessary to change the code, but I cannot get this same behavior to occur there, and `except StopIteration` seems to be sufficient! 

/shrug

## Ticket

https://www.pivotaltracker.com/story/show/177655233

## Contributions

## Test

Run the previously failing test:
```
pytest -k test_file_generator_end
```

Run the new test:
```
pytest -k test_producer_end
```

## Documentation

No documentation changes
