### PR TITLE
Stimuli Ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,25 @@ This version contains major refactoring efforts and features. We anticipate a fe
 ### Added
 
 - `run-with-defaults`: make command for running `bcipy`
+- `bcipy.helpers.stimuli.StimuliOrder`: defined ordering of inquiry stimuli. The current approach is to randomize. This adds
+    an alphabetical option. #153 
+- `bcipy.helpers.stimuli.alphabetize`: method for taking a list of strings and returning them in alphabetical order with characters last in the list. #153
 
 ### Updated
 
 - `LICENSE.md`: to used the Hippocratic license 2.1
 - `CODE_OF_CONDUCT.md`: to latest version of the Contributor Covenant
 - `bcipy.main`: formally, `bci_main`. To give a better console entry point and infrastructure for integration testing. In the terminal, you can now run `bcipy` instead of `python bci_main.py` 
+- `parameters.json`: add stim_order #153 
+- `demo_stimuli_generation.py`: update imports and add a case showing the new ordering functionality. #153
+- `copy_phrase_wrapper`: update logging and exception handling. add stim order. #153
+- `random_rsvp_calibration_inq_gen`: rename to `calibration_inquiry_generator` #153
 
 ### Removed
-
+ 
+ - `target_rsvp_inquiry_generator`: #153 unused
+ - `rsvp_copy_phrase_inq_generator`: #153 unused
+ - `generate_icon_match_images`: #153 deprecated task
 
 # 1.5.0
 

--- a/bcipy/display/main.py
+++ b/bcipy/display/main.py
@@ -8,6 +8,7 @@ from bcipy.helpers.system_utils import get_screen_resolution
 
 BCIPY_LOGO_PATH = 'bcipy/static/images/gui/cambi.png'
 
+
 class Display(ABC):
     """Display.
 

--- a/bcipy/helpers/copy_phrase_wrapper.py
+++ b/bcipy/helpers/copy_phrase_wrapper.py
@@ -95,7 +95,7 @@ class CopyPhraseWrapper:
                  filter_order: int = 2,
                  notch_filter_frequency: int = 60,
                  stim_length: int = 10,
-                 stim_order: StimuliOrder = StimuliOrder.RANDOM.value):
+                 stim_order: StimuliOrder = StimuliOrder.RANDOM):
 
         self.conjugator = EvidenceFusion(evidence_names, len_dist=len(alp))
 

--- a/bcipy/helpers/copy_phrase_wrapper.py
+++ b/bcipy/helpers/copy_phrase_wrapper.py
@@ -2,14 +2,16 @@
 from typing import Any, List, Tuple
 
 import numpy as np
+import logging
 from bcipy.helpers.acquisition import analysis_channels
+from bcipy.helpers.exceptions import BciPyCoreException
 from bcipy.helpers.language_model import (
     equally_probable,
     histogram,
     norm_domain,
     sym_appended,
 )
-from bcipy.helpers.stimuli import InquirySchedule
+from bcipy.helpers.stimuli import InquirySchedule, StimuliOrder
 from bcipy.helpers.task import BACKSPACE_CHAR
 from bcipy.signal.model import SignalModel
 from bcipy.signal.process import get_default_transform
@@ -22,6 +24,9 @@ from bcipy.tasks.rsvp.stopping_criteria import (
     ProbThresholdCriteria,
 )
 from bcipy.tasks.session_data import EvidenceType
+
+
+log = logging.getLogger(__name__)
 
 
 class CopyPhraseWrapper:
@@ -89,7 +94,8 @@ class CopyPhraseWrapper:
                  filter_low: int = 2,
                  filter_order: int = 2,
                  notch_filter_frequency: int = 60,
-                 stim_length: int = 10):
+                 stim_length: int = 10,
+                 stim_order: StimuliOrder = StimuliOrder.RANDOM.value):
 
         self.conjugator = EvidenceFusion(evidence_names, len_dist=len(alp))
 
@@ -104,6 +110,7 @@ class CopyPhraseWrapper:
                              ProbThresholdCriteria(decision_threshold)])
 
         self.stim_length = stim_length
+        self.stim_order = stim_order
         stimuli_agent = NBestStimuliAgent(alphabet=alp,
                                           len_query=self.stim_length)
 
@@ -114,6 +121,7 @@ class CopyPhraseWrapper:
             alphabet=alp,
             is_txt_stim=is_txt_stim,
             stimuli_timing=stimuli_timing,
+            stimuli_order=self.stim_order,
             inq_constants=inq_constants)
 
         self.alp = alp
@@ -265,8 +273,9 @@ class CopyPhraseWrapper:
         # Raise an error if the stimuli includes unexpected terms
         if not set(letters).issubset(self.valid_targets):
             invalid = set(letters).difference(self.valid_targets)
-            raise Exception(
-                f'unexpected letters received in copy phrase: {invalid}')
+            error_message = f'unexpected letters received in copy phrase: {invalid}'
+            log.error(error_message)
+            raise BciPyCoreException(error_message)
 
         return letters, times, target_types
 
@@ -314,23 +323,23 @@ class CopyPhraseWrapper:
                          if alp_letter == prior_sym]
 
                 # display histogram of LM probabilities
-                print(
+                log.info(
                     f"Printed letters: '{self.decision_maker.displayed_state}'")
-                print(histogram(lm_letter_prior))
+                log.debug(histogram(lm_letter_prior))
 
             # Try fusing the lmodel evidence
             try:
                 prob_dist = self.conjugator.update_and_fuse(
                     {EvidenceType.LM: np.array(prior)})
-            except Exception as lm_exception:
-                print("Error updating language model!")
-                raise lm_exception
+            except Exception as e:
+                log.exception(f'Error updating language model!: {e}')
+                raise BciPyCoreException(e)
 
             # Get decision maker to give us back some decisions and stimuli
             is_accepted, sti = self.decision_maker.decide(prob_dist)
 
-        except Exception as init_exception:
-            print("Error in initialize_series: %s" % (init_exception))
-            raise init_exception
+        except Exception as e:
+            log.exception(f'Error in initialize_series: {e}')
+            raise BciPyCoreException(e)
 
         return is_accepted, sti

--- a/bcipy/helpers/demo/demo_stimuli_generation.py
+++ b/bcipy/helpers/demo/demo_stimuli_generation.py
@@ -1,4 +1,4 @@
-from bcipy.helpers.stimuli_generation import random_rsvp_calibration_inq_gen, best_case_rsvp_inq_gen
+from bcipy.helpers.stimuli import StimuliOrder, calibration_inquiry_generator, best_case_rsvp_inq_gen
 import numpy as np
 
 
@@ -6,16 +6,17 @@ def _demo_random_rsvp_inquiry_generator():
     alp = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N',
            'O', 'P', 'R', 'S', 'T', 'U', 'V', 'Y', 'Z', '<', '_']
 
-    num_samples = int(np.random.randint(10, 30, 1))
-    len_samples = int(np.random.randint(1, 20, 1))
+    num_samples = 2
+    len_samples = 10
 
     print('Number of inquiries:{}, Number of trials:{}'.format(num_samples,
                                                                len_samples))
 
     print('Alphabet:{}'.format(alp))
-    schedule = random_rsvp_calibration_inq_gen(alp=alp,
-                                               stim_number=num_samples,
-                                               stim_length=len_samples)
+    schedule = calibration_inquiry_generator(alp=alp,
+                                             stim_number=num_samples,
+                                             stim_length=len_samples,
+                                             stim_order=StimuliOrder.RANDOM.value)
     inquiries = schedule[0]
     timing = schedule[1]
     color = schedule[2]
@@ -26,15 +27,41 @@ def _demo_random_rsvp_inquiry_generator():
             raise Exception('Letter repetition!')
         print('time{}:{}'.format(i, timing[i]))
         print('color{}:{}'.format(i, color[i]))
-    return 0
+
+
+def _demo_alphabetical_rsvp_inquiry_generator():
+    alp = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N',
+           'O', 'P', 'R', 'S', 'T', 'U', 'V', 'Y', 'Z', '<', '_']
+
+    num_samples = 2
+    len_samples = 10
+
+    print('Number of inquiries:{}, Number of trials:{}'.format(num_samples,
+                                                               len_samples))
+
+    print('Alphabet:{}'.format(alp))
+    schedule = calibration_inquiry_generator(alp=alp,
+                                             stim_number=num_samples,
+                                             stim_length=len_samples,
+                                             stim_order=StimuliOrder.ALPHABETICAL.value)
+    inquiries = schedule[0]
+    timing = schedule[1]
+    color = schedule[2]
+
+    for i in range(len(inquiries)):
+        print('inq{}:{}'.format(i, inquiries[i]))
+        if len(set(inquiries[i][2::])) != len(inquiries[i][2::]):
+            raise Exception('Letter repetition!')
+        print('time{}:{}'.format(i, timing[i]))
+        print('color{}:{}'.format(i, color[i]))
 
 
 def _demo_best_case_inquiry_generator():
     alp = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N',
            'O', 'P', 'R', 'S', 'T', 'U', 'V', 'Y', 'Z', '<', '_']
 
-    num_samples = int(np.random.randint(1, 10, 1))
-    len_samples = int(np.random.randint(1, 20, 1))
+    num_samples = 2
+    len_samples = 10
 
     print('Number of inquiries:{}, Number of trials:{}'.format(num_samples,
                                                                len_samples))
@@ -56,5 +83,11 @@ def _demo_best_case_inquiry_generator():
 
 
 if __name__ == '__main__':
+    print('\n\n\n====== Best Case =======\n')
     _demo_best_case_inquiry_generator()
+
+    print('\n\n\n====== Random RSVP Inquiry Generator =======\n')
     _demo_random_rsvp_inquiry_generator()
+
+    print('\n\n\n====== Alphabetical RSVP Inquiry Generator =======\n')
+    _demo_alphabetical_rsvp_inquiry_generator()

--- a/bcipy/helpers/demo/demo_stimuli_generation.py
+++ b/bcipy/helpers/demo/demo_stimuli_generation.py
@@ -16,7 +16,7 @@ def _demo_random_rsvp_inquiry_generator():
     schedule = calibration_inquiry_generator(alp=alp,
                                              stim_number=num_samples,
                                              stim_length=len_samples,
-                                             stim_order=StimuliOrder.RANDOM.value)
+                                             stim_order=StimuliOrder.RANDOM)
     inquiries = schedule[0]
     timing = schedule[1]
     color = schedule[2]
@@ -43,7 +43,7 @@ def _demo_alphabetical_rsvp_inquiry_generator():
     schedule = calibration_inquiry_generator(alp=alp,
                                              stim_number=num_samples,
                                              stim_length=len_samples,
-                                             stim_order=StimuliOrder.ALPHABETICAL.value)
+                                             stim_order=StimuliOrder.ALPHABETICAL)
     inquiries = schedule[0]
     timing = schedule[1]
     color = schedule[2]

--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -1,19 +1,40 @@
 import glob
 import itertools
+import re
 import logging
 import random
 from os import path, sep
-from typing import Iterator, List, NamedTuple
+from typing import Iterator, List, Tuple, NamedTuple
 
 import numpy as np
+from enum import Enum
+
 import sounddevice as sd
 import soundfile as sf
 from PIL import Image
+
+from bcipy.helpers.exceptions import BciPyCoreException
+
 from psychopy import core
 
 # Prevents pillow from filling the console with debug info
 logging.getLogger('PIL').setLevel(logging.WARNING)
+log = logging.getLogger(__name__)
 DEFAULT_FIXATION_PATH = 'bcipy/static/images/main/PLUS.png'
+
+
+class StimuliOrder(Enum):
+    """Stimuli Order.
+
+    Enum to define the ordering of stimuli for inquiry.
+    """
+    RANDOM = 'random'
+    ALPHABETICAL = 'alphabetical'
+
+    @classmethod
+    def list(cls):
+        """Returns all enum values as a list"""
+        return list(map(lambda c: c.value, cls))
 
 
 class InquirySchedule(NamedTuple):
@@ -31,12 +52,20 @@ class InquirySchedule(NamedTuple):
     colors: List[List[str]]
 
 
-def rsvp_inq_generator(query: list,
-                       timing=[1, 0.2],
-                       color=['red', 'white'],
-                       stim_number=1,
-                       is_txt=True,
-                       inq_constants=None) -> InquirySchedule:
+def alphabetize(stimuli: List[str]) -> List[str]:
+    """Alphabetize.
+
+    Given a list of string stimuli, return a list of sorted stimuli by alphabet.
+    """
+    return sorted(stimuli, key=lambda x: re.sub(r'[^a-zA-Z0-9 \n\.]', 'ZZ', x).lower())
+
+
+def rsvp_inq_generator(query: List[str],
+                       timing: List[float] = [1, 0.2],
+                       color: List[str] = ['red', 'white'],
+                       stim_number: int = 1,
+                       stim_order: StimuliOrder = StimuliOrder.RANDOM.value,
+                       is_txt: bool = True) -> InquirySchedule:
     """ Given the query set, prepares the stimuli, color and timing
         Args:
             query(list[str]): list of queries to be shown
@@ -44,8 +73,6 @@ def rsvp_inq_generator(query: list,
             color(list[str]): Task specific color for generator
                 First element is the target, second element is the fixation
                 Observe that [-1] element represents the trial information
-            inq_constants(list[str]): list of letters that should always be
-                included in every inquiry. If provided, must be alp items.
         Return:
             schedule_inq(tuple(
                 samples[list[list[str]]]: list of inquiries
@@ -53,8 +80,10 @@ def rsvp_inq_generator(query: list,
                 color(list(list[str])): list of colors)): scheduled inquiries
             """
 
-    # shuffle the returned values
-    random.shuffle(query)
+    if stim_order == StimuliOrder.ALPHABETICAL.value:
+        query = alphabetize(query)
+    else:
+        random.shuffle(query)
 
     stim_length = len(query)
 
@@ -82,7 +111,7 @@ def rsvp_inq_generator(query: list,
 def best_selection(selection_elements: list,
                    val: list,
                    len_query: int,
-                   always_included=None) -> list:
+                   always_included: List[str] = None) -> list:
     """Best Selection.
 
      given set of elements and a value function over the set, picks the len_query
@@ -114,13 +143,14 @@ def best_selection(selection_elements: list,
 
 
 def best_case_rsvp_inq_gen(alp: list,
-                           session_stimuli: list,
-                           timing=[1, 0.2],
-                           color=['red', 'white'],
-                           stim_number=1,
-                           stim_length=10,
-                           is_txt=True,
-                           inq_constants=None) -> InquirySchedule:
+                           session_stimuli: np.ndarray,
+                           timing: List[float] = [1, 0.2],
+                           color: List[str] = ['red', 'white'],
+                           stim_number: int = 1,
+                           stim_length: int = 10,
+                           stim_order: StimuliOrder = StimuliOrder.RANDOM.value,
+                           is_txt: bool = True,
+                           inq_constants: List[str] = None) -> InquirySchedule:
     """Best Case RSVP Inquiry Generation.
 
     generates RSVPKeyboard inquiry by picking n-most likely letters.
@@ -134,6 +164,7 @@ def best_case_rsvp_inq_gen(alp: list,
                 Observe that [-1] element represents the trial information
             stim_number(int): number of random stimuli to be created
             stim_length(int): number of trials in a inquiry
+            stim_order(StimuliOrder): ordering of stimuli in the inquiry
             inq_constants(list[str]): list of letters that should always be
                 included in every inquiry. If provided, must be alp items.
         Return:
@@ -144,12 +175,12 @@ def best_case_rsvp_inq_gen(alp: list,
             """
 
     if len(alp) != len(session_stimuli):
-        raise Exception('Missing information about alphabet. len(alp):{}, '
-                        'len(session_stimuli):{}, should be same!'.format(
-                            len(alp), len(session_stimuli)))
+        raise BciPyCoreException((
+            f'Missing information about alphabet.'
+            f'len(alp):{len(alp)} and len(session_stimuli):{len(session_stimuli)} should be same!'))
 
     if inq_constants and not set(inq_constants).issubset(alp):
-        raise Exception('Inquiry constants must be alphabet items.')
+        raise BciPyCoreException('Inquiry constants must be alphabet items.')
 
     # create a list of alphabet letters
     alphabet = [i for i in alp]
@@ -161,8 +192,10 @@ def best_case_rsvp_inq_gen(alp: list,
         stim_length,
         inq_constants)
 
-    # shuffle the returned values
-    random.shuffle(query)
+    if stim_order == StimuliOrder.ALPHABETICAL.value:
+        query = alphabetize(query)
+    else:
+        random.shuffle(query)
 
     # Init some lists to construct our stimuli with
     samples, times, colors = [], [], []
@@ -185,23 +218,27 @@ def best_case_rsvp_inq_gen(alp: list,
     return InquirySchedule(samples, times, colors)
 
 
-def random_rsvp_calibration_inq_gen(alp,
-                                    timing=[0.5, 1, 0.2],
-                                    color=['green', 'red', 'white'],
-                                    stim_number=10,
-                                    stim_length=10,
-                                    is_txt=True) -> InquirySchedule:
+def calibration_inquiry_generator(
+        alp: List[str],
+        timing: List[float] = [0.5, 1, 0.2],
+        color: List[str] = ['green', 'red', 'white'],
+        stim_number: int = 10,
+        stim_length: int = 10,
+        stim_order: StimuliOrder = StimuliOrder.RANDOM.value,
+        is_txt: bool = True) -> InquirySchedule:
     """Random RSVP Calibration Inquiry Generator.
 
     Generates random RSVPKeyboard inquiries.
         Args:
-            alp(list[str]): alphabet (can be arbitrary)
-            timing(list[float]): Task specific timing for generator
+            alp(list[str]): stimuli
+            timing(list[float]): Task specific timing for generator.
+                [target, fixation, stimuli]
             color(list[str]): Task specific color for generator
-                First element is the target, second element is the fixation
-                Observe that [-1] element represents the trial information
+                [target, fixation, stimuli]
             stim_number(int): number of random stimuli to be created
             stim_length(int): number of trials in a inquiry
+            stim_order(StimuliOrder): ordering of stimuli in the inquiry
+            is_txt(bool): whether or not the stimuli type is text. False would be an image stimuli.
         Return:
             schedule_inq(tuple(
                 samples[list[list[str]]]: list of inquiries
@@ -215,14 +252,22 @@ def random_rsvp_calibration_inq_gen(alp,
     for _ in range(stim_number):
         idx = np.random.permutation(np.array(list(range(len_alp))))
         rand_smp = (idx[0:stim_length])
+
+        # define the target and fixation that come before an inquiry
         if not is_txt:
             sample = [
                 alp[rand_smp[0]],
                 get_fixation(is_txt=False)]
         else:
             sample = [alp[rand_smp[0]], '+']
+
+        # generate the samples using the permutated random indexes
         rand_smp = np.random.permutation(rand_smp)
-        sample += [alp[i] for i in rand_smp]
+        if stim_order == StimuliOrder.ALPHABETICAL.value:
+            inquiry = alphabetize([alp[i] for i in rand_smp])
+        else:
+            inquiry = [alp[i] for i in rand_smp]
+        sample.extend(inquiry)
         samples.append(sample)
         times.append([timing[i] for i in range(len(timing) - 1)] +
                      [timing[-1]] * stim_length)
@@ -232,63 +277,7 @@ def random_rsvp_calibration_inq_gen(alp,
     return InquirySchedule(samples, times, colors)
 
 
-def target_rsvp_inquiry_generator(alp,
-                                  target_letter,
-                                  parameters,
-                                  timing=[0.5, 1, 0.2],
-                                  color=['green', 'white', 'white'],
-                                  stim_length=10,
-                                  is_txt=True) -> InquirySchedule:
-    """Target RSVP Inquiry Generator.
-
-    Generate target RSVPKeyboard inquiries.
-
-        Args:
-            alp(list[str]): alphabet (can be arbitrary)
-            target_letter([str]): letter to be copied
-            timing(list[float]): Task specific timing for generator
-            color(list[str]): Task specific color for generator
-                First element is the target, second element is the fixation
-                Observe that [-1] element represents the trial information
-            stim_length(int): number of trials in a inquiry
-        Return:
-            schedule_inq(tuple(
-                samples[list[list[str]]]: list of inquiries
-                timing(list[list[float]]): list of timings
-                color(list(list[str])): list of colors)): scheduled inquiries
-    """
-
-    len_alp = len(alp)
-
-    # initialize our arrays
-    samples, times, colors = [], [], []
-    rand_smp = random.sample(range(len_alp), stim_length)
-    sample = [get_fixation(is_txt)]
-    target_letter = parameters['path_to_presentation_images'] + \
-        target_letter + '.png'
-    sample += [alp[i] for i in rand_smp]
-
-    # if the target isn't in the array, replace it with some random index that
-    #  is not fixation
-    if target_letter not in sample:
-        random_index = np.random.randint(0, stim_length - 1)
-        sample[random_index + 1] = target_letter
-
-    # add target letter to start
-    sample = [target_letter] + sample
-
-    # to-do shuffle the target letter
-
-    samples.append(sample)
-    times.append([timing[i] for i in range(len(timing) - 1)] +
-                 [timing[-1]] * stim_length)
-    colors.append([color[i] for i in range(len(color) - 1)] +
-                  [color[-1]] * stim_length)
-
-    return InquirySchedule(samples, times, colors)
-
-
-def get_task_info(experiment_length, task_color):
+def get_task_info(experiment_length: int, task_color: str) -> Tuple[List[str], List[str]]:
     """Get Task Info.
 
     Generates fixed RSVPKeyboard task text and color information for
@@ -303,7 +292,6 @@ def get_task_info(experiment_length, task_color):
     """
 
     # Do list comprehensions to get the arrays for the task we need.
-
     task_text = ['%s/%s' % (stim + 1, experiment_length)
                  for stim in range(experiment_length)]
     task_color = [[str(task_color)] for stim in range(experiment_length)]
@@ -311,123 +299,7 @@ def get_task_info(experiment_length, task_color):
     return (task_text, task_color)
 
 
-def rsvp_copy_phrase_inq_generator(alp, target_letter, timing=[0.5, 1, 0.2],
-                                   color=['green', 'white', 'white'],
-                                   stim_length=10) -> InquirySchedule:
-    """Generate copy phrase RSVPKeyboard inquiries.
-
-        Args:
-            alp(list[str]): alphabet (can be arbitrary)
-            target_letter([str]): letter to be copied
-            timing(list[float]): Task specific timing for generator
-            color(list[str]): Task specific color for generator
-                First element is the target, second element is the fixation
-                Observe that [-1] element represents the trial information
-            stim_length(int): number of trials in an inquiry
-        Return:
-            schedule_inq(tuple(
-                samples[list[list[str]]]: list of inquiries
-                timing(list[list[float]]): list of timings
-                color(list(list[str])): list of colors)): scheduled inquiries
-    """
-
-    len_alp = len(alp)
-
-    # initialize our arrays
-    samples, times, colors = [], [], []
-    rand_smp = np.random.randint(0, len_alp, stim_length)
-    sample = ['+']
-    sample += [alp[i] for i in rand_smp]
-
-    # if the target isn't in the array, replace it with some random index that
-    #  is not fixation
-    if target_letter not in sample:
-        random_index = np.random.randint(0, stim_length - 1)
-        sample[random_index + 1] = target_letter
-
-    # to-do shuffle the target letter
-
-    samples.append(sample)
-    times.append([timing[i] for i in range(len(timing) - 1)] +
-                 [timing[-1]] * stim_length)
-    colors.append([color[i] for i in range(len(color) - 1)] +
-                  [color[-1]] * stim_length)
-
-    return InquirySchedule(samples, times, colors)
-
-
-def generate_icon_match_images(
-        experiment_length, image_path, number_of_inquiries, timing, is_word):
-    """Generate Image Icon Matches.
-
-    Generates an array of images to use for the icon matching task.
-    Args:
-        experiment_length(int): Number of images per inquiry
-        image_path(str): Path to image files
-        number_of_inquiries(int): Number of inquiries to generate
-        timing(list): List of timings; [parameters['time_target'],
-                       parameters['time_cross'],
-                       parameters['time_flash']]
-        is_word(bool): Whether or not this is an icon to word matching task
-    Return generate_icon_match_images(arrays of tuples of paths to images to
-    display, and timings)
-    """
-    # Get all png images in image path
-    image_array = [
-        img for img in glob.glob(image_path + "*.png")
-        if not img.endswith("PLUS.png")
-    ]
-
-    if experiment_length > len(image_array) - 1:
-        raise Exception(
-            'Number of images to be displayed on screen is longer than number of images available')
-
-    # Generate indexes of target images
-    target_image_numbers = np.random.randint(
-        0, len(image_array), number_of_inquiries)
-
-    # Array of images to return
-    return_array = []
-
-    # Array of timings to return
-    return_timing = []
-    for specific_time in range(len(timing) - 1):
-        return_timing.append(timing[specific_time])
-    for item_without_timing in range(len(return_timing), experiment_length):
-        return_timing.append(timing[-1])
-
-    for inquiry in range(number_of_inquiries):
-        return_array.append([])
-        # Generate random permutation of image indexes
-        random_number_array = np.random.permutation(len(image_array))
-        if is_word:
-            # Add name of target image to array
-            image_path = path.basename(
-                image_array[target_image_numbers[inquiry]])
-            return_array[inquiry].append(image_path.replace('.png', ''))
-        else:
-            # Add target image to image array
-            return_array[inquiry].append(
-                image_array[target_image_numbers[inquiry]])
-        # Add PLUS.png to image array TODO: get this from parameters file
-        return_array[inquiry].append(
-            get_fixation(is_txt=False))
-
-        # Add target image to inquiry, if it is not already there
-        if not target_image_numbers[inquiry] in random_number_array[
-                2:experiment_length]:
-            random_number_array[np.random.randint(
-                2, experiment_length)] = target_image_numbers[inquiry]
-
-        # Fill the rest of the image array with random images
-        for item in range(2, experiment_length):
-            return_array[inquiry].append(
-                image_array[random_number_array[item]])
-
-    return (return_array, return_timing)
-
-
-def resize_image(image_path: str, screen_size: tuple, sti_height: int):
+def resize_image(image_path: str, screen_size: tuple, sti_height: int) -> Tuple[float, float]:
     """Resize Image.
 
     Returns the width and height that a given image should be displayed at
@@ -489,13 +361,13 @@ def play_sound(sound_file_path: str,
 
     try:
         # load in the sound file and wait some time before playing
-        data, fs = sf.read(
-            sound_file_path, dtype=dtype)
+        data, fs = sf.read(sound_file_path, dtype=dtype)
         core.wait(sound_load_buffer_time)
 
-    except Exception:
-        raise Exception(
-            'StimGenPlaySoundError: sound file could not be found or initialized.')
+    except Exception as e:
+        error_message = f'Sound file could not be found or initialized. \n Exception={e}'
+        log.exception(error_message)
+        raise BciPyCoreException(error_message)
 
     #  if timing is wanted, get trigger timing for this sound stimuli
     if track_timing:
@@ -528,8 +400,9 @@ def soundfiles(directory: str) -> Iterator[str]:
         iterator that infinitely cycles through the filenames.
     """
     if not path.isdir(directory):
-        raise Exception(('Invalid directory for sound files. Please check '
-                         'your configuration.'))
+        error_message = f'Invalid directory=[{directory}] for sound files.'
+        log.error(error_message)
+        raise BciPyCoreException(error_message)
     if not directory.endswith(sep):
         directory += sep
     return itertools.cycle(glob.glob(directory + '*.wav'))

--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -64,7 +64,7 @@ def rsvp_inq_generator(query: List[str],
                        timing: List[float] = [1, 0.2],
                        color: List[str] = ['red', 'white'],
                        stim_number: int = 1,
-                       stim_order: StimuliOrder = StimuliOrder.RANDOM.value,
+                       stim_order: StimuliOrder = StimuliOrder.RANDOM,
                        is_txt: bool = True) -> InquirySchedule:
     """ Given the query set, prepares the stimuli, color and timing
         Args:
@@ -80,7 +80,7 @@ def rsvp_inq_generator(query: List[str],
                 color(list(list[str])): list of colors)): scheduled inquiries
             """
 
-    if stim_order == StimuliOrder.ALPHABETICAL.value:
+    if stim_order == StimuliOrder.ALPHABETICAL:
         query = alphabetize(query)
     else:
         random.shuffle(query)
@@ -148,7 +148,7 @@ def best_case_rsvp_inq_gen(alp: list,
                            color: List[str] = ['red', 'white'],
                            stim_number: int = 1,
                            stim_length: int = 10,
-                           stim_order: StimuliOrder = StimuliOrder.RANDOM.value,
+                           stim_order: StimuliOrder = StimuliOrder.RANDOM,
                            is_txt: bool = True,
                            inq_constants: List[str] = None) -> InquirySchedule:
     """Best Case RSVP Inquiry Generation.
@@ -192,7 +192,7 @@ def best_case_rsvp_inq_gen(alp: list,
         stim_length,
         inq_constants)
 
-    if stim_order == StimuliOrder.ALPHABETICAL.value:
+    if stim_order == StimuliOrder.ALPHABETICAL:
         query = alphabetize(query)
     else:
         random.shuffle(query)
@@ -224,7 +224,7 @@ def calibration_inquiry_generator(
         color: List[str] = ['green', 'red', 'white'],
         stim_number: int = 10,
         stim_length: int = 10,
-        stim_order: StimuliOrder = StimuliOrder.RANDOM.value,
+        stim_order: StimuliOrder = StimuliOrder.RANDOM,
         is_txt: bool = True) -> InquirySchedule:
     """Random RSVP Calibration Inquiry Generator.
 
@@ -263,7 +263,7 @@ def calibration_inquiry_generator(
 
         # generate the samples using the permutated random indexes
         rand_smp = np.random.permutation(rand_smp)
-        if stim_order == StimuliOrder.ALPHABETICAL.value:
+        if stim_order == StimuliOrder.ALPHABETICAL:
             inquiry = alphabetize([alp[i] for i in rand_smp])
         else:
             inquiry = [alp[i] for i in rand_smp]

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -7,13 +7,15 @@ from mockito import any, mock, unstub, verify, when
 from psychopy import core
 
 from bcipy.helpers.stimuli import (
+    alphabetize,
     best_case_rsvp_inq_gen,
     best_selection,
     DEFAULT_FIXATION_PATH,
     get_fixation,
     play_sound,
-    random_rsvp_calibration_inq_gen,
+    calibration_inquiry_generator,
     soundfiles,
+    StimuliOrder
 )
 
 MOCK_FS = 44100
@@ -145,12 +147,13 @@ class TestStimuliGeneration(unittest.TestCase):
         ]
         stim_number = 10
         stim_length = 10
-        inquiries, inq_timings, inq_colors = random_rsvp_calibration_inq_gen(
+        inquiries, inq_timings, inq_colors = calibration_inquiry_generator(
             alp,
             timing=[0.5, 1, 0.2],
             color=['green', 'red', 'white'],
             stim_number=stim_number,
             stim_length=stim_length,
+            stim_order=StimuliOrder.RANDOM.value,
             is_txt=True)
 
         self.assertEqual(
@@ -168,6 +171,48 @@ class TestStimuliGeneration(unittest.TestCase):
             choices = inq[2:]
             self.assertEqual(stim_length, len(set(choices)),
                              'All choices should be unique')
+
+            # create a string of the options
+            inq_strings.append(''.join(choices))
+
+        self.assertEqual(
+            len(inquiries), len(set(inq_strings)),
+            'All inquiries should be different')
+
+    def test_alphabetical_inquiry_gen(self):
+        """Test generation of random inquiries"""
+        alp = [
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            '<', '_'
+        ]
+        stim_number = 10
+        stim_length = 10
+        inquiries, inq_timings, inq_colors = calibration_inquiry_generator(
+            alp,
+            timing=[0.5, 1, 0.2],
+            color=['green', 'red', 'white'],
+            stim_number=stim_number,
+            stim_length=stim_length,
+            stim_order=StimuliOrder.ALPHABETICAL.value,
+            is_txt=True)
+
+        self.assertEqual(
+            len(inquiries), stim_number,
+            'Should have produced the correct number of inquiries')
+        self.assertEqual(len(inq_timings), stim_number)
+        self.assertEqual(len(inq_colors), stim_number)
+
+        inq_strings = []
+        for inq in inquiries:
+            self.assertEqual(
+                len(inq), stim_length + 2,
+                ('inquiry should include the correct number of choices as ',
+                 'well as the target and cross.'))
+            choices = inq[2:]
+            self.assertEqual(stim_length, len(set(choices)),
+                             'All choices should be unique')
+            self.assertEqual(alphabetize(choices), choices)
 
             # create a string of the options
             inq_strings.append(''.join(choices))
@@ -311,6 +356,31 @@ class TestGetFixation(unittest.TestCase):
     def test_image_fixation_uses_default(self):
         expected = DEFAULT_FIXATION_PATH
         response = get_fixation(is_txt=False)
+        self.assertEqual(expected, response)
+
+
+class TestAlphabetize(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.list_to_alphabetize = ['Z', 'Q', 'A', 'G']
+
+    def test_alphabetize(self):
+
+        expected = ['A', 'G', 'Q', 'Z']
+        response = alphabetize(self.list_to_alphabetize)
+        self.assertEqual(expected, response)
+
+    def test_alphabetize_image_name(self):
+        list_of_images = ['testing.png', '_ddtt.jpeg', 'bci_image.png']
+        expected = ['bci_image.png', 'testing.png', '_ddtt.jpeg']
+        response = alphabetize(list_of_images)
+        self.assertEqual(expected, response)
+
+    def test_alphabetize_special_characters_at_end(self):
+        character = '<'
+        expected = ['A', 'G', 'Q', 'Z', character]
+        self.list_to_alphabetize.append(character)
+        response = alphabetize(self.list_to_alphabetize)
         self.assertEqual(expected, response)
 
 

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -153,7 +153,7 @@ class TestStimuliGeneration(unittest.TestCase):
             color=['green', 'red', 'white'],
             stim_number=stim_number,
             stim_length=stim_length,
-            stim_order=StimuliOrder.RANDOM.value,
+            stim_order=StimuliOrder.RANDOM,
             is_txt=True)
 
         self.assertEqual(
@@ -194,7 +194,7 @@ class TestStimuliGeneration(unittest.TestCase):
             color=['green', 'red', 'white'],
             stim_number=stim_number,
             stim_length=stim_length,
-            stim_order=StimuliOrder.ALPHABETICAL.value,
+            stim_order=StimuliOrder.ALPHABETICAL,
             is_txt=True)
 
         self.assertEqual(
@@ -365,7 +365,6 @@ class TestAlphabetize(unittest.TestCase):
         self.list_to_alphabetize = ['Z', 'Q', 'A', 'G']
 
     def test_alphabetize(self):
-
         expected = ['A', 'G', 'Q', 'Z']
         response = alphabetize(self.list_to_alphabetize)
         self.assertEqual(expected, response)
@@ -379,7 +378,7 @@ class TestAlphabetize(unittest.TestCase):
     def test_alphabetize_special_characters_at_end(self):
         character = '<'
         expected = ['A', 'G', 'Q', 'Z', character]
-        self.list_to_alphabetize.append(character)
+        self.list_to_alphabetize.insert(1, character)
         response = alphabetize(self.list_to_alphabetize)
         self.assertEqual(expected, response)
 

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -351,10 +351,10 @@
     "type": "str"
   },
   "stim_order": {
-    "value": "alphabetical",
+    "value": "random",
     "section": "bci_config",
     "readableName": "Stimuli Order",
-    "helpTip": "Specifies the ordering of stimuli in an inquiry. Default is alphabetical.",
+    "helpTip": "Specifies the ordering of stimuli in an inquiry. Default is random.",
     "recommended_values": [
       "alphabetical",
       "random"

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -350,6 +350,17 @@
     ],
     "type": "str"
   },
+  "stim_order": {
+    "value": "alphabetical",
+    "section": "bci_config",
+    "readableName": "Stimuli Order",
+    "helpTip": "Specifies the ordering of stimuli in an inquiry. Default is alphabetical.",
+    "recommended_values": [
+      "alphabetical",
+      "random"
+    ],
+    "type": "str"
+  },
   "stim_length": {
     "value": "10",
     "section": "bci_config",

--- a/bcipy/tasks/rsvp/calibration/calibration.py
+++ b/bcipy/tasks/rsvp/calibration/calibration.py
@@ -6,7 +6,7 @@ from bcipy.display.rsvp import StimuliProperties, TaskDisplayProperties, Informa
 from bcipy.tasks.task import Task
 
 from bcipy.helpers.triggers import _write_triggers_from_inquiry_calibration
-from bcipy.helpers.stimuli import calibration_inquiry_generator, get_task_info
+from bcipy.helpers.stimuli import calibration_inquiry_generator, get_task_info, StimuliOrder
 from bcipy.helpers.task import (
     alphabet, trial_complete_message, get_user_input, pause_calibration)
 
@@ -56,7 +56,7 @@ class RSVPCalibrationTask(Task):
 
         self.stim_number = parameters['stim_number']
         self.stim_length = parameters['stim_length']
-        self.stim_order = parameters['stim_order']
+        self.stim_order = StimuliOrder(parameters['stim_order'])
 
         self.timing = [parameters['time_target'],
                        parameters['time_cross'],

--- a/bcipy/tasks/rsvp/calibration/calibration.py
+++ b/bcipy/tasks/rsvp/calibration/calibration.py
@@ -6,7 +6,7 @@ from bcipy.display.rsvp import StimuliProperties, TaskDisplayProperties, Informa
 from bcipy.tasks.task import Task
 
 from bcipy.helpers.triggers import _write_triggers_from_inquiry_calibration
-from bcipy.helpers.stimuli import random_rsvp_calibration_inq_gen, get_task_info
+from bcipy.helpers.stimuli import calibration_inquiry_generator, get_task_info
 from bcipy.helpers.task import (
     alphabet, trial_complete_message, get_user_input, pause_calibration)
 
@@ -56,6 +56,7 @@ class RSVPCalibrationTask(Task):
 
         self.stim_number = parameters['stim_number']
         self.stim_length = parameters['stim_length']
+        self.stim_order = parameters['stim_order']
 
         self.timing = [parameters['time_target'],
                        parameters['time_cross'],
@@ -83,12 +84,13 @@ class RSVPCalibrationTask(Task):
                 timing(list[list[float]]): list of timings
                 color(list(list[str])): list of colors)
         """
-        return random_rsvp_calibration_inq_gen(self.alp,
-                                               stim_number=self.stim_number,
-                                               stim_length=self.stim_length,
-                                               timing=self.timing,
-                                               is_txt=self.rsvp.is_txt_stim,
-                                               color=self.color)
+        return calibration_inquiry_generator(self.alp,
+                                             stim_number=self.stim_number,
+                                             stim_length=self.stim_length,
+                                             stim_order=self.stim_order,
+                                             timing=self.timing,
+                                             is_txt=self.rsvp.is_txt_stim,
+                                             color=self.color)
 
     def execute(self):
 

--- a/bcipy/tasks/rsvp/calibration/inter_inquiry_feedback_calibration.py
+++ b/bcipy/tasks/rsvp/calibration/inter_inquiry_feedback_calibration.py
@@ -6,7 +6,7 @@ from bcipy.tasks.task import Task
 from bcipy.tasks.exceptions import InsufficientDataException
 from bcipy.tasks.rsvp.calibration.calibration import RSVPCalibrationTask
 from bcipy.helpers.triggers import _write_triggers_from_inquiry_calibration
-from bcipy.helpers.stimuli import random_rsvp_calibration_inq_gen, get_task_info
+from bcipy.helpers.stimuli import calibration_inquiry_generator, get_task_info
 from bcipy.helpers.task import (
     trial_complete_message,
     get_user_input,
@@ -140,7 +140,7 @@ class RSVPInterInquiryFeedbackCalibration(Task):
 
             # Get random inquiry information given stimuli parameters
             (stimuli_elements, timing_sti,
-             color_sti) = random_rsvp_calibration_inq_gen(
+             color_sti) = calibration_inquiry_generator(
                  self.alp,
                  stim_number=self.stim_number,
                  stim_length=self.stim_length,

--- a/bcipy/tasks/rsvp/copy_phrase.py
+++ b/bcipy/tasks/rsvp/copy_phrase.py
@@ -82,7 +82,7 @@ class RSVPCopyPhraseTask(Task):
         'preview_inquiry_progress_method', 'session_file_name',
         'show_feedback', 'show_preview_inquiry', 'spelled_letters_count',
         'static_trigger_offset', 'stim_color', 'stim_font', 'stim_height',
-        'stim_length', 'stim_number', 'stim_pos_x', 'stim_pos_y',
+        'stim_length', 'stim_number', 'stim_order', 'stim_pos_x', 'stim_pos_y',
         'stim_space_char', 'target_color', 'task_buffer_len', 'task_color',
         'task_font', 'task_height', 'task_text', 'text_pos_x', 'text_pos_y',
         'time_cross', 'time_flash', 'time_target', 'trial_complete_message',
@@ -186,7 +186,8 @@ class RSVPCopyPhraseTask(Task):
             filter_low=self.parameters['filter_low'],
             filter_order=self.parameters['filter_order'],
             notch_filter_frequency=self.parameters['notch_filter_frequency'],
-            stim_length=self.parameters['stim_length'])
+            stim_length=self.parameters['stim_length'],
+            stim_order=self.parameters['stim_order'])
 
     def await_start(self) -> bool:
         """Wait on the splash screen for the user to either exit or start."""
@@ -601,7 +602,6 @@ class RSVPCopyPhraseTask(Task):
         - stim_times : list of (stim, clock_time) tuples
         - trigger_file : data will be appended to this file
         """
-        # TODO: fix the helper to correctly handle the targetness of inquiry_preview stims.
         _write_triggers_from_inquiry_copy_phrase(stim_times, trigger_file,
                                                  self.copy_phrase,
                                                  self.spelled_text)
@@ -658,7 +658,7 @@ def _init_copy_phrase_wrapper(min_num_inq, max_num_inq, signal_model, fs, k,
                               stimuli_timing, decision_threshold,
                               backspace_prob, backspace_always_shown,
                               filter_high, filter_low, filter_order,
-                              notch_filter_frequency, stim_length):
+                              notch_filter_frequency, stim_length, stim_order):
     return CopyPhraseWrapper(min_num_inq,
                              max_num_inq,
                              signal_model=signal_model,
@@ -679,4 +679,5 @@ def _init_copy_phrase_wrapper(min_num_inq, max_num_inq, signal_model, fs, k,
                              filter_low=filter_low,
                              filter_order=filter_order,
                              notch_filter_frequency=notch_filter_frequency,
-                             stim_length=stim_length)
+                             stim_length=stim_length,
+                             stim_order=stim_order)

--- a/bcipy/tasks/rsvp/copy_phrase.py
+++ b/bcipy/tasks/rsvp/copy_phrase.py
@@ -9,7 +9,7 @@ from bcipy.display.rsvp.mode.copy_phrase import CopyPhraseDisplay
 from bcipy.feedback.visual.visual_feedback import VisualFeedback
 from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
 from bcipy.helpers.save import _save_session_related_data
-from bcipy.helpers.stimuli import InquirySchedule
+from bcipy.helpers.stimuli import InquirySchedule, StimuliOrder
 from bcipy.helpers.task import (BACKSPACE_CHAR, alphabet, construct_triggers,
                                 fake_copy_phrase_decision, get_user_input,
                                 process_data_for_decision, target_info,
@@ -187,7 +187,7 @@ class RSVPCopyPhraseTask(Task):
             filter_order=self.parameters['filter_order'],
             notch_filter_frequency=self.parameters['notch_filter_frequency'],
             stim_length=self.parameters['stim_length'],
-            stim_order=self.parameters['stim_order'])
+            stim_order=StimuliOrder(self.parameters['stim_order']))
 
     def await_start(self) -> bool:
         """Wait on the splash screen for the user to either exit or start."""

--- a/bcipy/tasks/rsvp/main_frame.py
+++ b/bcipy/tasks/rsvp/main_frame.py
@@ -231,7 +231,6 @@ class DecisionMaker:
             return True, None
         else:
             stimuli = self.schedule_inquiry()
-            print(stimuli)
             return False, stimuli
 
     def do_series(self):

--- a/bcipy/tasks/rsvp/main_frame.py
+++ b/bcipy/tasks/rsvp/main_frame.py
@@ -40,7 +40,6 @@ class EvidenceFusion(object):
         for value in dict_evidence.values():
             self.likelihood *= value[:]
 
-        # I
         if np.isinf(np.sum(self.likelihood)):
             tmp = np.zeros(len(self.likelihood))
             tmp[np.where(self.likelihood == np.inf)[0][0]] = 1
@@ -136,7 +135,7 @@ class DecisionMaker:
                  alphabet=list(string.ascii_uppercase) + [BACKSPACE_CHAR] + [SPACE_CHAR],
                  is_txt_stim=True,
                  stimuli_timing=[1, .2],
-                 stimuli_order: StimuliOrder = StimuliOrder.RANDOM.value,
+                 stimuli_order: StimuliOrder = StimuliOrder.RANDOM,
                  inq_constants=None,
                  stopping_evaluator=CriteriaEvaluator.default(min_num_inq=2,
                                                               max_num_inq=10,

--- a/bcipy/tasks/tests/test_copy_phrase.py
+++ b/bcipy/tasks/tests/test_copy_phrase.py
@@ -65,6 +65,7 @@ class TestCopyPhrase(unittest.TestCase):
             'stim_height': 0.6,
             'stim_length': 10,
             'stim_number': 100,
+            'stim_order': 'random',
             'stim_pos_x': 0.0,
             'stim_pos_y': 0.0,
             'stim_space_char': '–',

--- a/bcipy/tasks/tests/test_copy_phrase.py
+++ b/bcipy/tasks/tests/test_copy_phrase.py
@@ -15,7 +15,7 @@ from bcipy.acquisition.device_info import DeviceInfo
 from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
 from bcipy.tasks.rsvp.copy_phrase import RSVPCopyPhraseTask
 from bcipy.tasks.session_data import Session, EvidenceType
-from bcipy.helpers.stimuli import InquirySchedule
+from bcipy.helpers.stimuli import InquirySchedule, StimuliOrder
 
 
 class TestCopyPhrase(unittest.TestCase):
@@ -65,7 +65,7 @@ class TestCopyPhrase(unittest.TestCase):
             'stim_height': 0.6,
             'stim_length': 10,
             'stim_number': 100,
-            'stim_order': 'random',
+            'stim_order': StimuliOrder.RANDOM,
             'stim_pos_x': 0.0,
             'stim_pos_y': 0.0,
             'stim_space_char': '–',


### PR DESCRIPTION
# Overview

Added stimuli ordering parameter and implemented in RSVP tasks. Various logging and typing improvements while I was in the files.

## Ticket

https://www.pivotaltracker.com/story/show/175769809

## Contributions

- `copy_phrase_wrapper`: update logging and exception handling. add stim order.
- `main_frame`: update `DecisionMaker` to use stim_order. Remove constants (unused).. consider writing a ticket to address? Use BACKSPACE_CHAR.
- `demo_stimuli_generation.py`: update imports and add a case showing the new ordering functionality.
- `bcipy/helpers/stimuli.py ` add `StimuliOrder`. Add method `alphabetize`. Implement `alphabetize` where stimuli are generated. Remove unused or abandoned generators.  update logging, typing and exception handling.
- `parameters.json`: add `stim_order`.
- Updated tasks to pull in and use the stim_order parameters in their generators.

## Test

- Added tests to `test_stimuli` and updated the copy phrase test with new parameter.
- `make test-all`
- `bcipy`: try running with random and alphabetical in both calibration and copy phrase. 

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? I don't think so.. I updated inline as I noticed.