### PR TITLE
#179057693 ; Analysis Channels

### DIFF
--- a/bcipy/acquisition/devices.json
+++ b/bcipy/acquisition/devices.json
@@ -6,7 +6,8 @@
             "T5", "O1", "O2", "X3", "X2", "F7", "F8", "X1", "A2", "T6", "T4", "TRG" ],
         "connection_methods": [ "TCP", "LSL" ],
         "sample_rate": 300.0,
-        "description": "Wearable Sensing DSI-24"
+        "description": "Wearable Sensing DSI-24",
+        "excluded_from_analysis": ["Pz", "TRG", "X1", "X2", "X3"]
     },
     {
         "name": "DSI-VR300",
@@ -14,7 +15,8 @@
         "channels": [ "P4", "Fz", "Pz", "F7", "PO8", "PO7", "Oz", "TRG" ],
         "sample_rate": 300.0,
         "connection_methods": ["TCP", "LSL"],
-        "description": "Wearable Sensing DSI-VR300"
+        "description": "Wearable Sensing DSI-VR300",
+        "excluded_from_analysis": ["TRG"]
     },
     {
         "name": "g.USBamp-1",
@@ -28,11 +30,12 @@
     {
         "name": "DSI",
         "content_type": "EEG",
-        "channels": [ "P3", "C3", "F3", "Fz", "F4", "C4", "P4",  "Cz", "A1", "Fp1", "Fp2", "T3",
-            "T5", "O1", "O2", "F7", "F8", "A2", "T6", "T4", "TRG" ],
+        "channels": [ "P3", "C3", "F3", "Fz", "F4", "C4", "P4", "Cz", "Pz", "Fp1", "Fp2", "T3",
+            "T5", "O1", "O2", "X3", "X2", "F7", "F8", "X1", "A2", "T6", "T4", "TRG" ],
         "connection_methods": [ "TCP", "LSL" ],
         "sample_rate": 300.0,
-        "description": "Alias to DSI-24 for backwards compatibility and demos."
+        "description": "Alias to DSI-24 for backwards compatibility and demos.",
+        "excluded_from_analysis": ["Pz", "TRG", "X1", "X2", "X3"]
     },
     {
         "name": "LSL",
@@ -49,6 +52,7 @@
         "channels": [ "P4", "Fz", "Pz", "F7", "PO8", "PO7", "Oz", "TRG" ],
         "sample_rate": 300.0,
         "connection_methods": ["TCP", "LSL"],
-        "description": "Alias to DSI-VR300 for backwards compatibility."
+        "description": "Alias to DSI-VR300 for backwards compatibility.",
+        "excluded_from_analysis": ["TRG"]
     }
 ]

--- a/bcipy/acquisition/devices.json
+++ b/bcipy/acquisition/devices.json
@@ -7,7 +7,7 @@
         "connection_methods": [ "TCP", "LSL" ],
         "sample_rate": 300.0,
         "description": "Wearable Sensing DSI-24",
-        "excluded_from_analysis": ["Pz", "TRG", "X1", "X2", "X3"]
+        "excluded_from_analysis": ["TRG", "X1", "X2", "X3", "A2"]
     },
     {
         "name": "DSI-VR300",
@@ -35,7 +35,7 @@
         "connection_methods": [ "TCP", "LSL" ],
         "sample_rate": 300.0,
         "description": "Alias to DSI-24 for backwards compatibility and demos.",
-        "excluded_from_analysis": ["Pz", "TRG", "X1", "X2", "X3"]
+        "excluded_from_analysis": ["TRG", "X1", "X2", "X3", "A2"]
     },
     {
         "name": "LSL",

--- a/bcipy/acquisition/tests/test_devices.py
+++ b/bcipy/acquisition/tests/test_devices.py
@@ -101,6 +101,13 @@ class TestDeviceSpecs(unittest.TestCase):
                                   channels=['C1', 'C2', 'C3', 'TRG'],
                                   sample_rate=256.0)
 
-        self.assertEqual(['C1', 'C2', 'C3'], spec.analysis_channels())
+        self.assertEqual(['C1', 'C2', 'C3'], spec.analysis_channels)
+        spec.excluded_from_analysis = []
         self.assertEqual(['C1', 'C2', 'C3', 'TRG'],
-                         spec.analysis_channels(exclude_trg=False))
+                         spec.analysis_channels)
+
+        spec2 = devices.DeviceSpec(name='Device2',
+                                  channels=['C1', 'C2', 'C3', 'TRG'],
+                                  sample_rate=256.0,
+                                  excluded_from_analysis=['C1', 'TRG'])
+        self.assertEqual(['C2', 'C3'], spec2.analysis_channels)

--- a/bcipy/helpers/acquisition.py
+++ b/bcipy/helpers/acquisition.py
@@ -133,7 +133,7 @@ def analysis_channels(channels: List[str], device_name: str) -> list:
         If i'th element is 0, i'th channel in filtered_eeg is removed.
     """
     device = supported_device(device_name)
-    relevant_channels = device.analysis_channels()
+    relevant_channels = device.analysis_channels
     if not relevant_channels:
         raise Exception("Analysis channels for the given device not found: "
                         f"{device_name}.")


### PR DESCRIPTION
# Overview

We need the ability to configure which channels are used for analysis (or excluded). Prior to refactoring to use DeviceSpecs, we maintained a list of analysis channels for each device. However, this information was lost in the refactor and the code currently uses all channels (except 'TRG'). This pull request modifies the DeviceSpec class with an additional attribute that allows us to configure channels which should be ignored for modeling purposes.

## Ticket

https://www.pivotaltracker.com/story/show/179057693

## Contributions

- Created additional DeviceSpec parameter
- Updated devices.json configuration with channels to exclude
- Updated the acquisition helper
- Updated unit tests

## Test

- Ran the test suite to confirm that all unit tests pass
