### PR TITLE
Keypress clock fix

### DIFF
--- a/bcipy/display/tests/rsvp/test_rsvp_display.py
+++ b/bcipy/display/tests/rsvp/test_rsvp_display.py
@@ -1,6 +1,7 @@
 import unittest
 
 import psychopy
+from mock import patch
 from mockito import (
     any,
     mock,
@@ -171,7 +172,8 @@ class TestRSVPDisplayInquiryPreview(unittest.TestCase):
         response = self.rsvp._generate_inquiry_preview()
         self.assertEqual(response, stim_mock)
 
-    def test_preview_inquiry_evoked_press_to_accept_pressed(self):
+    @patch('bcipy.display.rsvp.display.get_key_press')
+    def test_preview_inquiry_evoked_press_to_accept_pressed(self, get_key_press_mock):
         stim_mock = mock()
         # mock the stimulus generation
         when(self.rsvp)._generate_inquiry_preview().thenReturn(stim_mock)
@@ -183,15 +185,17 @@ class TestRSVPDisplayInquiryPreview(unittest.TestCase):
         # skip the core wait for testing
         when(psychopy.core).wait(self.preview_inquiry.preview_inquiry_isi).thenReturn()
         key_timestamp = 1000
-        key_response = [[self.preview_inquiry_key_input, key_timestamp]]
-        when(psychopy.event).getKeys(keyList=any(), timeStamped=any()).thenReturn(key_response)
+        get_key_press_mock.return_value = [
+            f'bcipy_key_press_{self.preview_inquiry_key_input}', key_timestamp
+        ]
         response = self.rsvp.preview_inquiry()
         # we expect the trigger callback to return none, the key press to return the time and key press message,
         #  The second item should be True as it is press to accept and a response was returned
         expected = ([None, [f'bcipy_key_press_{self.preview_inquiry_key_input}', key_timestamp]], True)
         self.assertEqual(response, expected)
 
-    def test_preview_inquiry_evoked_press_to_skip_pressed(self):
+    @patch('bcipy.display.rsvp.display.get_key_press')
+    def test_preview_inquiry_evoked_press_to_skip_pressed(self, get_key_press_mock):
         # set the progress method to press to skip
         self.rsvp._preview_inquiry.press_to_accept = False
         stim_mock = mock()
@@ -205,15 +209,17 @@ class TestRSVPDisplayInquiryPreview(unittest.TestCase):
         # skip the core wait for testing
         when(psychopy.core).wait(self.preview_inquiry.preview_inquiry_isi).thenReturn()
         key_timestamp = 1000
-        key_response = [[self.preview_inquiry_key_input, key_timestamp]]
-        when(psychopy.event).getKeys(keyList=any(), timeStamped=any()).thenReturn(key_response)
+        get_key_press_mock.return_value = [
+            f'bcipy_key_press_{self.preview_inquiry_key_input}', key_timestamp
+        ]
         response = self.rsvp.preview_inquiry()
         # we expect the trigger callback to return none, the key press to return the time and key press message,
         #  The second item should be False as it is press to skip and a response was returned
         expected = ([None, [f'bcipy_key_press_{self.preview_inquiry_key_input}', key_timestamp]], False)
         self.assertEqual(response, expected)
 
-    def test_preview_inquiry_evoked_press_to_accept_not_pressed(self):
+    @patch('bcipy.display.rsvp.display.get_key_press')
+    def test_preview_inquiry_evoked_press_to_accept_not_pressed(self, get_key_press_mock):
         stim_mock = mock()
         # mock the stimulus generation
         when(self.rsvp)._generate_inquiry_preview().thenReturn(stim_mock)
@@ -224,14 +230,15 @@ class TestRSVPDisplayInquiryPreview(unittest.TestCase):
 
         # skip the core wait for testing
         when(psychopy.core).wait(self.preview_inquiry.preview_inquiry_isi).thenReturn()
-        when(psychopy.event).getKeys(keyList=any(), timeStamped=any()).thenReturn(None)
+        get_key_press_mock.return_value = None
         response = self.rsvp.preview_inquiry()
         # we expect the trigger callback to return none, the key press to return the time and key press message,
         #  The second item should be True as it is press to accept and a response was returned
         expected = ([None], False)
         self.assertEqual(response, expected)
 
-    def test_preview_inquiry_evoked_press_to_skip_not_pressed(self):
+    @patch('bcipy.display.rsvp.display.get_key_press')
+    def test_preview_inquiry_evoked_press_to_skip_not_pressed(self, get_key_press_mock):
         # set the progress method to press to skip
         self.rsvp._preview_inquiry.press_to_accept = False
         stim_mock = mock()
@@ -244,7 +251,7 @@ class TestRSVPDisplayInquiryPreview(unittest.TestCase):
 
         # skip the core wait for testing
         when(psychopy.core).wait(self.preview_inquiry.preview_inquiry_isi).thenReturn()
-        when(psychopy.event).getKeys(keyList=any(), timeStamped=any()).thenReturn(None)
+        get_key_press_mock.return_value = None
         response = self.rsvp.preview_inquiry()
         # we expect the trigger callback to return none, the key press to return the time and key press message,
         #  The second item should be False as it is press to skip and a response was returned

--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -331,9 +331,15 @@ def get_key_press(
     -------
         Key Press Timing(List[stamp_label, timestamp])
     """
-    response = event.getKeys(keyList=key_list, timeStamped=clock)
+    response = event.getKeys(keyList=key_list, timeStamped=True)
     if response:
-        return [f'{stamp_label}_{response[0][0]}', response[0][1]]
+        # The timestamp from the response uses the psychopy.core.monotonicClock
+        # which records the number of seconds since the experiment start (core
+        # was imported).
+        key, stamp = response[0]
+        offset = clock.getTime() - core.getTime()
+        timestamp = stamp + offset
+        return [f'{stamp_label}_{key}', timestamp]
     return None
 
 

--- a/bcipy/helpers/tests/test_task.py
+++ b/bcipy/helpers/tests/test_task.py
@@ -189,13 +189,31 @@ class TestGetKeyPress(unittest.TestCase):
         clock = mock()
         # get keys returns a list of lists with the key and timestamp per hit
         key_response = [[key_list[0], 1000]]
-        when(psychopy.event).getKeys(keyList=key_list, timeStamped=clock).thenReturn(key_response)
-
+        when(psychopy.event).getKeys(keyList=key_list,
+                                     timeStamped=True).thenReturn(key_response)
+        when(clock).getTime().thenReturn(psychopy.core.getTime())
         # use the default label
         stamp_label = 'bcipy_key_press'
         expected = [f'{stamp_label}_{key_response[0][0]}', key_response[0][1]]
         response = get_key_press(key_list, clock)
-        self.assertEqual(expected, response)
+        self.assertEqual(expected[0], response[0])
+        self.assertAlmostEqual(expected[1], response[1], delta=0.01)
+
+    def test_get_key_press_clock_adjustment(self):
+        """Test for the stamp label defaults, ensures the calls occur with the correct inputs to psychopy"""
+        key_list = ['space']
+        clock = mock()
+        # get keys returns a list of lists with the key and timestamp per hit
+        key_response = [[key_list[0], 1000]]
+        when(psychopy.event).getKeys(keyList=key_list,
+                                     timeStamped=True).thenReturn(key_response)
+        when(clock).getTime().thenReturn(psychopy.core.getTime() + 100)
+        # use the default label
+        stamp_label = 'bcipy_key_press'
+        expected = [f'{stamp_label}_{key_response[0][0]}', key_response[0][1]]
+        response = get_key_press(key_list, clock)
+        self.assertEqual(expected[0], response[0])
+        self.assertAlmostEqual(1100, response[1], delta=0.01)
 
     def test_get_key_press_returns_none_if_no_keys_pressed(self):
         """Test for the case not keys are returned, ensures the calls occur with the correct inputs to psychopy"""
@@ -203,7 +221,8 @@ class TestGetKeyPress(unittest.TestCase):
         key_list = ['space']
         key_response = None
         clock = mock()
-        when(psychopy.event).getKeys(keyList=key_list, timeStamped=clock).thenReturn(key_response)
+        when(psychopy.event).getKeys(keyList=key_list,
+                                     timeStamped=True).thenReturn(key_response)
 
         response = get_key_press(key_list, clock)
         self.assertEqual(None, response)
@@ -214,13 +233,15 @@ class TestGetKeyPress(unittest.TestCase):
         key_list = ['space']
         # get keys returns a list of lists with the key and timestamp per hit
         key_response = [[key_list[0], 1000]]
-        when(psychopy.event).getKeys(keyList=key_list, timeStamped=clock).thenReturn(key_response)
-
+        when(psychopy.event).getKeys(keyList=key_list,
+                                     timeStamped=True).thenReturn(key_response)
+        when(clock).getTime().thenReturn(psychopy.core.getTime())
         # set a custom label
         stamp_label = 'custom_label'
         expected = [f'{stamp_label}_{key_response[0][0]}', key_response[0][1]]
         response = get_key_press(key_list, clock, stamp_label=stamp_label)
-        self.assertEqual(expected, response)
+        self.assertEqual(expected[0], response[0])
+        self.assertAlmostEqual(expected[1], response[1], delta=0.01)
 
 
 class TestTriggers(unittest.TestCase):


### PR DESCRIPTION
# Overview

Fix a bug in the task helper `get_key_press` method introduced by recent changes to the experiment clock.

## Ticket

https://www.pivotaltracker.com/story/show/179628895

## Contributions

- Refactored get_key_press to convert the timestamp after it is retrieved from psychopy.

## Test

- Run Copy Phrase with the Inquiry Preview feature. The keypress should not throw an exception. The stamp associated with the keypress in the triggers.txt file should have a value greater than the preceding inquiry_preview trigger and less than the fixation trigger.

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.
