### PR TITLE
Max inq per trial

### DIFF
--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -672,17 +672,6 @@
     ],
     "type": "int"
   },
-  "max_inq_per_trial": {
-    "value": "10",
-    "section": "bci_config",
-    "readableName": "Maximum Inquiries Per Trial",
-    "helpTip": "Maximum number of inquiries to present for a single trial before making a decision",
-    "recommended_values": [
-      "10",
-      "15"
-    ],
-    "type": "int"
-  },
   "max_minutes": {
     "value": "20",
     "section": "bci_config",
@@ -830,7 +819,7 @@
     "section": "bci_config",
     "readableName": "Preview Inquiry Display Key Input Method",
     "helpTip": "Defines the key used to engage with inquiry preview.",
-    "recommended_values": 
+    "recommended_values":
       ["space",
        "escape"],
     "type": "str"

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -77,7 +77,7 @@ class RSVPCopyPhraseTask(Task):
         'feedback_pos_y', 'feedback_stim_height', 'feedback_stim_width',
         'filter_high', 'filter_low', 'filter_order', 'fixation_color',
         'info_color', 'info_font', 'info_height', 'info_text', 'is_txt_stim',
-        'lm_backspace_prob', 'max_inq_len', 'max_inq_per_trial', 'max_minutes',
+        'lm_backspace_prob', 'max_inq_len', 'max_inq_per_series', 'max_minutes',
         'min_inq_len', 'notch_filter_frequency', 'preview_inquiry_isi',
         'preview_inquiry_key_input', 'preview_inquiry_length',
         'preview_inquiry_progress_method', 'session_file_name',
@@ -167,7 +167,7 @@ class RSVPCopyPhraseTask(Task):
 
         self.copy_phrase_task = _init_copy_phrase_wrapper(
             self.parameters['min_inq_len'],
-            self.parameters['max_inq_per_trial'],
+            self.parameters['max_inq_per_series'],
             signal_model=self.signal_model,
             fs=self.daq.device_info.fs,
             k=self.parameters['down_sampling_rate'],

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -47,7 +47,7 @@ class TestCopyPhrase(unittest.TestCase):
             'is_txt_stim': True,
             'lm_backspace_prob': 0.05,
             'max_inq_len': 50,
-            'max_inq_per_trial': 10,
+            'max_inq_per_series': 10,
             'max_minutes': 20,
             'min_inq_len': 1,
             'notch_filter_frequency': 60.0,


### PR DESCRIPTION
# Overview

Replaced uses of `max_inq_per_trial` parameter with `max_inq_per_series`. Removed the duplicate parameter. 
The old parameter should be removed.

## Ticket

https://www.pivotaltracker.com/story/show/179844387

## Contributions

- Updated Copy Phrase task and tests to use max_inq_per_series parameter.
- Removed duplicate parameter from parameters.json file.

## Test

- Ran unit tests.
- Ran Copy Phrase task to ensure consistent behavior.
