### PR TITLE
#175674845 ; module for raw data format

### DIFF
--- a/bcipy/acquisition/buffer.py
+++ b/bcipy/acquisition/buffer.py
@@ -6,10 +6,10 @@ import os
 import sqlite3
 from collections import deque
 import logging
-import csv
 
 from builtins import range
 from bcipy.acquisition.record import Record
+from bcipy.helpers.raw_data import RawDataWriter
 
 log = logging.getLogger(__name__)
 
@@ -285,23 +285,14 @@ class Buffer():
             sample_rate - metadata for the sample rate; ex. 300.0
         """
 
-        with open(raw_data_file_name, "w", encoding='utf-8', newline='') as raw_data_file:
-            # write metadata
-            raw_data_file.write(f"daq_type,{daq_type}\n")
-            raw_data_file.write(f"sample_rate,{sample_rate}\n")
-
-            # if flush is missing the previous content may be appended at the end
-            raw_data_file.flush()
-
-            self._flush()
-            cursor = self._new_connection().cursor()
-            cursor.execute("select * from data;")
-            columns = [description[0] for description in cursor.description]
-
-            csv_writer = csv.writer(raw_data_file, delimiter=',')
-            csv_writer.writerow(columns)
+        self._flush()
+        cursor = self._new_connection().cursor()
+        cursor.execute("select * from data;")
+        columns = [description[0] for description in cursor.description]
+        with RawDataWriter(raw_data_file_name, daq_type, sample_rate,
+                           columns) as writer:
             for row in cursor:
-                csv_writer.writerow(row)
+                writer.writerow(row)
 
 
 def _adapt_record(record):

--- a/bcipy/acquisition/datastream/tcp_server.py
+++ b/bcipy/acquisition/datastream/tcp_server.py
@@ -9,6 +9,7 @@ import time
 from bcipy.acquisition.datastream.producer import Producer
 from bcipy.acquisition.datastream.generator import random_data_generator
 from bcipy.acquisition.util import StoppableThread
+from bcipy.helpers.raw_data import settings
 
 log = logging.getLogger(__name__)
 
@@ -180,18 +181,6 @@ def await_start(dataserver, max_wait=2):
             dataserver.stop()
             raise Exception("Server couldn't start up in time.")
 
-# TODO: refactor this into a raw_data module
-
-
-def _settings(filename):
-    """Read the daq settings from the given data file"""
-
-    with open(filename, 'r') as infile:
-        daq_type = infile.readline().strip().split(',')[1]
-        sample_hz = int(infile.readline().strip().split(',')[1])
-        channels = infile.readline().strip().split(',')
-        return daq_type, sample_hz, channels
-
 
 def main():
     """Initialize and run the server."""
@@ -214,7 +203,7 @@ def main():
     args = parser.parse_args()
 
     if args.filename:
-        daq_type, sample_rate, channels = _settings(args.filename)
+        daq_type, sample_rate, channels = settings(args.filename)
         device_spec = supported_device(daq_type)
         device_spec.sample_rate = sample_rate
         device_spec.channels = channels

--- a/bcipy/acquisition/tests/test_processor.py
+++ b/bcipy/acquisition/tests/test_processor.py
@@ -1,53 +1,9 @@
 # pylint: disable=no-self-use
 """Tests for the processor module."""
 import unittest
-import pytest
-from mock import mock_open, patch
 from mockito import any, mock, verify, when
 from bcipy.acquisition.device_info import DeviceInfo
-from bcipy.acquisition.processor import FileWriter, DispatchProcessor, Processor
-
-
-class TestFilewriter(unittest.TestCase):
-    """Tests for the Processor that writes the rawdata files."""
-
-    def test_filewriter(self):
-        """Test FileWriter functionality"""
-
-        data = [[i + j for j in range(3)] for i in range(3)]
-        expected_csv_rows = ['0,1,2\r\n', '1,2,3\r\n', '2,3,4\r\n']
-
-        filewriter = FileWriter('foo.csv')
-        filewriter.set_device_info(DeviceInfo(name='foo-device', fs=100,
-                                              channels=['c1', 'c2', 'c3']))
-
-        mockopen = mock_open()
-        with patch('bcipy.acquisition.processor.open', mockopen):
-            with filewriter:
-                mockopen.assert_called_once_with('foo.csv', 'w', newline='')
-
-                handle = mockopen()
-                handle.write.assert_called_with('timestamp,c1,c2,c3\r\n')
-
-                for i, row in enumerate(data):
-                    timestamp = float(i)
-                    filewriter.process(row, timestamp)
-                    handle.write.assert_called_with(
-                        str(timestamp) + "," + str(expected_csv_rows[i]))
-
-            mockopen().close.assert_called_once()
-
-    def test_filewriter_setup(self):
-        """
-        Test that FileWriter throws an exception if it is used without setting
-        the device_info.
-        """
-
-        filewriter = FileWriter('foo.csv')
-
-        with pytest.raises(Exception):
-            with filewriter:
-                pass
+from bcipy.acquisition.processor import DispatchProcessor, Processor
 
 
 class TestDispatchProcessor(unittest.TestCase):
@@ -66,7 +22,8 @@ class TestDispatchProcessor(unittest.TestCase):
 
         multi = DispatchProcessor(proc1, proc2)
 
-        device_info = DeviceInfo(name='foo-device', fs=100,
+        device_info = DeviceInfo(name='foo-device',
+                                 fs=100,
                                  channels=['c1', 'c2', 'c3'])
 
         multi.set_device_info(device_info)

--- a/bcipy/gui/viewer/data_source/file_streamer.py
+++ b/bcipy/gui/viewer/data_source/file_streamer.py
@@ -1,6 +1,8 @@
-import csv
+"""Streams file data for the viewer"""
 import logging
+import time
 from bcipy.acquisition.util import StoppableThread
+from bcipy.helpers.raw_data import RawDataReader
 log = logging.getLogger(__name__)
 
 
@@ -23,16 +25,11 @@ class FileStreamer(StoppableThread):
 
     def run(self):
         log.debug("Starting raw_data file streamer")
-        import time
-        with open(self.data_file) as csvfile:
-            # read metadata
-            _name_row = next(csvfile)
-            fs = float(next(csvfile).strip().split(",")[1])
 
-            reader = csv.reader(csvfile)
-            _channels = next(reader)
+        with RawDataReader(self.data_file, convert_data=True) as reader:
+            fs = reader.sample_rate
+            log.debug(f"Publishing data at sample rate {fs} hz")
 
-            log.debug("Publishing data")
             # publish data
             for data in reader:
                 if not self.running():

--- a/bcipy/gui/viewer/data_viewer.py
+++ b/bcipy/gui/viewer/data_viewer.py
@@ -1,5 +1,4 @@
 """EEG Data Viewer"""
-import csv
 import sys
 from functools import partial
 from queue import Queue
@@ -22,6 +21,7 @@ from bcipy.gui.viewer.data_source.data_source import QueueDataSource
 from bcipy.gui.viewer.data_source.lsl_data_source import LslDataSource
 from bcipy.gui.viewer.ring_buffer import RingBuffer
 from bcipy.helpers.parameters import DEFAULT_PARAMETERS_PATH, Parameters
+from bcipy.helpers.raw_data import settings
 from bcipy.signal.process.transform import Downsample, get_default_transform
 
 
@@ -628,14 +628,7 @@ def file_data(path: str
 
     from bcipy.gui.viewer.data_source.file_streamer import FileStreamer
     # read metadata
-    with open(path) as csvfile:
-        row1 = next(csvfile)
-        name = row1.strip().split(",")[1]
-        row2 = next(csvfile)
-        freq = float(row2.strip().split(",")[1])
-
-        reader = csv.reader(csvfile)
-        channels = next(reader)
+    name, freq, channels = settings(path)
     queue = Queue()
     streamer = FileStreamer(path, queue)
     data_source = QueueDataSource(queue)
@@ -694,10 +687,10 @@ def main(data_file: str,
 
     panel.start()
 
-    sys.exit(app.exec_())
-
+    app_exit = app.exec_()
     if proc:
         proc.stop()
+    sys.exit(app_exit)
 
 
 if __name__ == "__main__":

--- a/bcipy/helpers/raw_data.py
+++ b/bcipy/helpers/raw_data.py
@@ -1,0 +1,303 @@
+"""Functionality for reading and writing raw signal data."""
+import csv
+from typing import List, TextIO, Tuple
+
+import numpy as np
+import pandas as pd
+
+from bcipy.signal.generator.generator import gen_random_data
+
+TIMESTAMP_COLUMN = 'timestamp'
+
+
+class RawData:
+    """Represents the raw data format used by BciPy. Used primarily for loading
+    a raw data file into memory."""
+
+    def __init__(self,
+                 daq_type: str = None,
+                 sample_rate: int = None,
+                 columns: List[str] = []):
+        self.daq_type = daq_type
+        self.sample_rate = sample_rate
+        self.columns = columns
+        self._rows = []
+        self._dataframe = None
+
+    @classmethod
+    def load(cls, filename: str):
+        """Constructs a RawData object by deserializing the given file.
+        All data will be read into memory. If you want to lazily read data one
+        record at a time, use a RawDataReader.
+
+        Parameters
+        ----------
+        - filename : path to the csv file to read
+        """
+        return load(filename)
+
+    @property
+    def rows(self) -> List[List]:
+        """Returns the data rows"""
+        return self._rows
+
+    @rows.setter
+    def rows(self, value):
+        self._rows = value
+        self._dataframe = None
+
+    @property
+    def channels(self) -> List[str]:
+        """Compute the list of channels. Channels are the numeric columns
+        excluding the timestamp column."""
+
+        # Start data slice at 1 to remove the timestamp column.
+        return list(self.numeric_data.columns[1:])
+
+    @property
+    def numeric_data(self) -> pd.DataFrame:
+        """Data for columns with numeric data. This is usually comprised of the
+        timestamp column and device channels, excluding triggers."""
+        return self.dataframe.select_dtypes(exclude=['object'])
+
+    def by_channel(self) -> np.ndarray:
+        """Data organized by channel.
+
+        Returns
+        ----------
+        C x N numpy array with samples where C is the number of channels and N
+        is number of time samples."""
+
+        numeric_data = self.numeric_data
+
+        numeric_vals = numeric_data.values
+        numeric_column_count = numeric_vals.shape[1]
+        return numeric_vals[:, 1:numeric_column_count].transpose()
+
+    @property
+    def dataframe(self) -> pd.DataFrame:
+        if self._dataframe is None:
+            self._dataframe = pd.DataFrame(data=self.rows,
+                                           columns=self.columns)
+        return self._dataframe
+
+    def append(self, row: List):
+        """Append the given row of data.
+
+        Parameters
+        ----------
+        - row : row of data
+        """
+        assert len(row) == len(self.columns), "Wrong number of columns"
+        self._rows.append(row)
+        self._dataframe = None
+
+
+def maybe_float(val):
+    """Attempt to convert the given value to float. If conversion fails return
+    as is."""
+    try:
+        return float(val)
+    except ValueError:
+        return val
+
+
+class RawDataReader:
+    """Lazily reads raw data from a file. Intended to be used as a ContextManager
+    using Python's `with` keyword.
+
+    Example usage:
+
+    ```
+    with RawDataReader(path) as reader:
+        print(f"Data from ${reader.daq_type}")
+        print(reader.columns)
+        for row in reader:
+            print(row)
+    ```
+
+    Parameters
+    ----------
+    - file_path : path to the csv file
+    - convert_data : if True attempts to convert data values to floats;
+    default is False
+    """
+
+    def __init__(self, file_path: str, convert_data: bool = False):
+        self.file_path = file_path
+        self._file_obj = None
+        self.convert_data = convert_data
+
+    def __enter__(self):
+        self._file_obj = open(self.file_path, mode="r")
+        self.daq_type, self.sample_rate = read_metadata(self._file_obj)
+        self._reader = csv.reader(self._file_obj)
+        self.columns = next(self._reader)
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        """Exit the context manager. Close resources"""
+        self._file_obj.close()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        assert self._reader, "Reader must be initialized"
+        row = next(self._reader)
+        if self.convert_data:
+            return list(map(maybe_float, row))
+        return row
+
+
+class RawDataWriter:
+    """Writes a raw data file one row at a time without storing the records
+    in memory. Intended to be used as a ContextManager using Python's `with`
+    keyword.
+
+    Example usage:
+
+    ```
+    with RawDataWriter(path, daq_type, sample_rate, columns) as writer:
+        for row in data:
+            writer.writerow(row)
+    ```
+
+    Parameters
+    ----------
+    - file_path : path to the csv file
+    - daq_type : name of device
+    - sample_rate : sample frequency in Hz
+    - columns : list of column names
+    """
+
+    def __init__(self, file_path: str, daq_type: str, sample_rate: float,
+                 columns: List[str]):
+        self.file_path = file_path
+        self.daq_type = daq_type
+        self.sample_rate = sample_rate
+        self.columns = columns
+        self._file_obj = None
+
+    def __enter__(self):
+        self._file_obj = open(self.file_path,
+                              mode='w',
+                              encoding='utf-8',
+                              newline='')
+        # write metadata
+        self._file_obj.write(f"daq_type,{self.daq_type}\n")
+        self._file_obj.write(f"sample_rate,{self.sample_rate}\n")
+
+        # If flush is missing the previous content may be appended at the end.
+        self._file_obj.flush()
+
+        self._csv_writer = csv.writer(self._file_obj, delimiter=',')
+        self._csv_writer.writerow(self.columns)
+
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        """Exit the context manager. Close resources"""
+        self._file_obj.close()
+
+    def writerow(self, row: List) -> None:
+        assert self._csv_writer, "Writer must be initialized"
+        self._csv_writer.writerow(row)
+
+
+def load(filename: str) -> RawData:
+    """Reads the file at the given path and initializes a RawData object.
+    All data will be read into memory. If you want to lazily read data one
+    record at a time, use a RawDataReader.
+
+    Parameters
+    ----------
+    - filename : path to the csv file to read
+    """
+    # Loading all data from a csv is faster using pandas than using the
+    # RawDataReader.
+    with open(filename, mode='r') as file_obj:
+        daq_type, sample_rate = read_metadata(file_obj)
+        dataframe = pd.read_csv(file_obj)
+        data = RawData(daq_type, sample_rate, list(dataframe.columns))
+        data.rows = dataframe.values.tolist()
+        return data
+
+
+def read_metadata(file_obj: TextIO) -> Tuple[str, float]:
+    """Reads the metadata from an open raw data file and retuns the result as
+    a tuple. Increments the reader.
+
+    Parameters
+    ----------
+    - file_obj : open TextIO object
+
+    Returns
+    -------
+    tuple of daq_type, sample_rate
+    """
+    daq_type = next(file_obj).strip().split(',')[1]
+    sample_rate = float(next(file_obj).strip().split(",")[1])
+    return daq_type, sample_rate
+
+
+def write(data: RawData, filename: str):
+    """Write the given raw data file.
+
+    Parameters
+    ----------
+    - data : raw data object to write
+    - filename : path to destination file.
+    """
+    with RawDataWriter(filename, data.daq_type, data.sample_rate,
+                       data.columns) as writer:
+        for row in data.rows:
+            writer.writerow(row)
+
+
+def settings(filename: str) -> Tuple[str, float, List[str]]:
+    """Read the daq settings from the given data file
+
+    Parameters
+    ----------
+    - filename : path to the raw data file (csv)
+
+    Returns
+    -------
+    tuple of (acquisition type, sample_rate, columns)
+    """
+
+    with RawDataReader(filename) as reader:
+        return reader.daq_type, reader.sample_rate, reader.columns
+
+
+def sample_data(rows: int = 1000,
+                ch_names: List[str] = ['ch1', 'ch2', 'ch3'],
+                daq_type: str = 'SampleDevice',
+                sample_rate: float = 256.0,
+                triggers: List[Tuple[float, str]] = []) -> RawData:
+    """Creates sample data to be written as a raw_data.csv file. The resulting data has
+    a column for the timestamp, one for each channel, and a TRG column.
+
+    - rows : number of sample rows to generate
+    - ch_names : list of channel names
+    - daq_type : metadata for the device name
+    - sample_rate : device sample rate in hz
+    - triggers : List of (timestamp, trigger_value) tuples to be inserted
+    in the data.
+    """
+    channels = [name for name in ch_names if name != 'TRG']
+    columns = [TIMESTAMP_COLUMN] + channels + ['TRG']
+    trg_times = dict(triggers)
+
+    data = RawData(daq_type, sample_rate, columns)
+
+    for i in range(rows):
+        timestamp = i + 1
+        channel_data = gen_random_data(low=-1000,
+                                       high=1000,
+                                       channel_count=len(channels))
+        trg = trg_times.get(timestamp, '0.0')
+        data.append([timestamp] + channel_data + [trg])
+
+    return data

--- a/bcipy/helpers/tests/test_convert.py
+++ b/bcipy/helpers/tests/test_convert.py
@@ -5,14 +5,11 @@ import tempfile
 import unittest
 import warnings
 
-from itertools import chain
 from pathlib import Path
-from typing import List
 
 from bcipy.helpers.convert import convert_to_edf
 from bcipy.helpers.parameters import Parameters
-from bcipy.signal.generator.generator import gen_random_data
-
+from bcipy.helpers.raw_data import sample_data, write
 from mne.io import read_raw_edf
 
 
@@ -30,30 +27,6 @@ Z nontarget 10.70310750597855
 R nontarget 11.00485198898241
 _ nontarget 11.306160968990298
 offset offset_correction 1.23828125'''
-
-
-def sample_data(rows: int = 1000, ch_names: List[str] = None) -> str:
-    """Creates sample data to be written as a raw_data.csv file
-
-    rows - number of sample rows to generate
-    ch_names - channel names
-    """
-    if not ch_names:
-        ch_names = ['ch1', 'ch2', 'ch3']
-    # Mock the raw_data file
-    sep = '\n'
-    meta = sep.join(['daq_type,LSL', 'sample_rate,256.0'])
-    header = 'timestamp,' + ','.join(ch_names) + ',TRG'
-
-    data = []
-    for i in range(rows):
-        channel_data = gen_random_data(low=-1000,
-                                       high=1000,
-                                       channel_count=len(ch_names))
-        columns = chain([str(i)], map(str, channel_data), ['0.0'])
-        data.append(','.join(columns))
-
-    return sep.join([meta, header, *data])
 
 
 class TestConvert(unittest.TestCase):
@@ -76,8 +49,7 @@ class TestConvert(unittest.TestCase):
         with open(Path(self.temp_dir, 'triggers.txt'), 'w') as trg_file:
             trg_file.write(self.__class__.trg_data)
 
-        with open(Path(self.temp_dir, 'raw_data.csv'), 'w') as data_file:
-            data_file.write(self.__class__.sample_data)
+        write(self.__class__.sample_data, Path(self.temp_dir, 'raw_data.csv'))
 
         params = Parameters.from_cast_values(raw_data_name='raw_data.csv',
                                              trigger_file_name='triggers.txt')

--- a/bcipy/helpers/tests/test_raw_data.py
+++ b/bcipy/helpers/tests/test_raw_data.py
@@ -1,0 +1,272 @@
+"""Tests for BciPy raw data format."""
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from bcipy.helpers.raw_data import (RawData, RawDataReader, RawDataWriter,
+                                    load, sample_data, settings, write)
+
+
+class TestRawData(unittest.TestCase):
+    """Tests for raw_data format"""
+
+    def setUp(self):
+        """Override; set up the needed path for load functions."""
+        self.data_dir = f"{os.path.dirname(__file__)}/resources/"
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Override"""
+        shutil.rmtree(self.temp_dir)
+
+    def test_init(self):
+        """Test that a RawData structure can be initialized"""
+        columns = ['timestamp', 'ch1', 'ch2', 'ch3', 'TRG']
+        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=columns)
+        self.assertEqual(data.daq_type, 'DSI-24')
+        self.assertEqual(data.sample_rate, 300.0)
+        self.assertEqual(data.columns, columns)
+
+    def test_write_with_no_data(self):
+        """Test that raw data can be persisted to disk."""
+        path = Path(self.temp_dir, 'test_raw_data.csv')
+        data = RawData(daq_type='DSI-24',
+                       sample_rate=300.0,
+                       columns=['timestamp', 'ch1', 'ch2', 'ch3', 'TRG'])
+
+        self.assertFalse(path.exists())
+        write(data, path)
+        self.assertTrue(path.exists())
+
+    def test_load_with_no_data(self):
+        """Test that the raw data format can be read by the module."""
+        columns = ['timestamp', 'ch1', 'ch2', 'ch3', 'TRG']
+        path = Path(self.temp_dir, 'test_raw_data.csv')
+        existing_data = RawData(daq_type='DSI-24',
+                                sample_rate=300.0,
+                                columns=columns)
+        write(existing_data, path)
+
+        self.assertTrue(path.exists())
+        data = load(path)
+
+        self.assertEqual(data.daq_type, 'DSI-24')
+        self.assertEqual(data.sample_rate, 300.0)
+        self.assertEqual(data.columns, columns)
+
+    def test_load_with_data(self):
+        """Test that data can be loaded from a file."""
+        columns = columns = ['timestamp', 'ch1', 'ch2', 'ch3']
+        path = Path(self.temp_dir, 'test_raw_data.csv')
+        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=columns)
+
+        row1 = [1, 1.0, 2.0, 3.0]
+        row2 = [2, 4.0, 5.0, 6.0]
+        row3 = [3, 7.0, 8.0, 9.0]
+
+        data.append(row1)
+        data.append(row2)
+        data.append(row3)
+
+        self.assertFalse(path.exists())
+        write(data, path)
+        self.assertTrue(path.exists())
+
+        loaded_data = load(path)
+
+        self.assertEqual(loaded_data.daq_type, 'DSI-24')
+        self.assertEqual(loaded_data.sample_rate, 300.0)
+        self.assertEqual(loaded_data.columns, columns)
+
+        self.assertEqual(len(loaded_data.rows), 3)
+        self.assertEqual(loaded_data.rows[0], row1)
+        self.assertEqual(loaded_data.rows[1], row2)
+        self.assertEqual(loaded_data.rows[2], row3)
+
+    def test_deserialization(self):
+        """Test that the load function can be accessed through a class
+        constructor."""
+        columns = columns = ['timestamp', 'ch1', 'ch2', 'ch3']
+        path = Path(self.temp_dir, 'test_raw_data.csv')
+        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=columns)
+
+        row1 = [1, 1.0, 2.0, 3.0]
+        row2 = [2, 4.0, 5.0, 6.0]
+        row3 = [3, 7.0, 8.0, 9.0]
+
+        data.append(row1)
+        data.append(row2)
+        data.append(row3)
+
+        write(data, path)
+        self.assertTrue(path.exists())
+
+        loaded_data = RawData.load(path)
+
+        self.assertEqual(loaded_data.daq_type, 'DSI-24')
+        self.assertEqual(loaded_data.sample_rate, 300.0)
+        self.assertEqual(loaded_data.columns, columns)
+
+        self.assertEqual(len(loaded_data.rows), 3)
+        self.assertEqual(loaded_data.rows[0], row1)
+        self.assertEqual(loaded_data.rows[1], row2)
+        self.assertEqual(loaded_data.rows[2], row3)
+
+    def test_settings(self):
+        """Test that metadata settings can be extracted from a raw data
+        file."""
+        path = Path(self.temp_dir, 'test_raw_data.csv')
+        write(
+            RawData(daq_type='LSL',
+                    sample_rate=256.0,
+                    columns=['ch_a', 'ch_b', 'ch_c']), path)
+        name, sample_rate, columns = settings(path)
+        self.assertEqual(name, 'LSL')
+        self.assertEqual(sample_rate, 256.0)
+        self.assertEqual(columns, ['ch_a', 'ch_b', 'ch_c'])
+
+    def test_raw_data_reader(self):
+        """Test that data can be read from a file incrementally."""
+        channels = ['ch1', 'ch2', 'ch3']
+        path = Path(self.temp_dir, 'test_raw_data.csv')
+        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=channels)
+
+        row1 = [1.0, 2.0, 3.0]
+        row2 = [4.0, 5.0, 6.0]
+        row3 = [7.0, 8.0, 9.0]
+
+        data.append(row1)
+        data.append(row2)
+        data.append(row3)
+
+        self.assertFalse(path.exists())
+        write(data, path)
+        self.assertTrue(path.exists())
+
+        with RawDataReader(path) as reader:
+            self.assertEqual(reader.daq_type, 'DSI-24')
+            self.assertEqual(reader.sample_rate, 300.0)
+            self.assertEqual(reader.columns, data.columns)
+
+            # all columns are read as strings by default
+            self.assertEqual(list(map(str, row1)), next(reader))
+            self.assertEqual(list(map(str, row2)), next(reader))
+            self.assertEqual(list(map(str, row3)), next(reader))
+
+    def test_raw_data_reader_with_type_conversions(self):
+        """Test that data can be read incrementally and that data can be
+        converted to numeric types."""
+        columns = ['timestamp', 'ch1', 'ch2', 'ch3', 'TRG']
+        path = Path(self.temp_dir, 'test_raw_data.csv')
+        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=columns)
+
+        row1 = [1, 1.0, 2.0, 3.0, 'A']
+        row2 = [2, 4.0, 5.0, 6.0, 'B']
+        row3 = [3, 7.0, 8.0, 9.0, 'C']
+
+        data.append(row1)
+        data.append(row2)
+        data.append(row3)
+
+        self.assertFalse(path.exists())
+        write(data, path)
+        self.assertTrue(path.exists())
+
+        with RawDataReader(path, convert_data=True) as reader:
+            self.assertEqual(reader.daq_type, 'DSI-24')
+            self.assertEqual(reader.sample_rate, 300.0)
+            self.assertEqual(reader.columns, data.columns)
+
+            self.assertEqual(row1, next(reader))
+            self.assertEqual(row2, next(reader))
+            self.assertEqual(row3, next(reader))
+
+    def test_raw_data_writer(self):
+        """Test that data can be written incrementally"""
+        columns = ['timestamp', 'ch1', 'ch2', 'ch3']
+        path = Path(self.temp_dir, 'test_raw_data_writer.csv')
+        rows = [[1, 1.0, 2.0, 3.0], [2, 4.0, 5.0, 6.0], [3, 7.0, 8.0, 9.0]]
+
+        self.assertFalse(path.exists())
+        with RawDataWriter(path,
+                           daq_type='DSI-24',
+                           sample_rate=300.0,
+                           columns=columns) as writer:
+            for row in rows:
+                writer.writerow(row)
+        self.assertTrue(path.exists())
+
+    def test_sample_data(self):
+        """Test that sample data can be generated for testing purposes."""
+        channels = ['ch1', 'ch2', 'ch3']
+        data = sample_data(rows=5, ch_names=channels)
+        self.assertEqual(5, len(data.rows))
+        self.assertEqual(['timestamp', 'ch1', 'ch2', 'ch3', 'TRG'],
+                         data.columns)
+        self.assertEqual(1, data.rows[0][0])
+        self.assertEqual(5, data.rows[4][0])
+
+        # Test data range of channel columns
+        for row in data.rows:
+            for col in row[1:-1]:
+                self.assertTrue(col >= -1000 and col <= 1000)
+
+    def test_sample_data_with_triggers(self):
+        """Test generating sample data with triggers at pre-defined timestamps.
+        This functionality is used primarily for other unit tests."""
+        channels = ['ch1', 'ch2', 'ch3']
+        data = sample_data(rows=10,
+                           ch_names=channels,
+                           triggers=[(1, 'A'), (5, 'B'), (10, 'C')])
+        self.assertEqual(10, len(data.rows))
+
+        trg_col = data.columns.index('TRG')
+        self.assertEqual('A', data.rows[0][trg_col])
+        self.assertEqual('B', data.rows[4][trg_col])
+        self.assertEqual('C', data.rows[9][trg_col])
+
+    def test_raw_data_numeric_channels(self):
+        """Tests that data channels can be extracted for analysis."""
+
+        columns = columns = ['timestamp', 'ch1', 'ch2', 'ch3', 'TRG']
+        path = Path(self.temp_dir, 'test_raw_data.csv')
+        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=columns)
+
+        row1 = [1, 1.0, 2.0, 3.0, '0.0']
+        row2 = [2, 4.0, 5.0, 6.0, 'A']
+        row3 = [3, 7.0, 8.0, 9.0, '0.0']
+
+        data.append(row1)
+        data.append(row2)
+        data.append(row3)
+
+        self.assertEqual(['ch1', 'ch2', 'ch3'], data.channels)
+
+        # Test numeric data frame
+        dataframe = pd.DataFrame(data=[[1, 1.0, 2.0, 3.0], [2, 4.0, 5.0, 6.0],
+                                       [3, 7.0, 8.0, 9.0]],
+                                 columns=['timestamp', 'ch1', 'ch2', 'ch3'])
+        self.assertTrue(np.all(dataframe == data.numeric_data))
+
+    def test_data_by_channel(self):
+        """Tests that data can be structured in column-order for analysis."""
+
+        columns = ['timestamp', 'ch1', 'ch2', 'TRG']
+        path = Path(self.temp_dir, 'test_raw_data.csv')
+        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=columns)
+
+        data.append([1, 1.0, 2.0, '0.0'])
+        data.append([2, 4.0, 5.0, 'A'])
+        data.append([3, 7.0, 8.0, '0.0'])
+
+        arr = data.by_channel()
+        self.assertEqual((2, 3), arr.shape)
+
+        self.assertTrue(len(data.channels), len(arr))
+        self.assertTrue(np.all(arr[0] == [1.0, 4.0, 7.0]), "Should have ch1 data")
+        self.assertTrue(np.all(arr[1] == [2.0, 5.0, 8.0]), "Should have ch2 data")

--- a/bcipy/helpers/tests/test_raw_data.py
+++ b/bcipy/helpers/tests/test_raw_data.py
@@ -19,151 +19,127 @@ class TestRawData(unittest.TestCase):
         """Override; set up the needed path for load functions."""
         self.data_dir = f"{os.path.dirname(__file__)}/resources/"
         self.temp_dir = tempfile.mkdtemp()
+        self.path = Path(self.temp_dir, 'test_raw_data.csv')
+        self.daq_type = 'Test-Device'
+        self.sample_rate = 300.0
+        self.columns = ['timestamp', 'ch1', 'ch2', 'ch3']
+        self.row1 = [1, 1.0, 2.0, 3.0]
+        self.row2 = [2, 4.0, 5.0, 6.0]
+        self.row3 = [3, 7.0, 8.0, 9.0]
 
     def tearDown(self):
         """Override"""
         shutil.rmtree(self.temp_dir)
 
+    def _write_raw_data(self, include_rows=False) -> RawData:
+        """Helper function to write a sample raw data file to disk using the
+        settings from setUp.
+        
+        Parameters
+        ----------
+        - include_rows : if True adds data, otherwise just writes the metadata
+        and columns.
+        """
+        data = RawData(daq_type=self.daq_type,
+                       sample_rate=self.sample_rate,
+                       columns=self.columns)
+        if include_rows:
+            data.append(self.row1)
+            data.append(self.row2)
+            data.append(self.row3)
+
+        write(data, self.path)
+
     def test_init(self):
         """Test that a RawData structure can be initialized"""
-        columns = ['timestamp', 'ch1', 'ch2', 'ch3', 'TRG']
-        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=columns)
-        self.assertEqual(data.daq_type, 'DSI-24')
-        self.assertEqual(data.sample_rate, 300.0)
-        self.assertEqual(data.columns, columns)
+        data = RawData(daq_type=self.daq_type,
+                       sample_rate=self.sample_rate,
+                       columns=self.columns)
+        self.assertEqual(data.daq_type, self.daq_type)
+        self.assertEqual(data.sample_rate, self.sample_rate)
+        self.assertEqual(data.columns, self.columns)
 
     def test_write_with_no_data(self):
         """Test that raw data can be persisted to disk."""
-        path = Path(self.temp_dir, 'test_raw_data.csv')
-        data = RawData(daq_type='DSI-24',
-                       sample_rate=300.0,
-                       columns=['timestamp', 'ch1', 'ch2', 'ch3', 'TRG'])
+        data = RawData(daq_type=self.daq_type,
+                       sample_rate=self.sample_rate,
+                       columns=self.columns)
 
-        self.assertFalse(path.exists())
-        write(data, path)
-        self.assertTrue(path.exists())
+        self.assertFalse(self.path.exists())
+        write(data, self.path)
+        self.assertTrue(self.path.exists())
 
     def test_load_with_no_data(self):
         """Test that the raw data format can be read by the module."""
-        columns = ['timestamp', 'ch1', 'ch2', 'ch3', 'TRG']
-        path = Path(self.temp_dir, 'test_raw_data.csv')
-        existing_data = RawData(daq_type='DSI-24',
-                                sample_rate=300.0,
-                                columns=columns)
-        write(existing_data, path)
+        self._write_raw_data()
+        data = load(self.path)
 
-        self.assertTrue(path.exists())
-        data = load(path)
-
-        self.assertEqual(data.daq_type, 'DSI-24')
-        self.assertEqual(data.sample_rate, 300.0)
-        self.assertEqual(data.columns, columns)
+        self.assertEqual(data.daq_type, self.daq_type)
+        self.assertEqual(data.sample_rate, self.sample_rate)
+        self.assertEqual(data.columns, self.columns)
+        self.assertEqual(0, len(data.rows))
 
     def test_load_with_data(self):
         """Test that data can be loaded from a file."""
-        columns = columns = ['timestamp', 'ch1', 'ch2', 'ch3']
-        path = Path(self.temp_dir, 'test_raw_data.csv')
-        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=columns)
+        self._write_raw_data(include_rows=True)
+        loaded_data = load(self.path)
 
-        row1 = [1, 1.0, 2.0, 3.0]
-        row2 = [2, 4.0, 5.0, 6.0]
-        row3 = [3, 7.0, 8.0, 9.0]
-
-        data.append(row1)
-        data.append(row2)
-        data.append(row3)
-
-        self.assertFalse(path.exists())
-        write(data, path)
-        self.assertTrue(path.exists())
-
-        loaded_data = load(path)
-
-        self.assertEqual(loaded_data.daq_type, 'DSI-24')
-        self.assertEqual(loaded_data.sample_rate, 300.0)
-        self.assertEqual(loaded_data.columns, columns)
+        self.assertEqual(loaded_data.daq_type, self.daq_type)
+        self.assertEqual(loaded_data.sample_rate, self.sample_rate)
+        self.assertEqual(loaded_data.columns, self.columns)
 
         self.assertEqual(len(loaded_data.rows), 3)
-        self.assertEqual(loaded_data.rows[0], row1)
-        self.assertEqual(loaded_data.rows[1], row2)
-        self.assertEqual(loaded_data.rows[2], row3)
+        self.assertEqual(loaded_data.rows[0], self.row1)
+        self.assertEqual(loaded_data.rows[1], self.row2)
+        self.assertEqual(loaded_data.rows[2], self.row3)
 
     def test_deserialization(self):
         """Test that the load function can be accessed through a class
         constructor."""
-        columns = columns = ['timestamp', 'ch1', 'ch2', 'ch3']
-        path = Path(self.temp_dir, 'test_raw_data.csv')
-        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=columns)
+        self._write_raw_data(include_rows=True)
 
-        row1 = [1, 1.0, 2.0, 3.0]
-        row2 = [2, 4.0, 5.0, 6.0]
-        row3 = [3, 7.0, 8.0, 9.0]
+        loaded_data = RawData.load(self.path)
 
-        data.append(row1)
-        data.append(row2)
-        data.append(row3)
-
-        write(data, path)
-        self.assertTrue(path.exists())
-
-        loaded_data = RawData.load(path)
-
-        self.assertEqual(loaded_data.daq_type, 'DSI-24')
-        self.assertEqual(loaded_data.sample_rate, 300.0)
-        self.assertEqual(loaded_data.columns, columns)
+        self.assertEqual(loaded_data.daq_type, self.daq_type)
+        self.assertEqual(loaded_data.sample_rate, self.sample_rate)
+        self.assertEqual(loaded_data.columns, self.columns)
 
         self.assertEqual(len(loaded_data.rows), 3)
-        self.assertEqual(loaded_data.rows[0], row1)
-        self.assertEqual(loaded_data.rows[1], row2)
-        self.assertEqual(loaded_data.rows[2], row3)
+        self.assertEqual(loaded_data.rows[0], self.row1)
+        self.assertEqual(loaded_data.rows[1], self.row2)
+        self.assertEqual(loaded_data.rows[2], self.row3)
 
     def test_settings(self):
         """Test that metadata settings can be extracted from a raw data
         file."""
-        path = Path(self.temp_dir, 'test_raw_data.csv')
-        write(
-            RawData(daq_type='LSL',
-                    sample_rate=256.0,
-                    columns=['ch_a', 'ch_b', 'ch_c']), path)
-        name, sample_rate, columns = settings(path)
-        self.assertEqual(name, 'LSL')
-        self.assertEqual(sample_rate, 256.0)
-        self.assertEqual(columns, ['ch_a', 'ch_b', 'ch_c'])
+        self._write_raw_data()
+
+        name, sample_rate, columns = settings(self.path)
+        self.assertEqual(name, self.daq_type)
+        self.assertEqual(sample_rate, self.sample_rate)
+        self.assertEqual(columns, self.columns)
 
     def test_raw_data_reader(self):
         """Test that data can be read from a file incrementally."""
-        channels = ['ch1', 'ch2', 'ch3']
-        path = Path(self.temp_dir, 'test_raw_data.csv')
-        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=channels)
+        self._write_raw_data(include_rows=True)
 
-        row1 = [1.0, 2.0, 3.0]
-        row2 = [4.0, 5.0, 6.0]
-        row3 = [7.0, 8.0, 9.0]
-
-        data.append(row1)
-        data.append(row2)
-        data.append(row3)
-
-        self.assertFalse(path.exists())
-        write(data, path)
-        self.assertTrue(path.exists())
-
-        with RawDataReader(path) as reader:
-            self.assertEqual(reader.daq_type, 'DSI-24')
-            self.assertEqual(reader.sample_rate, 300.0)
-            self.assertEqual(reader.columns, data.columns)
+        with RawDataReader(self.path) as reader:
+            self.assertEqual(reader.daq_type, self.daq_type)
+            self.assertEqual(reader.sample_rate, self.sample_rate)
+            self.assertEqual(reader.columns, self.columns)
 
             # all columns are read as strings by default
-            self.assertEqual(list(map(str, row1)), next(reader))
-            self.assertEqual(list(map(str, row2)), next(reader))
-            self.assertEqual(list(map(str, row3)), next(reader))
+            self.assertEqual(list(map(str, self.row1)), next(reader))
+            self.assertEqual(list(map(str, self.row2)), next(reader))
+            self.assertEqual(list(map(str, self.row3)), next(reader))
 
     def test_raw_data_reader_with_type_conversions(self):
         """Test that data can be read incrementally and that data can be
         converted to numeric types."""
         columns = ['timestamp', 'ch1', 'ch2', 'ch3', 'TRG']
-        path = Path(self.temp_dir, 'test_raw_data.csv')
-        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=columns)
+        data = RawData(daq_type=self.daq_type,
+                       sample_rate=self.sample_rate,
+                       columns=columns)
 
         row1 = [1, 1.0, 2.0, 3.0, 'A']
         row2 = [2, 4.0, 5.0, 6.0, 'B']
@@ -172,14 +148,11 @@ class TestRawData(unittest.TestCase):
         data.append(row1)
         data.append(row2)
         data.append(row3)
+        write(data, self.path)
 
-        self.assertFalse(path.exists())
-        write(data, path)
-        self.assertTrue(path.exists())
-
-        with RawDataReader(path, convert_data=True) as reader:
-            self.assertEqual(reader.daq_type, 'DSI-24')
-            self.assertEqual(reader.sample_rate, 300.0)
+        with RawDataReader(self.path, convert_data=True) as reader:
+            self.assertEqual(reader.daq_type, self.daq_type)
+            self.assertEqual(reader.sample_rate, self.sample_rate)
             self.assertEqual(reader.columns, data.columns)
 
             self.assertEqual(row1, next(reader))
@@ -188,18 +161,17 @@ class TestRawData(unittest.TestCase):
 
     def test_raw_data_writer(self):
         """Test that data can be written incrementally"""
-        columns = ['timestamp', 'ch1', 'ch2', 'ch3']
-        path = Path(self.temp_dir, 'test_raw_data_writer.csv')
-        rows = [[1, 1.0, 2.0, 3.0], [2, 4.0, 5.0, 6.0], [3, 7.0, 8.0, 9.0]]
 
-        self.assertFalse(path.exists())
-        with RawDataWriter(path,
-                           daq_type='DSI-24',
-                           sample_rate=300.0,
-                           columns=columns) as writer:
+        rows = [self.row1, self.row2, self.row3]
+
+        self.assertFalse(self.path.exists())
+        with RawDataWriter(self.path,
+                           daq_type=self.daq_type,
+                           sample_rate=self.sample_rate,
+                           columns=self.columns) as writer:
             for row in rows:
                 writer.writerow(row)
-        self.assertTrue(path.exists())
+        self.assertTrue(self.path.exists())
 
     def test_sample_data(self):
         """Test that sample data can be generated for testing purposes."""
@@ -233,9 +205,10 @@ class TestRawData(unittest.TestCase):
     def test_raw_data_numeric_channels(self):
         """Tests that data channels can be extracted for analysis."""
 
-        columns = columns = ['timestamp', 'ch1', 'ch2', 'ch3', 'TRG']
-        path = Path(self.temp_dir, 'test_raw_data.csv')
-        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=columns)
+        columns = ['timestamp', 'ch1', 'ch2', 'ch3', 'TRG']
+        data = RawData(daq_type=self.daq_type,
+                       sample_rate=self.sample_rate,
+                       columns=columns)
 
         row1 = [1, 1.0, 2.0, 3.0, '0.0']
         row2 = [2, 4.0, 5.0, 6.0, 'A']
@@ -257,8 +230,9 @@ class TestRawData(unittest.TestCase):
         """Tests that data can be structured in column-order for analysis."""
 
         columns = ['timestamp', 'ch1', 'ch2', 'TRG']
-        path = Path(self.temp_dir, 'test_raw_data.csv')
-        data = RawData(daq_type='DSI-24', sample_rate=300.0, columns=columns)
+        data = RawData(daq_type=self.daq_type,
+                       sample_rate=self.sample_rate,
+                       columns=columns)
 
         data.append([1, 1.0, 2.0, '0.0'])
         data.append([2, 4.0, 5.0, 'A'])
@@ -268,5 +242,7 @@ class TestRawData(unittest.TestCase):
         self.assertEqual((2, 3), arr.shape)
 
         self.assertTrue(len(data.channels), len(arr))
-        self.assertTrue(np.all(arr[0] == [1.0, 4.0, 7.0]), "Should have ch1 data")
-        self.assertTrue(np.all(arr[1] == [2.0, 5.0, 8.0]), "Should have ch2 data")
+        self.assertTrue(np.all(arr[0] == [1.0, 4.0, 7.0]),
+                        "Should have ch1 data")
+        self.assertTrue(np.all(arr[1] == [2.0, 5.0, 8.0]),
+                        "Should have ch2 data")

--- a/bcipy/helpers/tests/test_triggers.py
+++ b/bcipy/helpers/tests/test_triggers.py
@@ -24,10 +24,10 @@ from bcipy.helpers.raw_data import sample_data, write
 import psychopy
 
 
-def write_sample_raw_data(raw_data_path: str,
-                          trigger_seq: List[Tuple[str, str]] = [],
-                          first_trg_time: int = 100,
-                          trigger_interval: int = 10) -> List[float]:
+def write_sample_trigger_data(raw_data_path: str,
+                              trigger_seq: List[Tuple[str, str]] = [],
+                              first_trg_time: int = 100,
+                              trigger_interval: int = 10) -> List[float]:
     """Writes a sample raw_data file, adding trigger data to a TRG column at
     the specified interval.
 
@@ -178,7 +178,8 @@ class TestTriggers(unittest.TestCase):
         # phrase?
         start_index = int(len(phrase) / 2)
         copy_text = phrase[start_index:]  # 'LLO'
-        trigger_times = write_sample_raw_data(self.raw_data_path, trigger_seq)
+        trigger_times = write_sample_trigger_data(self.raw_data_path,
+                                                  trigger_seq)
         extracted = extract_from_copy_phrase(self.raw_data_path,
                                              copy_text=copy_text,
                                              typed_text=copy_text)
@@ -208,7 +209,8 @@ class TestTriggers(unittest.TestCase):
         ]
 
         # Mock the raw_data file
-        trigger_times = write_sample_raw_data(self.raw_data_path, trigger_seq)
+        trigger_times = write_sample_trigger_data(self.raw_data_path,
+                                                  trigger_seq)
         extracted = extract_from_calibration(self.raw_data_path, inq_len=10)
 
         # Assertions
@@ -236,7 +238,8 @@ class TestTriggers(unittest.TestCase):
         ]
 
         # Mock the raw_data file
-        trigger_times = write_sample_raw_data(self.raw_data_path, trigger_seq)
+        trigger_times = write_sample_trigger_data(self.raw_data_path,
+                                                  trigger_seq)
         output = StringIO()
         write_trigger_file_from_lsl_calibration(self.raw_data_path,
                                                 output,
@@ -323,41 +326,37 @@ class TestWriteCopyPhrase(unittest.TestCase):
         # mock the write to avoid any extra files
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(
-            triggers,
-            self.trigger_file,
-            self.copy_phrase,
-            self.typed_text,
-            offset=True
-        )
+        _write_triggers_from_inquiry_copy_phrase(triggers,
+                                                 self.trigger_file,
+                                                 self.copy_phrase,
+                                                 self.typed_text,
+                                                 offset=True)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_nontarget(self):
-        triggers = ['L', 1]  # given the defined typed text the target would be P
+        triggers = ['L',
+                    1]  # given the defined typed text the target would be P
         expected = f'{triggers[0]} nontarget {triggers[1]}\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(
-            [triggers],
-            self.trigger_file,
-            self.copy_phrase,
-            self.typed_text,
-            offset=False
-        )
+        _write_triggers_from_inquiry_copy_phrase([triggers],
+                                                 self.trigger_file,
+                                                 self.copy_phrase,
+                                                 self.typed_text,
+                                                 offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_target(self):
-        triggers = ['P', 1]  # given the defined typed text the target would be P
+        triggers = ['P',
+                    1]  # given the defined typed text the target would be P
         expected = f'{triggers[0]} target {triggers[1]}\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(
-            [triggers],
-            self.trigger_file,
-            self.copy_phrase,
-            self.typed_text,
-            offset=False
-        )
+        _write_triggers_from_inquiry_copy_phrase([triggers],
+                                                 self.trigger_file,
+                                                 self.copy_phrase,
+                                                 self.typed_text,
+                                                 offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_fixation(self):
@@ -365,13 +364,11 @@ class TestWriteCopyPhrase(unittest.TestCase):
         expected = f'{triggers[0]} fixation {triggers[1]}\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(
-            [triggers],
-            self.trigger_file,
-            self.copy_phrase,
-            self.typed_text,
-            offset=False
-        )
+        _write_triggers_from_inquiry_copy_phrase([triggers],
+                                                 self.trigger_file,
+                                                 self.copy_phrase,
+                                                 self.typed_text,
+                                                 offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_inquiry_preview(self):
@@ -379,13 +376,11 @@ class TestWriteCopyPhrase(unittest.TestCase):
         expected = f'{triggers[0]} preview {triggers[1]}\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(
-            [triggers],
-            self.trigger_file,
-            self.copy_phrase,
-            self.typed_text,
-            offset=False
-        )
+        _write_triggers_from_inquiry_copy_phrase([triggers],
+                                                 self.trigger_file,
+                                                 self.copy_phrase,
+                                                 self.typed_text,
+                                                 offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_key_press(self):
@@ -394,77 +389,59 @@ class TestWriteCopyPhrase(unittest.TestCase):
         expected = f'{triggers[0]} key_press {triggers[1]}\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(
-            [triggers],
-            self.trigger_file,
-            self.copy_phrase,
-            self.typed_text,
-            offset=False
-        )
+        _write_triggers_from_inquiry_copy_phrase([triggers],
+                                                 self.trigger_file,
+                                                 self.copy_phrase,
+                                                 self.typed_text,
+                                                 offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_inquiry(self):
-        triggers = [
-            ['+', 1],
-            ['P', 2],
-            ['N', 3]
-        ]
+        triggers = [['+', 1], ['P', 2], ['N', 3]]
 
         when(self.trigger_file).write(any()).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(
-            triggers,
-            self.trigger_file,
-            self.copy_phrase,
-            self.typed_text,
-            offset=False
-        )
+        _write_triggers_from_inquiry_copy_phrase(triggers,
+                                                 self.trigger_file,
+                                                 self.copy_phrase,
+                                                 self.typed_text,
+                                                 offset=False)
         verify(self.trigger_file, times=3).write(any())
 
     def test_write_offset_multiple_triggers_fails(self):
         triggers = ['offset', 1]
 
         with self.assertRaises(ValueError):
-            _write_triggers_from_inquiry_copy_phrase(
-                [triggers],
-                self.trigger_file,
-                self.copy_phrase,
-                self.typed_text,
-                offset=True
-            )
+            _write_triggers_from_inquiry_copy_phrase([triggers],
+                                                     self.trigger_file,
+                                                     self.copy_phrase,
+                                                     self.typed_text,
+                                                     offset=True)
 
     def test_write_offset_backspace_target(self):
-        triggers = [
-            ['<', 1]
-        ]
+        triggers = [['<', 1]]
         # update the typed text to an incorrect letter given copy phrase
         typed_text = 'TEST_H'
         expected = '< target 1\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(
-            triggers,
-            self.trigger_file,
-            self.copy_phrase,
-            typed_text,
-            offset=False
-        )
+        _write_triggers_from_inquiry_copy_phrase(triggers,
+                                                 self.trigger_file,
+                                                 self.copy_phrase,
+                                                 typed_text,
+                                                 offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_calibration_trigger(self):
-        triggers = [
-            ['calibration_trigger', 1]
-        ]
+        triggers = [['calibration_trigger', 1]]
         expected = 'calibration_trigger calib 1\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(
-            triggers,
-            self.trigger_file,
-            self.copy_phrase,
-            self.typed_text,
-            offset=False
-        )
+        _write_triggers_from_inquiry_copy_phrase(triggers,
+                                                 self.trigger_file,
+                                                 self.copy_phrase,
+                                                 self.typed_text,
+                                                 offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
 
@@ -487,23 +464,18 @@ class TestCalibrationTrigger(unittest.TestCase):
     def test_image_calibration_trigger(self):
         trigger_type = 'image'
         image_mock = mock()
-        when(psychopy.visual).ImageStim(
-            win=self.display,
-            image=any(),
-            pos=any(),
-            mask=any(),
-            ori=any()).thenReturn(image_mock)
+        when(psychopy.visual).ImageStim(win=self.display,
+                                        image=any(),
+                                        pos=any(),
+                                        mask=any(),
+                                        ori=any()).thenReturn(image_mock)
         when(self.display).callOnFlip(any(), any(), any())
         when(image_mock).draw()
         when(self.display).flip()
         when(psychopy.core).wait(self.trigger_time)
 
-        _calibration_trigger(
-            self.clock,
-            trigger_type,
-            self.trigger_name,
-            self.trigger_time,
-            self.display)
+        _calibration_trigger(self.clock, trigger_type, self.trigger_name,
+                             self.trigger_time, self.display)
 
         verify(self.display, times=1).callOnFlip(any(), any(), any())
         verify(image_mock, times=1).draw()
@@ -514,25 +486,19 @@ class TestCalibrationTrigger(unittest.TestCase):
         trigger_type = 'image'
         image_mock = mock()
         on_trigger = mock()
-        when(psychopy.visual).ImageStim(
-            win=self.display,
-            image=any(),
-            pos=any(),
-            mask=any(),
-            ori=any()).thenReturn(image_mock)
+        when(psychopy.visual).ImageStim(win=self.display,
+                                        image=any(),
+                                        pos=any(),
+                                        mask=any(),
+                                        ori=any()).thenReturn(image_mock)
         when(self.display).callOnFlip(any(), any(), any())
         when(self.display).callOnFlip(on_trigger, self.trigger_name)
         when(image_mock).draw()
         when(self.display).flip()
         when(psychopy.core).wait(self.trigger_time)
 
-        _calibration_trigger(
-            self.clock,
-            trigger_type,
-            self.trigger_name,
-            self.trigger_time,
-            self.display,
-            on_trigger)
+        _calibration_trigger(self.clock, trigger_type, self.trigger_name,
+                             self.trigger_time, self.display, on_trigger)
 
         verify(self.display, times=1).callOnFlip(any(), any(), any())
         verify(self.display, times=1).callOnFlip(on_trigger, self.trigger_name)
@@ -543,18 +509,15 @@ class TestCalibrationTrigger(unittest.TestCase):
     def test_text_calibration_trigger(self):
         trigger_type = 'text'
         text_mock = mock()
-        when(psychopy.visual).TextStim(self.display, text='').thenReturn(text_mock)
+        when(psychopy.visual).TextStim(self.display,
+                                       text='').thenReturn(text_mock)
         when(self.display).callOnFlip(any(), any(), any())
         when(text_mock).draw()
         when(self.display).flip()
         when(psychopy.core).wait(self.trigger_time)
 
-        _calibration_trigger(
-            self.clock,
-            trigger_type,
-            self.trigger_name,
-            self.trigger_time,
-            self.display)
+        _calibration_trigger(self.clock, trigger_type, self.trigger_name,
+                             self.trigger_time, self.display)
 
         verify(self.display, times=1).callOnFlip(any(), any(), any())
         verify(text_mock, times=1).draw()
@@ -565,20 +528,16 @@ class TestCalibrationTrigger(unittest.TestCase):
         trigger_type = 'text'
         text_mock = mock()
         on_trigger = mock()
-        when(psychopy.visual).TextStim(self.display, text='').thenReturn(text_mock)
+        when(psychopy.visual).TextStim(self.display,
+                                       text='').thenReturn(text_mock)
         when(self.display).callOnFlip(any(), any(), any())
         when(self.display).callOnFlip(on_trigger, self.trigger_name)
         when(text_mock).draw()
         when(self.display).flip()
         when(psychopy.core).wait(self.trigger_time)
 
-        _calibration_trigger(
-            self.clock,
-            trigger_type,
-            self.trigger_name,
-            self.trigger_time,
-            self.display,
-            on_trigger)
+        _calibration_trigger(self.clock, trigger_type, self.trigger_name,
+                             self.trigger_time, self.display, on_trigger)
 
         verify(self.display, times=1).callOnFlip(any(), any(), any())
         verify(self.display, times=1).callOnFlip(on_trigger, self.trigger_name)
@@ -589,13 +548,8 @@ class TestCalibrationTrigger(unittest.TestCase):
     def test_exception_invalid_calibration_trigger_type(self):
         trigger_type = 'invalid_type'
         with self.assertRaises(BciPyCoreException):
-            _calibration_trigger(
-                self.clock,
-                trigger_type,
-                self.trigger_name,
-                self.trigger_time,
-                self.display
-            )
+            _calibration_trigger(self.clock, trigger_type, self.trigger_name,
+                                 self.trigger_time, self.display)
 
     def test_exception_no_display_calibration_trigger_type(self):
         trigger_type = 'image'

--- a/bcipy/helpers/visualization.py
+++ b/bcipy/helpers/visualization.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
-from bcipy.helpers.load import load_csv_data, read_data_csv
+from bcipy.helpers.load import choose_csv_file, load_raw_data
 from mne.io import read_raw_edf
 from typing import List
 
@@ -153,8 +153,8 @@ def visualize_csv_eeg_triggers(trigger_col=None):
         Figure of Triggers
     """
     # Load in CSV
-    file_name = load_csv_data()
-    raw_data, stamp_time, channels, type_amp, fs = read_data_csv(file_name)
+    data = load_raw_data(choose_csv_file())
+    raw_data = data.by_channel()
 
     # Pull out the triggers
     if not trigger_col:


### PR DESCRIPTION
# Overview

Many BciPy modules depend on our raw_data.csv format to be structured in a specific way, and the code that writes and reads this data format is repeated in several places throughout the codebase. This PR creates a raw_data module that provides an interface for reading and writing the raw data format without knowing the details of its implementation.

## Ticket

https://www.pivotaltracker.com/story/show/175674845

## Contributions

- Created a single module responsible for reading and writing data into our raw data format.
- Added unit tests for all module functionality.
- Refactored existing code to use the new module.
- Provided methods to generate sample data for tests.
- Refactored existing tests to use data generated from the module (see test_convert.py and test_triggers.py).

## Test

- Ran all unit and integration tests.
- Ran a copy phrase task and performed offline analysis to confirm that this functionality still worked.
- Started the data viewer with a setting to read from an existing raw_data.csv file to confirm that this functionality still works.

