### PR TITLE
Language model base class

### DIFF
--- a/bcipy/language/README.md
+++ b/bcipy/language/README.md
@@ -1,0 +1,14 @@
+# Language
+
+BciPy Language module provides an interface for word and character level predictions. 
+
+The core methods of any `LanguageModel` include:
+
+> `predict` - given typing evidence input, return a prediction (character or word).
+
+> `load` - load a pre-trained model given a path (currently BciPy does not support training language models!)
+
+> `update` - update internal state of your model.
+
+You may of course define other methods, however all integrated BciPy experiments using your model will require those to be defined!
+

--- a/bcipy/language/main.py
+++ b/bcipy/language/main.py
@@ -35,3 +35,11 @@ class LanguageModel(ABC):
     def load(self, path: Path) -> None:
         """Restore model state from the provided checkpoint"""
         ...
+
+    def reset(self) -> None:
+        """Reset language model state"""
+        ...
+
+    def state_update(self, evidence: List[Tuple]) -> None:
+        """Update state by predicting and updating"""
+        ...

--- a/bcipy/language/main.py
+++ b/bcipy/language/main.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Tuple, List, Union
+from enum import Enum
+
+
+class ResponseType(Enum):
+    SYMBOL = 'Symbol'
+    WORD = 'Word'
+
+
+class LanguageModel(ABC):
+
+    response_type: ResponseType
+    symbol_set: List[str]
+
+    @abstractmethod
+    def predict(self, evidence: List[Tuple]) -> List[tuple]:
+        """
+        Using the provided data, compute log likelihoods over the entire symbol set.
+        Args:
+            evidence - [('A', .08), ('B', .1)]
+
+        Response:
+            probability - dependant on response type, a list of words or symbols with probability 
+        """
+        ...
+
+    @abstractmethod
+    def update(self) -> None:
+        """Update the model state"""
+        ...
+
+    @abstractmethod
+    def load(self, path: Path) -> None:
+        """Restore model state from the provided checkpoint"""
+        ...

--- a/bcipy/language/main.py
+++ b/bcipy/language/main.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Tuple, List, Union
+from typing import Tuple, List
 from enum import Enum
 
 
@@ -22,7 +22,7 @@ class LanguageModel(ABC):
             evidence - [('A', .08), ('B', .1)]
 
         Response:
-            probability - dependant on response type, a list of words or symbols with probability 
+            probability - dependant on response type, a list of words or symbols with probability
         """
         ...
 


### PR DESCRIPTION
# Overview

Added the language model base class. This will serve as the building block for all new language models in BciPy V2. The `language_model` module will be deprecated. 

## Ticket

https://www.pivotaltracker.com/story/show/178695658

## Contributions

- Add `language` module and `main.py`. Contains ABC for `LanguageModel` in line with our team redesign. 
- Add README describing module briefly. 


![Langauge Model Redesign](https://user-images.githubusercontent.com/11506578/128101749-584eaf43-8260-441e-81c9-159927abf01c.png)


## Test

- `make test-all`

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.
