### PR TITLE
Copy Phrase Fusion Error

### DIFF
--- a/bcipy/helpers/copy_phrase_wrapper.py
+++ b/bcipy/helpers/copy_phrase_wrapper.py
@@ -199,13 +199,13 @@ class CopyPhraseWrapper:
             bandpass_order=self.filter_order,
             downsample_factor=self.downsample_rate,
         )
-        data, self.sampling_rate = default_transform(raw_data, self.sampling_rate)
+        data, transformed_sample_rate = default_transform(raw_data, self.sampling_rate)
 
         data, _ = self.signal_model.reshaper(
             trial_labels=target_info,
             timing_info=times,
             eeg_data=data,
-            fs=self.sampling_rate,
+            fs=transformed_sample_rate,
             trials_per_inquiry=self.stim_length,
             channel_map=self.channel_map,
             trial_length=window_length)


### PR DESCRIPTION
# Overview

Fixed bug in reshaping data for Copy Phrase. 

The TrialReshaper has a parameter for the sample rate (`fs`) and the expected value is the sample rate of the EEG data after processing (downsampling). The calling code captured this new sample rate value after performing the default transform, but in the process mutated the existing instance value. The result of mutating this value was that for every inquiry, the data was transformed using a halved sample rate from the previous iteration.

## Ticket

https://www.pivotaltracker.com/story/show/178787961

## Contributions

- Fixed bug

## Test

- Using a calibration model trained on the current 1.5.1 branch, run a copy phrase task with inquiry preview tured on or off. The task should run without error
