### PR TITLE
InsufficientDataException fix

### DIFF
--- a/bcipy/acquisition/protocols/lsl/lsl_client.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_client.py
@@ -13,6 +13,7 @@ from bcipy.acquisition.protocols.lsl.lsl_connector import (channel_names,
 from bcipy.acquisition.protocols.lsl.lsl_recorder import LslRecordingThread
 from bcipy.acquisition.record import Record
 from bcipy.helpers.clock import Clock
+from bcipy.gui.viewer.ring_buffer import RingBuffer
 
 log = logging.getLogger(__name__)
 
@@ -55,6 +56,7 @@ class LslAcquisitionClient:
         self.raw_data_file_name = raw_data_file_name
 
         self.recorder = None
+        self.buffer = None
 
     def start_acquisition(self) -> bool:
         """Connect to the datasource and start acquiring data.
@@ -86,6 +88,7 @@ class LslAcquisitionClient:
                                                self.raw_data_file_name)
             self.recorder.start()
 
+        self.buffer = RingBuffer(size_max=self.max_samples)
         _, self._first_sample_time = self.inlet.pull_sample()
         return True
 
@@ -106,6 +109,8 @@ class LslAcquisitionClient:
         if self.recorder:
             self.recorder.stop()
             self.recorder.join()
+
+        self.buffer = None
 
     def __enter__(self):
         """Context manager enter method that starts data acquisition."""
@@ -132,36 +137,31 @@ class LslAcquisitionClient:
         -------
             List of Records
         """
-
         log.debug(f"Getting data from: {start} to: {end} limit: {limit}")
 
-        # Implementation Notes:
-        #   - Only data in the current buffer is available to query;
-        #     requests for data outside of this will fail. Buffer size is
-        #     set using the max_buflen parameter.
-        #   - Pulling data depletes the buffer so a subsequent query with
-        #     the same parameters will fail. If this becomes a requirement,
-        #     consider caching the last query result.
+        # Only data in the current buffer is available to query;
+        # requests for data outside of this will fail. Buffer size is
+        # set using the max_buflen parameter.
         data = self.get_latest_data()
 
-        if data:
-            log.debug(
-                (f'{len(data)} records available '
-                 f'(From: {data[0].timestamp} To: {data[-1].timestamp})'))
-            start = start or data[0].timestamp
-            end = end or data[-1].timestamp
-            limit = limit or -1
-            assert start >= data[0].timestamp, (
-                f'Start time of {start} is out of range: '
-                f'({data[0].timestamp} to {data[-1].timestamp}).')
+        if not data:
+            log.debug('No records available')
+            return []
 
-            data_slice = [
-                record for record in data if start <= record.timestamp <= end
-            ][0:limit]
-            log.debug(f'{len(data_slice)} records returned')
-            return data_slice
-        log.debug('No records available')
-        return []
+        log.debug((f'{len(data)} records available '
+                   f'(From: {data[0].timestamp} To: {data[-1].timestamp})'))
+        start = start or data[0].timestamp
+        end = end or data[-1].timestamp
+        limit = limit or -1
+        assert start >= data[0].timestamp, (
+            f'Start time of {start} is out of range: '
+            f'({data[0].timestamp} to {data[-1].timestamp}).')
+
+        data_slice = [
+            record for record in data if start <= record.timestamp <= end
+        ][0:limit]
+        log.debug(f'{len(data_slice)} records returned')
+        return data_slice
 
     @property
     def max_samples(self) -> int:
@@ -169,18 +169,19 @@ class LslAcquisitionClient:
         return int(self.max_buflen * self.device_spec.sample_rate)
 
     def get_latest_data(self) -> List[Record]:
-        """Pull all available samples in the buffer.
+        """Add all available samples in the inlet to the buffer.
 
         The number of items returned depends on the size of the configured
-        max_buflen as well as the time since the last data pull."""
+        max_buflen and the amount of data available in the inlet."""
 
         samples, timestamps = self.inlet.pull_chunk(
             max_samples=self.max_samples)
+        print(f'Pulled chunk size: {len(timestamps)}')
+        for i, sample in enumerate(samples):
+            self.buffer.append(
+                Record(data=sample, timestamp=timestamps[i], rownum=None))
 
-        return [
-            Record(data=sample, timestamp=timestamps[i], rownum=None)
-            for i, sample in enumerate(samples)
-        ]
+        return self.buffer.get()
 
     def convert_time(self, experiment_clock: Clock, timestamp: float) -> float:
         """

--- a/bcipy/acquisition/protocols/lsl/lsl_client.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_client.py
@@ -116,19 +116,24 @@ class LslAcquisitionClient:
         """Context manager exit method to clean up resources."""
         self.stop_acquisition()
 
-    def get_data(self, start: float = None, end: float = None) -> List[Record]:
+    def get_data(self,
+                 start: float = None,
+                 end: float = None,
+                 limit: int = None) -> List[Record]:
         """Get data in time range.
 
         Parameters
         ----------
             start : starting timestamp (acquisition clock).
             end : end timestamp (in acquisition clock).
+            limit: the max number of records that should be returned.
 
         Returns
         -------
             List of Records
         """
-        log.debug(f"Getting data from time {start} to {end}")
+
+        log.debug(f"Getting data from: {start} to: {end} limit: {limit}")
 
         # Implementation Notes:
         #   - Only data in the current buffer is available to query;
@@ -145,13 +150,14 @@ class LslAcquisitionClient:
                  f'(From: {data[0].timestamp} To: {data[-1].timestamp})'))
             start = start or data[0].timestamp
             end = end or data[-1].timestamp
+            limit = limit or -1
             assert start >= data[0].timestamp, (
                 f'Start time of {start} is out of range: '
                 f'({data[0].timestamp} to {data[-1].timestamp}).')
 
             data_slice = [
                 record for record in data if start <= record.timestamp <= end
-            ]
+            ][0:limit]
             log.debug(f'{len(data_slice)} records returned')
             return data_slice
         log.debug('No records available')

--- a/bcipy/acquisition/tests/protocols/lsl/test_lsl_client.py
+++ b/bcipy/acquisition/tests/protocols/lsl/test_lsl_client.py
@@ -112,12 +112,10 @@ class TestDataAcquisitionClient(unittest.TestCase):
         # Get a half second of data
         offset = client.clock_offset(experiment_clock)
         start = 0.5 + offset
-        end = 1.0 + offset
-        samples = client.get_data(start, end)
+        samples = client.get_data(start, limit=100)
 
         client.stop_acquisition()
-        expected_samples = DEVICE.sample_rate / 2
-        self.assertAlmostEqual(expected_samples, len(samples), delta=5.0)
+        self.assertEqual(100, len(samples))
         self.assertAlmostEqual(client.convert_time(experiment_clock, 0.5),
                                start,
                                delta=0.002)

--- a/bcipy/acquisition/tests/protocols/lsl/test_lsl_client.py
+++ b/bcipy/acquisition/tests/protocols/lsl/test_lsl_client.py
@@ -113,9 +113,12 @@ class TestDataAcquisitionClient(unittest.TestCase):
         offset = client.clock_offset(experiment_clock)
         start = 0.5 + offset
         samples = client.get_data(start, limit=100)
+        samples2 = client.get_data(start, limit=100)
 
         client.stop_acquisition()
         self.assertEqual(100, len(samples))
+        self.assertEqual(samples, samples2,
+                         "Consecutive queries should yield the same answers")
         self.assertAlmostEqual(client.convert_time(experiment_clock, 0.5),
                                start,
                                delta=0.002)

--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -173,10 +173,7 @@ def get_data_for_decision(inquiry_timing,
     _, first_stim_time = inquiry_timing[0]
     _, last_stim_time = inquiry_timing[-1]
 
-    time1 = (first_stim_time + static_offset)
-    # Ending time also needs to account for the time after the last stimulus in
-    # the inquiry to ensure that we're getting enough data.
-    time2 = (last_stim_time + static_offset + buffer_length)
+    time1 = first_stim_time + static_offset
 
     # Construct triggers to send off for processing
     triggers = [(text, ((timing) - first_stim_time))
@@ -191,7 +188,7 @@ def get_data_for_decision(inquiry_timing,
     log.debug(f'Need {data_limit} records for processing')
 
     # Query for raw data
-    raw_data = daq.get_data(start=time1, end=time2)
+    raw_data = daq.get_data(start=time1, limit=data_limit)
 
     if len(raw_data) < data_limit:
         message = f'Process Data Error: Not enough data received to process. ' \


### PR DESCRIPTION
# Overview

During execution of the Copy Phrase task, the `get_data_for_decision` function in the task helper would sometimes throw an `InsufficientDataException` after querying the acquisition client for data. The client had enough data in the desired range but the timestamp alignment was slightly off. The query was modified to explicitly ask for a given number of samples.

## Ticket

https://www.pivotaltracker.com/story/show/179644506

## Contributions

- Added utility methods to raw_data module to assist in debugging.
- Modified Copy Phrase task to query the acquisition module for a given number of samples.

## Test

- The Copy Phrase task should run without throwing an InsufficientDataException