### PR TITLE
AUC output fix + report timing

### DIFF
--- a/bcipy/acquisition/devices.py
+++ b/bcipy/acquisition/devices.py
@@ -13,6 +13,7 @@ _SUPPORTED_DEVICES = {}
 
 log = logging.getLogger(__name__)
 
+
 @auto_str
 class DeviceSpec:
     """Specification for a hardware device used in data acquisition.

--- a/bcipy/acquisition/tests/test_devices.py
+++ b/bcipy/acquisition/tests/test_devices.py
@@ -99,7 +99,8 @@ class TestDeviceSpecs(unittest.TestCase):
         """DeviceSpec should have a list of channels used for analysis."""
         spec = devices.DeviceSpec(name='TestDevice',
                                   channels=['C1', 'C2', 'C3', 'TRG'],
-                                  sample_rate=256.0)
+                                  sample_rate=256.0,
+                                  excluded_from_analysis=['TRG'])
 
         self.assertEqual(['C1', 'C2', 'C3'], spec.analysis_channels)
         spec.excluded_from_analysis = []
@@ -107,7 +108,7 @@ class TestDeviceSpecs(unittest.TestCase):
                          spec.analysis_channels)
 
         spec2 = devices.DeviceSpec(name='Device2',
-                                  channels=['C1', 'C2', 'C3', 'TRG'],
-                                  sample_rate=256.0,
-                                  excluded_from_analysis=['C1', 'TRG'])
+                                   channels=['C1', 'C2', 'C3', 'TRG'],
+                                   sample_rate=256.0,
+                                   excluded_from_analysis=['C1', 'TRG'])
         self.assertEqual(['C2', 'C3'], spec2.analysis_channels)

--- a/bcipy/helpers/system_utils.py
+++ b/bcipy/helpers/system_utils.py
@@ -10,6 +10,7 @@ import psutil
 import pyglet
 import importlib
 import pkgutil
+import time
 import logging
 
 
@@ -220,3 +221,14 @@ def log_to_stdout():
         '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     handler.setFormatter(formatter)
     root.addHandler(handler)
+
+
+def report_execution_time(method):
+    log = logging.getLogger()
+    def wrap(*args, **kwargs):
+        time1 = time.perf_counter_ns()
+        response = method(*args, **kwargs)
+        time2 = time.perf_counter_ns()
+        log.info('{:s} method took {:.4f} s'.format(method.__name__, (time2-time1)))
+        return response
+    return wrap

--- a/bcipy/helpers/system_utils.py
+++ b/bcipy/helpers/system_utils.py
@@ -141,7 +141,7 @@ def configure_logger(
     root_logger.setLevel(log_level)
     handler = logging.FileHandler(logfile, 'w', encoding='utf-8')
     handler.setFormatter(logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+        '[%(threadName)-9s][%(asctime)s][%(name)s][%(levelname)s]: %(message)s'))
     root_logger.addHandler(handler)
 
     print(f'Printing all BciPy logs to: {logfile}')
@@ -219,12 +219,12 @@ def log_to_stdout():
     handler = logging.StreamHandler(sys.stdout)
     handler.setLevel(logging.DEBUG)
     formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        '[%(threadName)-9s][%(asctime)s][%(name)s][%(levelname)s]: %(message)s')
     handler.setFormatter(formatter)
     root.addHandler(handler)
 
 
-def report_execution_time(func: Callable):
+def report_execution_time(func: Callable) -> Callable:
     """Report execution time.
 
     A decorator to log execution time of methods in seconds. To use,
@@ -236,6 +236,6 @@ def report_execution_time(func: Callable):
         time1 = time.perf_counter()
         response = func(*args, **kwargs)
         time2 = time.perf_counter()
-        log.info('{:s} method took {:0.4f} s'.format(func.__name__, (time2 - time1)))
+        log.info('{:s} method took {:0.4f}s to execute'.format(func.__name__, (time2 - time1)))
         return response
     return wrap

--- a/bcipy/helpers/system_utils.py
+++ b/bcipy/helpers/system_utils.py
@@ -2,7 +2,7 @@ import sys
 import os
 
 from cpuinfo import get_cpu_info
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Callable
 from pathlib import Path
 import pkg_resources
 import platform
@@ -140,7 +140,8 @@ def configure_logger(
     root_logger = logging.getLogger()
     root_logger.setLevel(log_level)
     handler = logging.FileHandler(logfile, 'w', encoding='utf-8')
-    handler.setFormatter(logging.Formatter('(%(threadName)-9s) %(message)s'))
+    handler.setFormatter(logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
     root_logger.addHandler(handler)
 
     print(f'Printing all BciPy logs to: {logfile}')
@@ -223,12 +224,18 @@ def log_to_stdout():
     root.addHandler(handler)
 
 
-def report_execution_time(method):
+def report_execution_time(func: Callable):
+    """Report execution time.
+
+    A decorator to log execution time of methods in seconds. To use,
+        decorate your method with @report_execution_time.
+    """
     log = logging.getLogger()
+
     def wrap(*args, **kwargs):
-        time1 = time.perf_counter_ns()
-        response = method(*args, **kwargs)
-        time2 = time.perf_counter_ns()
-        log.info('{:s} method took {:.4f} s'.format(method.__name__, (time2-time1)))
+        time1 = time.perf_counter()
+        response = func(*args, **kwargs)
+        time2 = time.perf_counter()
+        log.info('{:s} method took {:0.4f} s'.format(func.__name__, (time2 - time1)))
         return response
     return wrap

--- a/bcipy/helpers/tests/test_raw_data.py
+++ b/bcipy/helpers/tests/test_raw_data.py
@@ -34,7 +34,7 @@ class TestRawData(unittest.TestCase):
     def _write_raw_data(self, include_rows=False) -> RawData:
         """Helper function to write a sample raw data file to disk using the
         settings from setUp.
-        
+
         Parameters
         ----------
         - include_rows : if True adds data, otherwise just writes the metadata

--- a/bcipy/signal/model/offline_analysis.py
+++ b/bcipy/signal/model/offline_analysis.py
@@ -18,7 +18,7 @@ from matplotlib.figure import Figure
 log = logging.getLogger(__name__)
 logging.basicConfig(
     level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    format='[%(threadName)-9s][%(asctime)s][%(name)s][%(levelname)s]: %(message)s')
 
 
 @report_execution_time

--- a/bcipy/signal/model/offline_analysis.py
+++ b/bcipy/signal/model/offline_analysis.py
@@ -8,6 +8,7 @@ from bcipy.helpers.load import (
     load_raw_data,
 )
 from bcipy.helpers.stimuli import play_sound
+from bcipy.helpers.system_utils import report_execution_time
 from bcipy.helpers.triggers import trigger_decoder
 from bcipy.helpers.visualization import generate_offline_analysis_screen
 from bcipy.signal.model.pca_rda_kde import PcaRdaKdeModel
@@ -15,8 +16,11 @@ from bcipy.signal.process import get_default_transform
 from matplotlib.figure import Figure
 
 log = logging.getLogger(__name__)
+logging.basicConfig(
+        level=logging.INFO,
+        format='(%(threadName)-9s) %(message)s')
 
-
+@report_execution_time
 def offline_analysis(data_folder: str = None,
                      parameters: dict = {}, alert_finished: bool = True) -> List[Figure]:
     """ Gets calibration data and trains the model in an offline fashion.
@@ -131,10 +135,6 @@ if __name__ == "__main__":
     parser.add_argument('-p', '--parameters_file',
                         default='bcipy/parameters/parameters.json')
     args = parser.parse_args()
-
-    logging.basicConfig(
-        level=logging.DEBUG,
-        format='(%(threadName)-9s) %(message)s')
 
     log.info(f'Loading params from {args.parameters_file}')
     parameters = load_json_parameters(args.parameters_file,

--- a/bcipy/signal/model/offline_analysis.py
+++ b/bcipy/signal/model/offline_analysis.py
@@ -17,8 +17,9 @@ from matplotlib.figure import Figure
 
 log = logging.getLogger(__name__)
 logging.basicConfig(
-        level=logging.INFO,
-        format='(%(threadName)-9s) %(message)s')
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
 
 @report_execution_time
 def offline_analysis(data_folder: str = None,

--- a/bcipy/signal/model/offline_analysis.py
+++ b/bcipy/signal/model/offline_analysis.py
@@ -107,18 +107,18 @@ def offline_analysis(data_folder: str = None,
         offset=offset,
         channel_map=channel_map,
         trial_length=trial_length)
+
+    log.info('Training model. This will take some time...')
     model.fit(data, labels)
     model_performance = model.evaluate(data, labels)
 
-    log.info('Saving offline analysis plots!')
+    log.info(f'Training complete [AUC={model_performance.auc:0.4f}]. Saving data...')
 
     fig_handles = generate_offline_analysis_screen(
         data, labels, model=model, folder=data_folder,
         down_sample_rate=downsample_rate,
         fs=fs, save_figure=True, show_figure=False,
         channel_names=analysis_channel_names_by_pos(channels, channel_map))
-
-    log.info('Saving the model!')
     model.save(data_folder + f'/model_{model_performance.auc:0.4f}.pkl')
 
     if alert_finished:
@@ -141,5 +141,4 @@ if __name__ == "__main__":
     parameters = load_json_parameters(args.parameters_file,
                                       value_cast=True)
     offline_analysis(args.data_folder, parameters)
-
     log.info('Offline Analysis complete.')


### PR DESCRIPTION
# Overview

Update offline analysis to log level INFO to avoid unnecessary output into the terminal. Add `report_execution_time` to system_utils and implement in offline_analysis.

## Ticket

https://www.pivotaltracker.com/story/show/176582548

## Contributions

- `offline_analysis`: Update log level to `INFO`. Add `report_execution_time` decorator
- `system_utils`: Add `report_execution_time` decorator

## Test

- `make test-all`
- `python offline_analysis.py -d {my_local_data}`: successfully trains model that can be imported in copy phrase.

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? N/A
