### PR TITLE
Add tests copy phrase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,12 @@ test-all:
 	flake8 bcipy
 	coverage report
 
+unit-test:
+	pytest -k "not slow"
+
+integration-test:
+	pytest -k "slow"
+
 coverage-html:
 	coverage run --branch --source=bcipy -m pytest
 	coverage html

--- a/bcipy/helpers/tests/test_copy_phrase_wrapper.py
+++ b/bcipy/helpers/tests/test_copy_phrase_wrapper.py
@@ -2,9 +2,64 @@ import unittest
 
 from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
 from bcipy.helpers.task import alphabet
+import numpy as np
+import tempfile
+import shutil
+from bcipy.signal.model.mach_learning.train_model import train_pca_rda_kde_model
+from bcipy.helpers.load import load_json_parameters
+from bcipy.helpers.save import init_save_data_structure
+from bcipy.acquisition.devices import supported_device
+from bcipy.acquisition.devices import DeviceSpec, register
+
+from pathlib import Path
+import random
 
 
 class TestCopyPhraseWrapper(unittest.TestCase):
+    """Test CopyPhraseWrapper"""
+
+    @classmethod
+    def setUpClass(cls):
+        np.random.seed(0)
+        random.seed(0)
+        cls.tmp_dir = Path(tempfile.mkdtemp())
+
+        cls.device_spec = DeviceSpec(name="dummy_device", channels=["1", "2", "3"], sample_rate=10)
+        register(cls.device_spec)
+
+        cls.params_used = "bcipy/parameters/parameters.json"
+        cls.params = load_json_parameters(cls.params_used, value_cast=True)
+
+        # # Generate fake data and train a model
+        # Specify data dimensions
+        cls.num_trial = cls.params["stim_length"]
+        cls.dim_x = 5  # TODO - compute this based on device_spec and params
+        cls.num_channel = cls.device_spec.channel_count
+        cls.num_x_pos = 200
+        cls.num_x_neg = 200
+
+        # Generate Gaussian random data
+        # TODO - deduplicate, add to test utils somewhere (data generation matching a device_spec)
+        cls.pos_mean, cls.pos_std = 0, 0.5
+        cls.neg_mean, cls.neg_std = 1, 0.5
+        x_pos = cls.pos_mean + cls.pos_std * np.random.randn(cls.num_channel, cls.num_x_pos, cls.dim_x)
+        x_neg = cls.neg_mean + cls.neg_std * np.random.randn(cls.num_channel, cls.num_x_neg, cls.dim_x)
+        y_pos = np.ones(cls.num_x_pos)
+        y_neg = np.zeros(cls.num_x_neg)
+
+        # Stack and permute data
+        x = np.concatenate([x_pos, x_neg], 1)
+        y = np.concatenate([y_pos, y_neg], 0)
+        permutation = np.random.permutation(cls.num_x_pos + cls.num_x_neg)
+        x = x[:, permutation, :]
+        y = y[permutation]
+
+        cls.model, _ = train_pca_rda_kde_model(x, y, k_folds=10)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp_dir)
+
     def test_valid_letters(self):
         alp = alphabet()
         cp = CopyPhraseWrapper(
@@ -14,57 +69,174 @@ class TestCopyPhraseWrapper(unittest.TestCase):
             fs=25,
             k=2,
             alp=alp,
-            task_list=[('HELLO_WORLD', 'HE')],
+            task_list=[("HELLO_WORLD", "HE")],
             is_txt_stim=True,
-            device_name='LSL',
-            evidence_names=['LM', 'ERP'],
-            device_channels=[
-                'ch1', 'ch2', 'ch3', 'ch4', 'ch5', 'ch6', 'ch7', 'ch8', 'ch9',
-                'ch10', 'ch11', 'ch12', 'ch13', 'ch14', 'ch15', 'ch16', 'TRG'
-            ],
-            stimuli_timing=[0.5, 0.25])
+            device_name=self.device_spec.name,
+            evidence_names=["LM", "ERP"],
+            device_channels=self.device_spec.channels,
+            stimuli_timing=[0.5, 0.25],
+        )
 
-        triggers = [('+', 0.0), ('H', 0.5670222830376588),
-                    ('D', 0.8171830819919705), ('J', 1.0843321380089037),
-                    ('B', 1.3329724550130777), ('C', 1.5825864360085689),
-                    ('A', 1.833380013005808), ('F', 2.083211077027954),
-                    ('G', 2.333359022042714), ('I', 2.583265081048012),
-                    ('E', 2.833274284028448)]
+        triggers = [
+            ("+", 0.0),
+            ("H", 0.5670222830376588),
+            ("D", 0.8171830819919705),
+            ("J", 1.0843321380089037),
+            ("B", 1.3329724550130777),
+            ("C", 1.5825864360085689),
+            ("A", 1.833380013005808),
+            ("F", 2.083211077027954),
+            ("G", 2.333359022042714),
+            ("I", 2.583265081048012),
+            ("E", 2.833274284028448),
+        ]
         target_info = [
-            'nontarget', 'nontarget', 'nontarget', 'nontarget', 'nontarget',
-            'nontarget', 'nontarget', 'nontarget', 'nontarget', 'nontarget',
-            'nontarget'
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
         ]
 
         letters, timings, labels = cp.letter_info(triggers, target_info)
-        expected_letters = ['H', 'D', 'J', 'B', 'C', 'A', 'F', 'G', 'I', 'E']
+        expected_letters = ["H", "D", "J", "B", "C", "A", "F", "G", "I", "E"]
         expected_time = [
-            0.5670222830376588, 0.8171830819919705, 1.0843321380089037,
-            1.3329724550130777, 1.5825864360085689, 1.833380013005808,
-            2.083211077027954, 2.333359022042714, 2.583265081048012,
-            2.833274284028448
+            0.5670222830376588,
+            0.8171830819919705,
+            1.0843321380089037,
+            1.3329724550130777,
+            1.5825864360085689,
+            1.833380013005808,
+            2.083211077027954,
+            2.333359022042714,
+            2.583265081048012,
+            2.833274284028448,
         ]
         self.assertEqual(expected_letters, letters)
         self.assertEqual(expected_time, timings)
         self.assertEqual(len(letters), len(labels))
 
-        triggers = [('calibration_trigger', 0.0), ('+', 0.1), ('H', 0.5670222830376588),
-                    ('D', 0.8171830819919705), ('J', 1.0843321380089037),
-                    ('B', 1.3329724550130777), ('C', 1.5825864360085689),
-                    ('A', 1.833380013005808), ('F', 2.083211077027954),
-                    ('G', 2.333359022042714), ('I', 2.583265081048012),
-                    ('E', 2.833274284028448)]
+        triggers = [
+            ("calibration_trigger", 0.0),
+            ("+", 0.1),
+            ("H", 0.5670222830376588),
+            ("D", 0.8171830819919705),
+            ("J", 1.0843321380089037),
+            ("B", 1.3329724550130777),
+            ("C", 1.5825864360085689),
+            ("A", 1.833380013005808),
+            ("F", 2.083211077027954),
+            ("G", 2.333359022042714),
+            ("I", 2.583265081048012),
+            ("E", 2.833274284028448),
+        ]
         target_info = [
-            'calib', 'fixation', 'nontarget', 'nontarget', 'nontarget', 'nontarget',
-            'nontarget', 'nontarget', 'nontarget', 'nontarget', 'nontarget',
-            'nontarget'
+            "calib",
+            "fixation",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
         ]
         letters, timings, labels = cp.letter_info(triggers, target_info)
         self.assertEqual(expected_letters, letters)
         self.assertEqual(expected_time, timings)
-        self.assertEqual(['nontarget'] * (len(letters)), labels)
+        self.assertEqual(["nontarget"] * (len(letters)), labels)
 
         # Test it throws an exception when letter is outside alphabet
         with self.assertRaises(Exception):
-            cp.letter_info([('A', 0.0), ('*', 1.0)],
-                           ['nontarget', 'nontarget'])
+            cp.letter_info([("A", 0.0), ("*", 1.0)], ["nontarget", "nontarget"])
+
+    def test_init_series_evaluate_inquiry(self):
+        # TODO - it would be just as easy to store a snippet of real data, which would be a much better test
+        # (since this fake data likely does not exercise the dynamic range of the model)
+        alp = alphabet()
+
+        # Create fake data to provide as the user's response
+        # Create test items that resemble the fake training data, testing inference
+        # TODO - is this duration calculated precisely, or is it just large enough by coincidence?
+        # int(self.num_trial * self.device_spec.sample_rate * (self.params["time_flash"] + self.params["static_trigger_offset"]))
+        duration = 1000
+        response_eeg = self.pos_mean + self.pos_std * np.random.randn(self.num_channel, duration)
+
+        copy_phrase_task = CopyPhraseWrapper(
+            min_num_inq=1,
+            max_num_inq=50,
+            signal_model=self.model,
+            fs=self.device_spec.sample_rate,
+            k=1,
+            alp=alp,
+            task_list=[("HELLO_WORLD", "HE")],
+            is_txt_stim=True,
+            device_name=self.device_spec.name,
+            evidence_names=["LM", "ERP"],
+            device_channels=self.device_spec.channels,
+            stimuli_timing=[0.5, 0.25],
+            notch_filter_frequency=4.0,
+            filter_low=1.0,
+            filter_high=4.0,
+            stim_length=self.params["stim_length"],
+        )
+
+        is_accepted, sti = copy_phrase_task.initialize_series()
+        self.assertFalse(is_accepted)
+        self.assertEqual(
+            sti,
+            (
+                [['+', 'U', 'T', '_', 'W', 'Y', 'X', 'Z', '<', 'S', 'V']],
+                [[self.params["time_cross"]] + [self.params["time_flash"]] * self.params["stim_length"]],
+                [[self.params["fixation_color"]] + [self.params["stim_color"]] * self.params["stim_length"]],
+            ),
+        )
+
+        triggers = [
+            ("+", 0.0),
+            ("H", 0.5670222830376588),
+            ("D", 0.8171830819919705),
+            ("J", 1.0843321380089037),
+            ("B", 1.3329724550130777),
+            ("C", 1.5825864360085689),
+            ("A", 1.833380013005808),
+            ("F", 2.083211077027954),
+            ("G", 2.333359022042714),
+            ("I", 2.583265081048012),
+            ("E", 2.833274284028448),
+        ]
+        target_info = [
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+            "nontarget",
+        ]
+
+        new_series, sti = copy_phrase_task.evaluate_inquiry(
+            response_eeg, triggers, target_info, self.params["trial_length"]
+        )
+        self.assertFalse(new_series)
+        self.assertEqual(
+            sti,
+            (
+                [["+", "E", "I", "B", "F", "D", "G", "H", "C", "A", "J"]],
+                [[self.params["time_cross"]] + [self.params["time_flash"]] * self.params["stim_length"]],
+                [[self.params["fixation_color"]] + [self.params["stim_color"]] * self.params["stim_length"]],
+            ),
+        )

--- a/bcipy/helpers/tests/test_copy_phrase_wrapper.py
+++ b/bcipy/helpers/tests/test_copy_phrase_wrapper.py
@@ -4,9 +4,7 @@ from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
 from bcipy.helpers.task import alphabet
 
 
-class TestSignalModelRelated(unittest.TestCase):
-    """Test CopyPhraseWrapper"""
-
+class TestCopyPhraseWrapper(unittest.TestCase):
     def test_valid_letters(self):
         alp = alphabet()
         cp = CopyPhraseWrapper(

--- a/bcipy/signal/tests/model/test_offline_analysis.py
+++ b/bcipy/signal/tests/model/test_offline_analysis.py
@@ -16,6 +16,7 @@ input_folder = pwd / "integration_test_input"
 expected_output_folder = pwd / "integration_test_expected_output"  # global for the purpose of pytest-mpl decorator
 
 
+@pytest.mark.slow
 class TestOfflineAnalysis(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/bcipy/tasks/rsvp/query_mechanisms.py
+++ b/bcipy/tasks/rsvp/query_mechanisms.py
@@ -167,7 +167,6 @@ class MomentumStimuliAgent(StimuliAgent):
         self.reset()
 
 
-# A generic best selection from set function using values
 def best_selection(list_el: List[Any], val: List[float], len_query: int):
     """Return the top `len_query` items from `list_el` according to the values in `val`"""
     # numpy version: return list_el[(-val).argsort()][:len_query]

--- a/bcipy/tasks/rsvp/query_mechanisms.py
+++ b/bcipy/tasks/rsvp/query_mechanisms.py
@@ -1,33 +1,16 @@
 import numpy as np
 from copy import copy
 import random
-from typing import List
-
-# the small epsilon value. Prevents numerical issues with log
-eps = np.power(.1, 6)
+from typing import List, Any
+from abc import ABC, abstractmethod
 
 
-class StimuliAgent:
-    """ Query mechanism base class.
-        Attr:
-            alphabet(list[str]): Query space(possible queries).
-            len_query(int): number of elements in a query
-        Functions:
-            reset(): reset the agent
-            return_stimuli(): update the agent and return a stimuli set
-            do_series(): one a commitment is made update agent
-            """
-
-    def __init__(self,
-                 alphabet: List[str],
-                 len_query: int,
-                 **kwargs):
-        self.alp = alphabet
-        self.len_query = len_query
-
+class StimuliAgent(ABC):
+    @abstractmethod
     def reset(self):
-        return
+        ...
 
+    @abstractmethod
     def return_stimuli(self, list_distribution: np.ndarray, **kwargs):
         """ updates the agent with most likely posterior and selects queries
             Args:
@@ -35,11 +18,12 @@ class StimuliAgent:
                     stored in the decision maker
             Return:
                 query(list[str]): queries """
-        return
+        ...
 
+    @abstractmethod
     def do_series(self):
         """ If the system decides on a class let the agent know about it """
-        return
+        ...
 
 
 class RandomStimuliAgent(StimuliAgent):
@@ -82,6 +66,7 @@ class NBestStimuliAgent(StimuliAgent):
 
 
 class MomentumStimuliAgent(StimuliAgent):
+    # TODO - either add demo, add test, or delete this unused code!
     """ A query agent that utilizes the observed evidence so far at each step.
         This agent is specifically designed to overcome the adversary effect of
         the prior information to the system.
@@ -127,7 +112,7 @@ class MomentumStimuliAgent(StimuliAgent):
         tmp = list_distribution[-1]
 
         # conditional entropy as a surrogate for mutual information
-        entropy_term = np.array(tmp) * np.log(tmp + eps) + (
+        entropy_term = np.array(tmp) * np.log(tmp + 1e-6) + (
             1.01 - np.array(tmp)) * (np.log(1.01 - np.array(tmp)))
         entropy_term[np.isnan(entropy_term)] = 0
 
@@ -183,25 +168,8 @@ class MomentumStimuliAgent(StimuliAgent):
 
 
 # A generic best selection from set function using values
-def best_selection(list_el, val, len_query):
-    """ given set of elements and a value function over the set,
-        picks the len_query number of elements with the best value.
-        Args:
-            list_el(list[str]): the set of elements
-            val(list[float]): values for the corresponding elements
-            len_query(int): number of elements to be picked from the set
-        Return:
-            query(list[str]): elements from list_el with the best value """
-    max_p_val = np.sort(val)[::-1]
-    max_p_val = max_p_val[0:len_query]
-
-    query = []
-    for idx in range(len_query):
-        idx_q = np.where(val == max_p_val[idx])[0][0]
-
-        q = list_el[idx_q]
-        val = np.delete(val, idx_q)
-        list_el.remove(q)
-        query.append(q)
-
-    return query
+def best_selection(list_el: List[Any], val: List[float], len_query: int):
+    """Return the top `len_query` items from `list_el` according to the values in `val`"""
+    # numpy version: return list_el[(-val).argsort()][:len_query]
+    sorted_items = reversed(sorted(zip(val, list_el)))
+    return [el for (value, el) in sorted_items][:len_query]

--- a/bcipy/tasks/tests/test_query_mechanisms.py
+++ b/bcipy/tasks/tests/test_query_mechanisms.py
@@ -1,0 +1,20 @@
+import unittest
+from bcipy.tasks.rsvp.query_mechanisms import best_selection
+
+
+class TestQueryMechanisms(unittest.TestCase):
+    def test_best_selection(self):
+        list_el = ["A", "E", "I", "O", "U"]
+        values = [0.4, 0.1, 0.25, 0.1, 0.15]
+        len_query = 3
+        self.assertEqual(["A", "I", "U"], best_selection(list_el, values, len_query))
+
+        list_el = ["A", "E", "I", "O", "U"]
+        values = [0.15, 0.4, 0.1, 0.25, 0.1]
+        len_query = 3
+        self.assertEqual(["E", "O", "A"], best_selection(list_el, values, len_query))
+
+        list_el = ["A", "E", "I", "O", "U"]
+        values = [0.1, 0.2, 0.2, 0.2, 0.2]
+        len_query = 3
+        self.assertEqual(["U", "O", "I"], best_selection(list_el, values, len_query))


### PR DESCRIPTION
# Overview

Added a smoke test for CopyPhraseWrapper to prepare for refactoring PcaRdaKde model.

Simplified code in query_mechanisms.py and add test.
Note - in the case of a tie, the new code takes items from the rear of the list, rather than from the front.
This behavior was not tested and presumably only occurs in the case of a uniform alphabet distribution.

## Ticket

https://www.pivotaltracker.com/story/show/177952877 ("add test for CopyPhraseWrapper")

https://www.pivotaltracker.com/story/show/177856966 ("Separate integration from unit tests")

## Contributions

- `bcipy/helpers/tests/test_copy_phrase_wrapper.py` - renamed the file, and added a smoke test for uncovered methods `CopyPhraseWrapper.initialize_series()` and `CopyPhraseWrapper.evaluate_inquiry()`
- `bcipy/signal/tests/model/test_offline_analysis.py` - mark integration tests as "slow"  (test can be skipped with `pytest -k "not slow"` or `pytest -k "MyKeyword and not slow"`)
- `bcipy/tasks/rsvp/query_mechanisms.py` - make base class into proper abstract base class. Shorten the `best_selection` method.
- `bcipy/tasks/tests/test_query_mechanisms.py` - add test for `best_selection` method. As noted, the method breaks ties differently than before.

## Test

`pytest  --disable-warnings -k "TestCopyPhraseWrapper or TestQueryMechanisms"`

## Documentation

Updated docstrings
