### PR TITLE
Copy Phrase task max selections

### DIFF
--- a/bcipy/acquisition/protocols/lsl/lsl_client.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_client.py
@@ -176,7 +176,7 @@ class LslAcquisitionClient:
 
         samples, timestamps = self.inlet.pull_chunk(
             max_samples=self.max_samples)
-        print(f'Pulled chunk size: {len(timestamps)}')
+
         for i, sample in enumerate(samples):
             self.buffer.append(
                 Record(data=sample, timestamp=timestamps[i], rownum=None))

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -680,6 +680,14 @@
     "recommended_values": "",
     "type": "int"
   },
+  "max_selections": {
+    "value": "25",
+    "section": "bci_config",
+    "readableName": "Maximum Number of Selections",
+    "helpTip": "The maximum number of selections for copy/spelling tasks. The task will end if this number is reached.",
+    "recommended_values": "",
+    "type": "int"
+  },
   "decision_threshold": {
     "value": "0.8",
     "section": "bci_config",

--- a/bcipy/task/tests/core/test_data.py
+++ b/bcipy/task/tests/core/test_data.py
@@ -129,6 +129,8 @@ class TestSessionData(unittest.TestCase):
     def test_empty_session(self):
         """Test initial session creation"""
         session = Session(save_location=".")
+        self.assertEqual(0, session.total_number_series)
+        self.assertEqual(0, session.total_number_decisions)
         serialized = session.as_dict()
 
         self.assertEqual(0, serialized['total_time_spent'])
@@ -169,13 +171,18 @@ class TestSessionData(unittest.TestCase):
 
         session.add_series()
         self.assertEqual(0, session.total_number_series)
+        self.assertEqual(0, session.total_number_decisions)
 
         session.add_sequence(sample_stim_seq())
         self.assertEqual(1, session.total_number_series)
+        self.assertEqual(0, session.total_number_decisions)
 
         session.add_series()
+        self.assertEqual(1, session.total_number_decisions)
+
         session.add_sequence(sample_stim_seq())
         self.assertEqual(2, session.total_number_series)
+        self.assertEqual(1, session.total_number_decisions)
 
     def test_session_deserialization(self):
         """Test that a Session can be deserialized"""

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -50,6 +50,7 @@ class TestCopyPhrase(unittest.TestCase):
             'max_inq_per_series': 10,
             'max_minutes': 20,
             'min_inq_len': 1,
+            'max_selections': 50,
             'notch_filter_frequency': 60.0,
             'preview_inquiry_isi': 1.0,
             'preview_inquiry_key_input': 'space',


### PR DESCRIPTION
# Overview

Added a parameter to configure the maximum number of selections allowed in a Copy Phrase session.

## Ticket

https://www.pivotaltracker.com/story/show/179844380

## Contributions

- Added parameter to configure max_selections
- Added logic to Copy Phrase task to check the max_selections in the stoppage criteria
- Code cleanup; mypy fixes

## Test

- Set the max_selections parameter to a low number. Take the Copy Phrase task (with or without the inquiry preview). After the given number of selections the task should exit.
