### PR TITLE
Model save fix

### DIFF
--- a/bcipy/signal/model/offline_analysis.py
+++ b/bcipy/signal/model/offline_analysis.py
@@ -111,8 +111,7 @@ def offline_analysis(data_folder: str = None,
         channel_names=analysis_channel_names_by_pos(channels, channel_map))
 
     log.info('Saving the model!')
-    with open(data_folder + f'/model_{model_performance.auc}.pkl', 'wb') as output:
-        pickle.dump(model, output)
+    model.save(data_folder + f'/model_{model_performance.auc}.pkl')
 
     if alert_finished:
         offline_analysis_tone = parameters.get('offline_analysis_tone')


### PR DESCRIPTION
# Overview

Ensured that offline_analysis was calling the correct save method.

## Ticket

https://www.pivotaltracker.com/story/show/178148286


## Test

- Ran a calibration session through offline_analysis. Used the generated model to successfully run the Copy Phrase task.

