### PR TITLE
Copy Phrase targetness bug

### DIFF
--- a/bcipy/helpers/tests/test_triggers.py
+++ b/bcipy/helpers/tests/test_triggers.py
@@ -11,7 +11,7 @@ from bcipy.helpers.exceptions import BciPyCoreException
 from bcipy.helpers.parameters import Parameters
 from bcipy.helpers.triggers import (
     _calibration_trigger,
-    _write_triggers_from_inquiry_copy_phrase,
+    write_triggers_from_inquiry_copy_phrase,
     extract_from_calibration,
     extract_from_copy_phrase,
     read_triggers,
@@ -314,8 +314,6 @@ offset offset_correction 6.23828125
 class TestWriteCopyPhrase(unittest.TestCase):
 
     trigger_file = mock()
-    copy_phrase = 'TEST_PHRASE'
-    typed_text = 'TEST_P'
 
     def tearDown(self) -> None:
         unstub()
@@ -326,11 +324,10 @@ class TestWriteCopyPhrase(unittest.TestCase):
         # mock the write to avoid any extra files
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(triggers,
-                                                 self.trigger_file,
-                                                 self.copy_phrase,
-                                                 self.typed_text,
-                                                 offset=True)
+        write_triggers_from_inquiry_copy_phrase(triggers,
+                                                self.trigger_file,
+                                                target_symbol=None,
+                                                offset=True)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_nontarget(self):
@@ -339,24 +336,22 @@ class TestWriteCopyPhrase(unittest.TestCase):
         expected = f'{triggers[0]} nontarget {triggers[1]}\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase([triggers],
-                                                 self.trigger_file,
-                                                 self.copy_phrase,
-                                                 self.typed_text,
-                                                 offset=False)
+        write_triggers_from_inquiry_copy_phrase([triggers],
+                                                self.trigger_file,
+                                                target_symbol='H',
+                                                offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_target(self):
-        triggers = ['P',
-                    1]  # given the defined typed text the target would be P
+        # given the defined typed text the target would be H
+        triggers = ['H', 1]
         expected = f'{triggers[0]} target {triggers[1]}\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase([triggers],
-                                                 self.trigger_file,
-                                                 self.copy_phrase,
-                                                 self.typed_text,
-                                                 offset=False)
+        write_triggers_from_inquiry_copy_phrase([triggers],
+                                                self.trigger_file,
+                                                target_symbol='H',
+                                                offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_fixation(self):
@@ -364,11 +359,10 @@ class TestWriteCopyPhrase(unittest.TestCase):
         expected = f'{triggers[0]} fixation {triggers[1]}\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase([triggers],
-                                                 self.trigger_file,
-                                                 self.copy_phrase,
-                                                 self.typed_text,
-                                                 offset=False)
+        write_triggers_from_inquiry_copy_phrase([triggers],
+                                                self.trigger_file,
+                                                target_symbol='H',
+                                                offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_inquiry_preview(self):
@@ -376,11 +370,10 @@ class TestWriteCopyPhrase(unittest.TestCase):
         expected = f'{triggers[0]} preview {triggers[1]}\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase([triggers],
-                                                 self.trigger_file,
-                                                 self.copy_phrase,
-                                                 self.typed_text,
-                                                 offset=False)
+        write_triggers_from_inquiry_copy_phrase([triggers],
+                                                self.trigger_file,
+                                                target_symbol='H',
+                                                offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_key_press(self):
@@ -389,11 +382,10 @@ class TestWriteCopyPhrase(unittest.TestCase):
         expected = f'{triggers[0]} key_press {triggers[1]}\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase([triggers],
-                                                 self.trigger_file,
-                                                 self.copy_phrase,
-                                                 self.typed_text,
-                                                 offset=False)
+        write_triggers_from_inquiry_copy_phrase([triggers],
+                                                self.trigger_file,
+                                                target_symbol='H',
+                                                offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_inquiry(self):
@@ -401,35 +393,31 @@ class TestWriteCopyPhrase(unittest.TestCase):
 
         when(self.trigger_file).write(any()).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(triggers,
-                                                 self.trigger_file,
-                                                 self.copy_phrase,
-                                                 self.typed_text,
-                                                 offset=False)
+        write_triggers_from_inquiry_copy_phrase(triggers,
+                                                self.trigger_file,
+                                                target_symbol='H',
+                                                offset=False)
         verify(self.trigger_file, times=3).write(any())
 
     def test_write_offset_multiple_triggers_fails(self):
         triggers = ['offset', 1]
 
         with self.assertRaises(ValueError):
-            _write_triggers_from_inquiry_copy_phrase([triggers],
-                                                     self.trigger_file,
-                                                     self.copy_phrase,
-                                                     self.typed_text,
-                                                     offset=True)
+            write_triggers_from_inquiry_copy_phrase([triggers],
+                                                    self.trigger_file,
+                                                    target_symbol=None,
+                                                    offset=True)
 
     def test_write_offset_backspace_target(self):
         triggers = [['<', 1]]
         # update the typed text to an incorrect letter given copy phrase
-        typed_text = 'TEST_H'
         expected = '< target 1\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(triggers,
-                                                 self.trigger_file,
-                                                 self.copy_phrase,
-                                                 typed_text,
-                                                 offset=False)
+        write_triggers_from_inquiry_copy_phrase(triggers,
+                                                self.trigger_file,
+                                                target_symbol='<',
+                                                offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
     def test_write_calibration_trigger(self):
@@ -437,11 +425,10 @@ class TestWriteCopyPhrase(unittest.TestCase):
         expected = 'calibration_trigger calib 1\n'
         when(self.trigger_file).write(expected).thenReturn(None)
 
-        _write_triggers_from_inquiry_copy_phrase(triggers,
-                                                 self.trigger_file,
-                                                 self.copy_phrase,
-                                                 self.typed_text,
-                                                 offset=False)
+        write_triggers_from_inquiry_copy_phrase(triggers,
+                                                self.trigger_file,
+                                                target_symbol='H',
+                                                offset=False)
         verify(self.trigger_file, times=1).write(expected)
 
 

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -15,7 +15,7 @@ from bcipy.helpers.task import (BACKSPACE_CHAR, alphabet, construct_triggers,
                                 fake_copy_phrase_decision,
                                 get_data_for_decision, get_user_input,
                                 target_info, trial_complete_message)
-from bcipy.helpers.triggers import _write_triggers_from_inquiry_copy_phrase
+from bcipy.helpers.triggers import write_triggers_from_inquiry_copy_phrase
 from bcipy.signal.model.inquiry_preview import compute_probs_after_preview
 from bcipy.task import Task
 from bcipy.task.data import EvidenceType, Inquiry, Session
@@ -355,7 +355,8 @@ class RSVPCopyPhraseTask(Task):
                 stim_times, proceed = self.present_inquiry(
                     self.current_inquiry)
 
-                self.write_trigger_data(stim_times, trigger_file)
+                write_triggers_from_inquiry_copy_phrase(
+                    stim_times, trigger_file, target_letter)
                 self.wait()
 
                 evidence_types = self.add_evidence(stim_times, proceed)
@@ -611,25 +612,12 @@ class RSVPCopyPhraseTask(Task):
         - trigger_file : open file in which to write
         """
         if self.daq.is_calibrated:
-            _write_triggers_from_inquiry_copy_phrase(
-                ['offset', self.daq.offset(self.rsvp.first_stim_time)],
+            write_triggers_from_inquiry_copy_phrase(
+                ['offset',
+                 self.daq.offset(self.rsvp.first_stim_time)],
                 trigger_file,
-                self.copy_phrase,
-                self.spelled_text,
+                target_symbol=None,
                 offset=True)
-
-    def write_trigger_data(self, stim_times: List[Tuple[str, float]],
-                           trigger_file: TextIO) -> None:
-        """Save trigger data to disk.
-
-        Parameters
-        ----------
-        - stim_times : list of (stim, clock_time) tuples
-        - trigger_file : data will be appended to this file
-        """
-        _write_triggers_from_inquiry_copy_phrase(stim_times, trigger_file,
-                                                 self.copy_phrase,
-                                                 self.spelled_text)
 
     def name(self) -> str:
         return self.TASK_NAME

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -138,7 +138,7 @@ class TestCopyPhrase(unittest.TestCase):
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_user_input')
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.trial_complete_message')
     @patch(
-        'bcipy.task.paradigm.rsvp.copy_phrase._write_triggers_from_inquiry_copy_phrase'
+        'bcipy.task.paradigm.rsvp.copy_phrase.write_triggers_from_inquiry_copy_phrase'
     )
     def test_execute_without_inquiry(self, write_trg_mock, message_mock,
                                      user_input_mock):
@@ -176,7 +176,7 @@ class TestCopyPhrase(unittest.TestCase):
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_user_input')
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.trial_complete_message')
     @patch(
-        'bcipy.task.paradigm.rsvp.copy_phrase._write_triggers_from_inquiry_copy_phrase'
+        'bcipy.task.paradigm.rsvp.copy_phrase.write_triggers_from_inquiry_copy_phrase'
     )
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_data_for_decision')
     def test_execute_fake_data_single_inquiry(self, process_data_mock,
@@ -225,7 +225,7 @@ class TestCopyPhrase(unittest.TestCase):
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_user_input')
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.trial_complete_message')
     @patch(
-        'bcipy.task.paradigm.rsvp.copy_phrase._write_triggers_from_inquiry_copy_phrase'
+        'bcipy.task.paradigm.rsvp.copy_phrase.write_triggers_from_inquiry_copy_phrase'
     )
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_data_for_decision')
     def test_max_inq_len(self, process_data_mock, write_trg_mock, message_mock,
@@ -273,7 +273,7 @@ class TestCopyPhrase(unittest.TestCase):
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_user_input')
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.trial_complete_message')
     @patch(
-        'bcipy.task.paradigm.rsvp.copy_phrase._write_triggers_from_inquiry_copy_phrase'
+        'bcipy.task.paradigm.rsvp.copy_phrase.write_triggers_from_inquiry_copy_phrase'
     )
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_data_for_decision')
     def test_spelling_complete(self, process_data_mock, write_trg_mock,
@@ -384,7 +384,7 @@ class TestCopyPhrase(unittest.TestCase):
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_user_input')
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.trial_complete_message')
     @patch(
-        'bcipy.task.paradigm.rsvp.copy_phrase._write_triggers_from_inquiry_copy_phrase'
+        'bcipy.task.paradigm.rsvp.copy_phrase.write_triggers_from_inquiry_copy_phrase'
     )
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_data_for_decision')
     def test_next_letter(self, process_data_mock, write_trg_mock, message_mock,
@@ -416,7 +416,7 @@ class TestCopyPhrase(unittest.TestCase):
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_user_input')
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.trial_complete_message')
     @patch(
-        'bcipy.task.paradigm.rsvp.copy_phrase._write_triggers_from_inquiry_copy_phrase'
+        'bcipy.task.paradigm.rsvp.copy_phrase.write_triggers_from_inquiry_copy_phrase'
     )
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_data_for_decision')
     def test_execute_fake_data_with_preview(self, process_data_mock,
@@ -462,7 +462,7 @@ class TestCopyPhrase(unittest.TestCase):
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_user_input')
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.trial_complete_message')
     @patch(
-        'bcipy.task.paradigm.rsvp.copy_phrase._write_triggers_from_inquiry_copy_phrase'
+        'bcipy.task.paradigm.rsvp.copy_phrase.write_triggers_from_inquiry_copy_phrase'
     )
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_data_for_decision')
     def test_execute_real_data_single_inquiry(self, process_data_mock,


### PR DESCRIPTION
# Overview

This PR fixes the triggers.txt file output by the Copy Phrase task to correctly label targets.

The error was in the calculation for the next target in the helper function. This method took a parameter for the copy_phrase and one for the typed_letters and used this information to determine the target. However, prior to a recent refactor, the spelled text was updated before writing triggers. In the current code the triggers are written prior to the decision that updates spelled text. So the code was using the last letter of the spelled text rather than the next un-spelled letter.

Given the potential ambiguity here, I refactored the code to make the target_symbol a parameter. This was already being calculated by the Task for use in the session data.

## Ticket

https://www.pivotaltracker.com/story/show/179811273

## Contributions

- Refactored helper to write the triggers data
- Renamed the method to indicate that it was public
- Updated tests

## Test

- Ran the unit tests
- Ran the Copy Phrase task and analyzed the resulting triggers.txt file (along with the session.json file) to confirm that the correct labels were output.
