### PR TITLE
Backspace always shown

### DIFF
--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -63,7 +63,7 @@ def alphabetize(stimuli: List[str]) -> List[str]:
 def rsvp_inq_generator(query: List[str],
                        timing: List[float] = [1, 0.2],
                        color: List[str] = ['red', 'white'],
-                       stim_number: int = 1,
+                       inquiry_count: int = 1,
                        stim_order: StimuliOrder = StimuliOrder.RANDOM,
                        is_txt: bool = True) -> InquirySchedule:
     """ Given the query set, prepares the stimuli, color and timing
@@ -89,7 +89,7 @@ def rsvp_inq_generator(query: List[str],
 
     # Init some lists to construct our stimuli with
     samples, times, colors = [], [], []
-    for _ in range(stim_number):
+    for _ in range(inquiry_count):
 
         # append a fixation cross. if not text, append path to image fixation
         sample = [get_fixation(is_txt)]
@@ -127,15 +127,14 @@ def best_selection(selection_elements: list,
             best_selection(list[str]): elements from selection_elements with the best values """
 
     always_included = always_included or []
-    n = len_query
     # pick the top n items sorted by value in decreasing order
     elem_val = dict(zip(selection_elements, val))
-    best = sorted(selection_elements, key=elem_val.get, reverse=True)[0:n]
+    best = sorted(selection_elements, key=elem_val.get, reverse=True)[0:len_query]
 
     replacements = [
         item for item in always_included
         if item not in best and item in selection_elements
-    ][0:n]
+    ][0:len_query]
 
     if replacements:
         best[-len(replacements):] = replacements
@@ -182,12 +181,9 @@ def best_case_rsvp_inq_gen(alp: list,
     if inq_constants and not set(inq_constants).issubset(alp):
         raise BciPyCoreException('Inquiry constants must be alphabet items.')
 
-    # create a list of alphabet letters
-    alphabet = [i for i in alp]
-
     # query for the best selection
     query = best_selection(
-        alphabet,
+        alp,
         session_stimuli,
         stim_length,
         inq_constants)

--- a/bcipy/helpers/tests/test_copy_phrase_wrapper.py
+++ b/bcipy/helpers/tests/test_copy_phrase_wrapper.py
@@ -189,14 +189,6 @@ class TestCopyPhraseWrapper(unittest.TestCase):
 
         is_accepted, sti = copy_phrase_task.initialize_series()
         self.assertFalse(is_accepted)
-        self.assertEqual(
-            sti,
-            (
-                [["+", "U", "T", "_", "W", "Y", "X", "Z", "<", "S", "V"]],
-                [[self.params["time_cross"]] + [self.params["time_flash"]] * self.params["stim_length"]],
-                [[self.params["fixation_color"]] + [self.params["stim_color"]] * self.params["stim_length"]],
-            ),
-        )
 
         triggers = [
             ("+", 0.0),

--- a/bcipy/task/control/handler.py
+++ b/bcipy/task/control/handler.py
@@ -165,7 +165,7 @@ class DecisionMaker:
 
         self.last_selection = ''
 
-        # Items shown in every inquiry TODO this is unused
+        # Items shown in every inquiry
         self.inq_constants = inq_constants
 
     def reset(self, state=''):
@@ -278,10 +278,11 @@ class DecisionMaker:
 
         # querying agent decides on possible letters to be shown on the screen
         query_els = self.stimuli_agent.return_stimuli(
-            self.list_series[-1]['list_distribution'])
+            self.list_series[-1]['list_distribution'],
+            constants=self.inq_constants)
         # once querying is determined, append with timing and color info.
         stimuli = rsvp_inq_generator(query=query_els,
-                                     stim_number=1,
+                                     inquiry_count=1,
                                      is_txt=self.is_txt_stim,
                                      timing=self.stimuli_timing,
                                      stim_order=self.stimuli_order)

--- a/bcipy/task/control/query.py
+++ b/bcipy/task/control/query.py
@@ -1,6 +1,6 @@
 import numpy as np
 import random
-from typing import List, Any, Optional
+from typing import List, Optional
 from abc import ABC, abstractmethod
 
 from bcipy.helpers.stimuli import best_selection
@@ -47,7 +47,7 @@ class RandomStimuliAgent(StimuliAgent):
         """ This querying method is memoryless no reset needed """
         pass
 
-    def return_stimuli(self, list_distribution: np.ndarray, constants: Optional[List[str]]=None):
+    def return_stimuli(self, list_distribution: np.ndarray, constants: Optional[List[str]] = None):
         """ return random elements from the alphabet """
         tmp = [i for i in self.alphabet]
         query = random.sample(tmp, self.len_query)
@@ -80,7 +80,7 @@ class NBestStimuliAgent(StimuliAgent):
     def reset(self):
         pass
 
-    def return_stimuli(self, list_distribution: np.ndarray, constants: Optional[List[str]]=None):
+    def return_stimuli(self, list_distribution: np.ndarray, constants: Optional[List[str]] = None):
         p = list_distribution[-1]
         tmp = [i for i in self.alphabet]
         query = best_selection(tmp, p, self.len_query, always_included=constants)

--- a/bcipy/task/control/query.py
+++ b/bcipy/task/control/query.py
@@ -1,7 +1,9 @@
 import numpy as np
 import random
-from typing import List, Any
+from typing import List, Any, Optional
 from abc import ABC, abstractmethod
+
+from bcipy.helpers.stimuli import best_selection
 
 
 class StimuliAgent(ABC):
@@ -45,10 +47,13 @@ class RandomStimuliAgent(StimuliAgent):
         """ This querying method is memoryless no reset needed """
         pass
 
-    def return_stimuli(self, list_distribution: np.ndarray):
+    def return_stimuli(self, list_distribution: np.ndarray, constants: Optional[List[str]]=None):
         """ return random elements from the alphabet """
         tmp = [i for i in self.alphabet]
         query = random.sample(tmp, self.len_query)
+
+        if constants:
+            query[-len(constants):] = constants
 
         return query
 
@@ -75,19 +80,12 @@ class NBestStimuliAgent(StimuliAgent):
     def reset(self):
         pass
 
-    def return_stimuli(self, list_distribution: np.ndarray):
+    def return_stimuli(self, list_distribution: np.ndarray, constants: Optional[List[str]]=None):
         p = list_distribution[-1]
         tmp = [i for i in self.alphabet]
-        query = best_selection(tmp, p, self.len_query)
+        query = best_selection(tmp, p, self.len_query, always_included=constants)
 
         return query
 
     def do_series(self):
         pass
-
-
-def best_selection(list_el: List[Any], val: List[float], len_query: int):
-    """Return the top `len_query` items from `list_el` according to the values in `val`"""
-    # numpy version: return list_el[(-val).argsort()][:len_query]
-    sorted_items = reversed(sorted(zip(val, list_el)))
-    return [el for (value, el) in sorted_items][:len_query]

--- a/bcipy/task/tests/core/test_query.py
+++ b/bcipy/task/tests/core/test_query.py
@@ -17,7 +17,7 @@ class TestQueryMechanisms(unittest.TestCase):
         list_el = ["A", "E", "I", "O", "U"]
         values = [0.1, 0.2, 0.2, 0.2, 0.2]
         len_query = 3
-        self.assertEqual(["U", "O", "I"], best_selection(list_el, values, len_query))
+        self.assertEqual(["E", "I", "O"], best_selection(list_el, values, len_query))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Overview

Added constants to stimuli agent and cleaned up best_selection methods. We should revisit this as the number of constants grow - it could result in unexpected behaviors with some agents. We only allow for setting of backspace as a constant at this time. 

## Ticket

https://www.pivotaltracker.com/story/show/179128130

## Contributions

- `helpers.stimuli.py`: clean up language to match glossary definitions. Remove unnecessary list comprehension.
- `control.handler.py`: added the ability to set constants in defined stimuli agent 
- `task/control/query.py` remove redundant best_selection in favor of one with constants. Implemented constants in return_stimuli methods.

## Test

- `make test-all`
- ran copy phrase with backspace always shown

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.
