### PR TITLE
Add preview only mode

### DIFF
--- a/bcipy/display/rsvp/display.py
+++ b/bcipy/display/rsvp/display.py
@@ -175,6 +175,7 @@ class PreviewInquiryProperties:
 
     def __init__(
             self,
+            preview_only: bool,
             preview_inquiry_length: float,
             preview_inquiry_progress_method: int,
             preview_inquiry_key_input: str,
@@ -190,7 +191,7 @@ class PreviewInquiryProperties:
         self.preview_inquiry_length = preview_inquiry_length
         self.preview_inquiry_key_input = preview_inquiry_key_input
         self.press_to_accept = True if preview_inquiry_progress_method == 1 else False
-        self.preview_only = True if preview_inquiry_progress_method == 0 else False
+        self.preview_only = preview_only
         self.preview_inquiry_isi = preview_inquiry_isi
 
 
@@ -404,6 +405,10 @@ class RSVPDisplay(Display):
             - A tuple containing the timing information and a boolean describing whether to present
                 the inquiry (True) or generate another (False).
         """
+        # self._preview_inquiry defaults to None on __init__, assert it is defined correctly
+        assert isinstance(self._preview_inquiry, PreviewInquiryProperties), (
+            'PreviewInquiryProperties are not set on this RSVPDisplay. '
+            'Add them as a preview_inquiry kwarg to use preview_inquiry().')
         # construct the timing to return and generate the content for preview
         timing = []
         if self.first_run:
@@ -433,7 +438,7 @@ class RSVPDisplay(Display):
                 clock=self.experiment_clock,
             )
 
-            # break if a response given unless this is preview only and wait the timer out
+            # break if a response given unless this is preview only and wait the timer
             if response and not self._preview_inquiry.preview_only:
                 break
 

--- a/bcipy/display/tests/rsvp/test_rsvp_display.py
+++ b/bcipy/display/tests/rsvp/test_rsvp_display.py
@@ -110,6 +110,7 @@ class TestRSVPDisplayInquiryPreview(unittest.TestCase):
         self.preview_inquiry_progress_method = 1  # preview only = 0; press to accept == 1; press to skip == 2
         self.preview_inquiry_key_input = 'space'
         self.preview_inquiry = PreviewInquiryProperties(
+            preview_only=False,
             preview_inquiry_length=self.preview_inquiry_length,
             preview_inquiry_isi=self.preview_inquiry_isi,
             preview_inquiry_progress_method=self.preview_inquiry_progress_method,
@@ -307,6 +308,15 @@ class TestRSVPDisplayInquiryPreview(unittest.TestCase):
         #  The second item should be True as it is preview only
         expected = ([None], True)
         self.assertEqual(response, expected)
+
+    def test_error_thrown_when_calling_preview_inquiry_without_properties_set(self):
+        # If not defined using the kwarg preview_inquiry, this value is set to None
+        self.rsvp._preview_inquiry = None
+
+        # Assert when set to None, calling the method will result in an exception
+        with self.assertRaises(Exception):
+            self.rsvp.preview_inquiry()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/bcipy/display/tests/rsvp/test_rsvp_display.py
+++ b/bcipy/display/tests/rsvp/test_rsvp_display.py
@@ -107,7 +107,7 @@ class TestRSVPDisplayInquiryPreview(unittest.TestCase):
         self.stimuli = TEST_STIM
         self.preview_inquiry_length = 0.1
         self.preview_inquiry_isi = 0.1
-        self.preview_inquiry_progress_method = 1  # press to accept == 1 press to skip == 2
+        self.preview_inquiry_progress_method = 1  # preview only = 0; press to accept == 1; press to skip == 2
         self.preview_inquiry_key_input = 'space'
         self.preview_inquiry = PreviewInquiryProperties(
             preview_inquiry_length=self.preview_inquiry_length,
@@ -233,7 +233,7 @@ class TestRSVPDisplayInquiryPreview(unittest.TestCase):
         get_key_press_mock.return_value = None
         response = self.rsvp.preview_inquiry()
         # we expect the trigger callback to return none, the key press to return the time and key press message,
-        #  The second item should be True as it is press to accept and a response was returned
+        #  The second item should be False as it is press to accept and a response was returned
         expected = ([None], False)
         self.assertEqual(response, expected)
 
@@ -254,10 +254,59 @@ class TestRSVPDisplayInquiryPreview(unittest.TestCase):
         get_key_press_mock.return_value = None
         response = self.rsvp.preview_inquiry()
         # we expect the trigger callback to return none, the key press to return the time and key press message,
-        #  The second item should be False as it is press to skip and a response was returned
+        #  The second item should be True as it is press to skip and a response was not returned
         expected = ([None], True)
         self.assertEqual(response, expected)
 
+    @patch('bcipy.display.rsvp.display.get_key_press')
+    def test_preview_inquiry_preview_only_response_registered(self, get_key_press_mock):
+        # set the progress method to press to skip
+        self.rsvp._preview_inquiry.press_to_accept = False
+        self.rsvp._preview_inquiry.preview_only = True
+        stim_mock = mock()
+        # mock the stimulus generation
+        when(self.rsvp)._generate_inquiry_preview().thenReturn(stim_mock)
+        when(stim_mock).draw().thenReturn()
+        when(self.rsvp).draw_static().thenReturn()
+        when(self.rsvp.window).flip().thenReturn()
+        when(self.rsvp)._trigger_pulse(any()).thenReturn([])
+
+        # skip the core wait for testing
+        when(psychopy.core).wait(self.preview_inquiry.preview_inquiry_isi).thenReturn()
+        # we return a key press value here to demonstrate, even if a response is returned by this method, it will not
+        #  be used in the preview_inquiry response from our display.
+        key_timestamp = 1000
+        get_key_press_mock.return_value = [
+            f'bcipy_key_press_{self.preview_inquiry_key_input}', key_timestamp
+        ]
+        response = self.rsvp.preview_inquiry()
+        # we expect the trigger callback to return none, no key press response even if returned,
+        #  The second item should be True as it is preview only
+        expected = ([None], True)
+        self.assertEqual(response, expected)
+
+    @patch('bcipy.display.rsvp.display.get_key_press')
+    def test_preview_inquiry_preview_only_no_response(self, get_key_press_mock):
+        # set the progress method to press to skip
+        self.rsvp._preview_inquiry.press_to_accept = False
+        self.rsvp._preview_inquiry.preview_only = True
+        stim_mock = mock()
+        # mock the stimulus generation
+        when(self.rsvp)._generate_inquiry_preview().thenReturn(stim_mock)
+        when(stim_mock).draw().thenReturn()
+        when(self.rsvp).draw_static().thenReturn()
+        when(self.rsvp.window).flip().thenReturn()
+        when(self.rsvp)._trigger_pulse(any()).thenReturn([])
+
+        # skip the core wait for testing
+        when(psychopy.core).wait(self.preview_inquiry.preview_inquiry_isi).thenReturn()
+
+        get_key_press_mock.return_value = None
+        response = self.rsvp.preview_inquiry()
+        # we expect the trigger callback to return none, no key press response,
+        #  The second item should be True as it is preview only
+        expected = ([None], True)
+        self.assertEqual(response, expected)
 
 if __name__ == '__main__':
     unittest.main()

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -804,11 +804,12 @@
     "type": "bool"
   },
   "preview_inquiry_progress_method": {
-    "value": "1",
+    "value": "0",
     "section": "bci_config",
     "readableName": "Preview Inquiry Progression Method",
-    "helpTip": "If show_preview_inquiry true, this will determine how to proceed after a key hit. 1 = press to confirm 2 = press to skip to another inquiry",
+    "helpTip": "If show_preview_inquiry true, this will determine how to proceed after a key hit. 0 = preview only; 1 = press to confirm; 2 = press to skip to another inquiry",
     "recommended_values": [
+      "0",
       "1",
       "2"
     ],

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -453,7 +453,7 @@ class RSVPCopyPhraseTask(Task):
         """
         if not self.parameters['show_preview_inquiry'] \
                 or not self.current_inquiry \
-                or self.parameters['preview_inquiry_progress_method'] == 0:
+                or self.rsvp._preview_inquiry.preview_only:
             return None
         probs = compute_probs_after_preview(self.current_inquiry.stimuli[0],
                                             self.alp,

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -451,8 +451,9 @@ class RSVPCopyPhraseTask(Task):
             tuple of (evidence type, evidence) or None if inquiry preview is
             not enabled.
         """
-        if not self.parameters[
-                'show_preview_inquiry'] or not self.current_inquiry:
+        if not self.parameters['show_preview_inquiry'] \
+                or not self.current_inquiry \
+                or self.parameters['preview_inquiry_progress_method'] == 0:
             return None
         probs = compute_probs_after_preview(self.current_inquiry.stimuli[0],
                                             self.alp,

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -106,10 +106,27 @@ class RSVPCopyPhraseTask(Task):
         self.experiment_clock = Clock()
         self.start_time = self.experiment_clock.getTime()
 
-        self.alp = alphabet(parameters)
+        self.alp = alphabet(self.parameters)
+
+        self.button_press_error_prob = 0.05
+        self.evidence_types = [EvidenceType.LM, EvidenceType.ERP]
+        if self.parameters['show_preview_inquiry']:
+            self.evidence_types.append(EvidenceType.BTN)
+        # set a preview_only parameter
+        self.parameters.add_entry(
+            'preview_only',
+            {
+                'value': True if self.parameters['preview_inquiry_progress_method'] == 0 else False,
+                'section': '',
+                'readableName': '',
+                'helpTip': '',
+                'recommended_values': '',
+                'type': 'bool'
+            }
+        )
+
         self.rsvp = _init_copy_phrase_display(self.parameters, self.window,
-                                              self.daq, self.static_clock,
-                                              self.experiment_clock)
+                                              self.static_clock, self.experiment_clock)
         self.file_save = file_save
 
         self.trigger_save_location = f"{self.file_save}/{parameters['trigger_file_name']}"
@@ -120,12 +137,6 @@ class RSVPCopyPhraseTask(Task):
         self.fake = fake
         self.language_model = language_model
         self.signal_model = signal_model
-
-        # TODO: add a parameter for button_press_error_prob.
-        self.button_press_error_prob = 0.05
-        self.evidence_types = [EvidenceType.LM, EvidenceType.ERP]
-        if self.parameters['show_preview_inquiry']:
-            self.evidence_types.append(EvidenceType.BTN)
 
     def setup(self) -> None:
         """Initialize/reset parameters used in the execute run loop."""
@@ -453,7 +464,7 @@ class RSVPCopyPhraseTask(Task):
         """
         if not self.parameters['show_preview_inquiry'] \
                 or not self.current_inquiry \
-                or self.rsvp._preview_inquiry.preview_only:
+                or self.parameters['preview_only']:
             return None
         probs = compute_probs_after_preview(self.current_inquiry.stimuli[0],
                                             self.alp,
@@ -624,9 +635,10 @@ class RSVPCopyPhraseTask(Task):
         return self.TASK_NAME
 
 
-def _init_copy_phrase_display(parameters, win, daq, static_clock,
+def _init_copy_phrase_display(parameters, win, static_clock,
                               experiment_clock):
     preview_inquiry = PreviewInquiryProperties(
+        preview_only=parameters['preview_only'],
         preview_inquiry_length=parameters['preview_inquiry_length'],
         preview_inquiry_key_input=parameters['preview_inquiry_key_input'],
         preview_inquiry_progress_method=parameters[

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -13,9 +13,10 @@ import bcipy.helpers.task
 from bcipy.acquisition.protocols.lsl.lsl_client import LslAcquisitionClient
 from bcipy.acquisition.device_info import DeviceInfo
 from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
+from bcipy.helpers.parameters import Parameters
 from bcipy.task.paradigm.rsvp.copy_phrase import RSVPCopyPhraseTask
 from bcipy.task.data import Session, EvidenceType
-from bcipy.helpers.stimuli import InquirySchedule, StimuliOrder
+from bcipy.helpers.stimuli import InquirySchedule
 
 
 class TestCopyPhrase(unittest.TestCase):
@@ -23,7 +24,7 @@ class TestCopyPhrase(unittest.TestCase):
 
     def setUp(self):
         """Override; set up the needed path for load functions."""
-        self.parameters = {
+        parameters = {
             'backspace_always_shown': True,
             'decision_threshold': 0.8,
             'down_sampling_rate': 2,
@@ -66,7 +67,7 @@ class TestCopyPhrase(unittest.TestCase):
             'stim_height': 0.6,
             'stim_length': 10,
             'stim_number': 100,
-            'stim_order': StimuliOrder.RANDOM,
+            'stim_order': 'random',
             'stim_pos_x': 0.0,
             'stim_pos_y': 0.0,
             'stim_space_char': '–',
@@ -89,6 +90,7 @@ class TestCopyPhrase(unittest.TestCase):
             'wait_screen_message': 'Press Space to start or Esc to exit',
             'wait_screen_message_color': 'white'
         }
+        self.parameters = Parameters.from_cast_values(**parameters)
 
         self.win = mock({'size': [500, 500], 'units': 'height'})
 
@@ -112,7 +114,7 @@ class TestCopyPhrase(unittest.TestCase):
 
         self.display = mock()
         when(bcipy.task.paradigm.rsvp.copy_phrase)._init_copy_phrase_display(
-            self.parameters, self.win, self.daq, any,
+            self.parameters, self.win, any,
             any).thenReturn(self.display)
 
         when(bcipy.task.paradigm.rsvp.copy_phrase)._init_copy_phrase_wrapper(


### PR DESCRIPTION
# Overview

Added the ability to preview an inquiry without a progress method. This is configured by setting preview_inquiry to True and preview_inquiry_progress_method to 0 (the new default).

## Ticket

https://www.pivotaltracker.com/story/show/179844270

## Contributions

- `parameters.json`: Added an option to preview_inquiry_progress_method (0 == preview only)
- `rsvp.display.py`: Updated display to factor in a preview only option. The get_key_press is still used and the response ignored. Initial testing with that removed led to odd behavior alongside our get_key_press call in copy_phrase (no triggers were written). Added `preview_only` to PreviewInquiryProperties.
- `task.paradigm.rsvp.copy_phrase.py`: added a check for preview only mode to determine whether to add button evidence 

## Test

- `make test-all`
- ran copy phrase in fake data mode with inquiry preview on (all preview_inquiry_progress_method conditions) and off.

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here. Updated inline documentation as needed. 
