### PR TITLE
Refactor generate_offline_analysis to visualize_erp

### DIFF
--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import random
+
 from abc import ABC, abstractmethod
 from itertools import zip_longest
 from string import ascii_uppercase
@@ -68,7 +69,7 @@ def calculate_stimulation_freq(flash_time: float) -> float:
 
     In an RSVP paradigm, the inquiry itself will produce an
         SSVEP response to the stimulation. Here we calculate
-        what that frequency should be based in the presentation
+        what that frequency should be based on the presentation
         time.
 
     PARAMETERS
@@ -215,7 +216,7 @@ def _float_val(col: Any) -> float:
     return float(col)
 
 
-def trial_complete_message(win, parameters):
+def trial_complete_message(win, parameters) -> List[visual.TextStim]:
     """Trial Complete Message.
 
     Function return a TextStim Object (see Psychopy) to complete the trial.

--- a/bcipy/helpers/tests/test_task.py
+++ b/bcipy/helpers/tests/test_task.py
@@ -15,13 +15,11 @@ from bcipy.helpers.task import (
     construct_triggers,
     target_info
 )
-from bcipy.helpers.load import load_json_parameters
 
 
 class TestAlphabet(unittest.TestCase):
     def test_alphabet_text(self):
-        parameters_used = './bcipy/parameters/parameters.json'
-        parameters = load_json_parameters(parameters_used, value_cast=True)
+        parameters = {}
 
         parameters['is_txt_stim'] = True
 
@@ -35,9 +33,7 @@ class TestAlphabet(unittest.TestCase):
              '_'])
 
     def test_alphabet_images(self):
-        parameters_used = './bcipy/parameters/parameters.json'
-        parameters = load_json_parameters(parameters_used, value_cast=True)
-
+        parameters = {}
         parameters['is_txt_stim'] = False
         parameters['path_to_presentation_images'] = ('bcipy/static/images/'
                                                      'rsvp/')

--- a/bcipy/helpers/visualization.py
+++ b/bcipy/helpers/visualization.py
@@ -48,8 +48,8 @@ def visualize_erp(
     channel_names = channel_names or {}
     classes = np.unique(labels)
 
-    means = [np.squeeze(np.mean(data[:, np.where(labels == i), :], 2))
-             for i in classes]
+    means = [np.squeeze(np.mean(data[:, np.where(labels == label), :], 2))
+             for label in classes]
 
     data_length = len(means[0][1, :])
 

--- a/bcipy/helpers/visualization.py
+++ b/bcipy/helpers/visualization.py
@@ -39,7 +39,6 @@ def visualize_erp(
     labels(ndarray[int]): N x k observation (class) array. Assumed to be two classes [0, 1]
     fs (sampling_rate): sampling rate of the current data signal
     class_labels: list of legend names for the respective classes for plotting (0 ,1).
-        Provide a single legend name in a list if plotting averages.
     plot_average: boolean: whether or not to average over all channels
     show_figure: boolean: whether or not to show the figures generated
     save_path: optional path to a save location of the figure generated

--- a/bcipy/helpers/visualization.py
+++ b/bcipy/helpers/visualization.py
@@ -1,73 +1,78 @@
-import os
-import numpy as np
-from matplotlib.figure import Figure
-import matplotlib.pyplot as plt
-from bcipy.helpers.load import choose_csv_file, load_raw_data
-from mne.io import read_raw_edf
-from typing import List
-
 import logging
+from os import path
+from typing import List, Optional
+
+from matplotlib.figure import Figure
+from mne.io import read_raw_edf
+import matplotlib.pyplot as plt
+import numpy as np
+
+from bcipy.helpers.load import choose_csv_file, load_raw_data
+
 log = logging.getLogger(__name__)
 
 
-def generate_offline_analysis_screen(
-        x,
-        y,
-        model=None,
-        folder=None,
-        save_figure=True,
-        down_sample_rate=2,
-        fs=300,
-        plot_x_ticks=8,
-        plot_average=False,
-        show_figure=False,
-        channel_names=None) -> List[Figure]:
-    """ Offline Analysis Screen.
+def visualize_erp(
+        data,
+        labels,
+        fs,
+        class_labels: List[str] = ['Non-Target', 'Target'],
+        plot_average: bool = False,
+        show_figure: bool = False,
+        save_path: Optional[str] = None,
+        figure_name: str = 'mean_erp.pdf',
+        channel_names: Optional[dict] = None) -> Figure:
+    """ Visualize ERP.
 
-    Generates the information figure following the offlineAnalysis.
-    The figure has multiple tabs containing the average ERP plots.
+    Generates a comparative ERP figure following a task execution. Given a set of trailed data,
+    and labels describing two classes, they are plotted and may be saved or shown in a window.
 
     Returns a list of the figure handles created.
 
     PARAMETERS
     ----------
+    N: samples
+    k: features
+    C: channels
 
-    x(ndarray[float]): C x N x k data array
-    y(ndarray[int]): N x k observation (class) array
-        N is number of samples k is dimensionality of features
-        C is number of channels
-    model(): trained model for data
-    folder(str): Folder of the data
-    save_figures: boolean: whether or not to save the plots as PDF
-    down_sample_rate: downsampling rate applied to signal (if any)
-    fs (sampling_rate): original sampling rate of the signal
-    plot_x_ticks: number of ticks desired on the ERP plot
+    data(ndarray[float]): C x N x k data array
+    labels(ndarray[int]): N x k observation (class) array. Assumed to be two classes [0, 1]
+    fs (sampling_rate): sampling rate of the current data signal
+    class_labels: list of legend names for the respective classes for plotting (0 ,1).
+        Provide a single legend name in a list if plotting averages.
     plot_average: boolean: whether or not to average over all channels
     show_figure: boolean: whether or not to show the figures generated
+    save_path: optional path to a save location of the figure generated
+    figure_name: name of the figure to be used when save_path provided
     channel_names: dict of channel names keyed by their position.
     """
-    fig_handles = []
-
     channel_names = channel_names or {}
-    classes = np.unique(y)
+    classes = np.unique(labels)
 
-    means = [np.squeeze(np.mean(x[:, np.where(y == i), :], 2))
+    means = [np.squeeze(np.mean(data[:, np.where(labels == i), :], 2))
              for i in classes]
+
+    data_length = len(means[0][1, :])
+
+    # set upper and lower bounds of figure legend
+    lower = 0
+    upper = data_length / fs * 1000  # convert to seconds
 
     fig = plt.figure(figsize=(20, 10))
     ax1 = fig.add_subplot(211)
-    ax2 = fig.add_subplot(212)
 
     if plot_average:
         # find the mean across rows for non target and target
-        non_target_mean = np.mean(means[0], axis=0)
-        target_mean = np.mean(means[1], axis=0)
+        class_one_mean = np.mean(means[0], axis=0)
+        class_two_mean = np.mean(means[1], axis=0)
 
         # plot the means
-        ax1.plot(non_target_mean)
-        ax2.plot(target_mean)
+        ax1.plot(class_one_mean, label=class_labels[0])
+        ax1.plot(class_two_mean, label=class_labels[1])
+        ax1.legend(loc='upper left', prop={'size': 8})
 
     else:
+        ax2 = fig.add_subplot(212)
         count = 0
         # Loop through all the channels and plot each on the non target/target
         # subplots
@@ -79,48 +84,36 @@ def generate_offline_analysis_screen(
         ax1.legend(loc='upper left', prop={'size': 8})
         ax2.legend(loc='upper left', prop={'size': 8})
 
-    # data points
-    data_length = len(means[0][1, :])
-
-    # generate appropriate data labels for the figure
-    lower = 0
-
-    # find the upper length of data and convert to seconds
-    upper = data_length * down_sample_rate / fs * 1000
-
     # make the labels
-    labels = [round(lower + x * (upper - lower) / (plot_x_ticks - 1)) for x in
-              range(plot_x_ticks)]
+    figure_labels = np.linspace(lower, upper, num=8).astype(int).tolist()
+    figure_labels.insert(0, 0)  # needed to force a 0 starting tick
 
-    # make sure it starts at zero
-    labels.insert(0, 0)
+    ax1.set_xticklabels(figure_labels)
 
-    # set the labels
-    ax1.set_xticklabels(labels)
-    ax2.set_xticklabels(labels)
+    if not plot_average:
+        ax2.set_xticklabels(figure_labels)
+        ax1.set_title(class_labels[0])
+        ax2.set_title(class_labels[1])
+    else:
+        ax1.set_title(f'Average {class_labels[0]} vs. {class_labels[1]}')
 
-    # Set common labels
+    # Set common figure labels
     fig.text(0.5, 0.04, 'Time (Seconds)', ha='center', va='center')
     fig.text(0.06, 0.5, r'$\mu V$', ha='center', va='center',
              rotation='vertical')
 
-    ax1.set_title('Non-target ERP')
-    ax2.set_title('Target ERP')
-
-    if save_figure:
-        fig.savefig(
-            os.path.join(
-                folder,
-                'mean_erp.pdf'),
-            bbox_inches='tight',
-            format='pdf')
-
-    fig_handles.append(fig)
-
     if show_figure:
         plt.show()
 
-    return fig_handles
+    if save_path:
+        fig.savefig(
+            path.join(
+                save_path,
+                figure_name),
+            bbox_inches='tight',
+            format='pdf')
+
+    return fig
 
 
 def plot_edf(edf_path: str, auto_scale: bool = False):
@@ -212,10 +205,11 @@ if __name__ == '__main__':
         19: 'T4'
     }
     # generate the offline analysis screen. show figure at the end
-    generate_offline_analysis_screen(
+    visualize_erp(
         x,
         y,
-        folder='bcipy',
-        save_figure=False,
+        150,
+        # save_path='.', # uncomment to save to current working directory
         show_figure=True,
+        plot_average=False,
         channel_names=names)

--- a/bcipy/signal/model/offline_analysis.py
+++ b/bcipy/signal/model/offline_analysis.py
@@ -1,11 +1,13 @@
 import logging
 from pathlib import Path
+from typing import Tuple
 from bcipy.helpers.acquisition import analysis_channel_names_by_pos, analysis_channels
 from bcipy.helpers.load import (
     load_experimental_data,
     load_json_parameters,
     load_raw_data,
 )
+from matplotlib.figure import Figure
 from bcipy.helpers.stimuli import play_sound
 from bcipy.helpers.system_utils import report_execution_time
 from bcipy.helpers.triggers import trigger_decoder
@@ -23,7 +25,7 @@ logging.basicConfig(
 
 @report_execution_time
 def offline_analysis(data_folder: str = None,
-                     parameters: dict = {}, alert_finished: bool = True) -> SignalModel:
+                     parameters: dict = {}, alert_finished: bool = True) -> Tuple[SignalModel, Figure]:
     """ Gets calibration data and trains the model in an offline fashion.
         pickle dumps the model into a .pkl folder
         Args:
@@ -122,11 +124,11 @@ def offline_analysis(data_folder: str = None,
         channel_names=analysis_channel_names_by_pos(channels, channel_map),
         show_figure=False
     )
-    visualize_erp(
+    figure_handles = visualize_erp(
         data,
         labels,
         fs,
-        plot_average=True,
+        plot_average=False, # set to True to see all channels target/nontarget
         save_path=data_folder,
         channel_names=analysis_channel_names_by_pos(channels, channel_map),
         show_figure=False,
@@ -136,7 +138,7 @@ def offline_analysis(data_folder: str = None,
         offline_analysis_tone = parameters.get('offline_analysis_tone')
         play_sound(offline_analysis_tone)
 
-    return model
+    return model, figure_handles
 
 
 if __name__ == "__main__":

--- a/bcipy/signal/model/offline_analysis.py
+++ b/bcipy/signal/model/offline_analysis.py
@@ -128,7 +128,7 @@ def offline_analysis(data_folder: str = None,
         data,
         labels,
         fs,
-        plot_average=False, # set to True to see all channels target/nontarget
+        plot_average=False,  # set to True to see all channels target/nontarget
         save_path=data_folder,
         channel_names=analysis_channel_names_by_pos(channels, channel_map),
         show_figure=False,

--- a/bcipy/signal/model/offline_analysis.py
+++ b/bcipy/signal/model/offline_analysis.py
@@ -11,6 +11,7 @@ from bcipy.helpers.system_utils import report_execution_time
 from bcipy.helpers.triggers import trigger_decoder
 from bcipy.helpers.visualization import visualize_erp
 from bcipy.signal.model.pca_rda_kde import PcaRdaKdeModel
+from bcipy.signal.model.base_model import SignalModel
 from bcipy.signal.process import get_default_transform
 
 
@@ -22,7 +23,7 @@ logging.basicConfig(
 
 @report_execution_time
 def offline_analysis(data_folder: str = None,
-                     parameters: dict = {}, alert_finished: bool = True) -> None:
+                     parameters: dict = {}, alert_finished: bool = True) -> SignalModel:
     """ Gets calibration data and trains the model in an offline fashion.
         pickle dumps the model into a .pkl folder
         Args:
@@ -117,14 +118,25 @@ def offline_analysis(data_folder: str = None,
         data,
         labels,
         fs,
-        plot_average=False,
         save_path=data_folder,
         channel_names=analysis_channel_names_by_pos(channels, channel_map),
-        show_figure=True
+        show_figure=False
+    )
+    visualize_erp(
+        data,
+        labels,
+        fs,
+        plot_average=True,
+        save_path=data_folder,
+        channel_names=analysis_channel_names_by_pos(channels, channel_map),
+        show_figure=False,
+        figure_name='average_erp.pdf'
     )
     if alert_finished:
         offline_analysis_tone = parameters.get('offline_analysis_tone')
         play_sound(offline_analysis_tone)
+
+    return model
 
 
 if __name__ == "__main__":

--- a/bcipy/signal/tests/model/test_offline_analysis.py
+++ b/bcipy/signal/tests/model/test_offline_analysis.py
@@ -35,7 +35,7 @@ class TestOfflineAnalysis(unittest.TestCase):
 
         cls.parameters = load_json_parameters(cls.tmp_dir / "parameters.json", value_cast=True)
         cls.model, fig_handles = offline_analysis(str(cls.tmp_dir), cls.parameters, alert_finished=False)
-        cls.mean_erp_fig_handle = fig_handles[0]
+        cls.mean_erp_fig_handle = fig_handles
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
# Overview

Fixed plotting bug, wherein downsampling was applied to an already downsampled sampling rate. Refactored for easier additions and testing in the future.

## Ticket

https://www.pivotaltracker.com/n/projects/2460065

## Contributions

- `helpers.visualization`: `generate_offline_analysis_screen` refactored to `visualize_erp`. Previously functionality retained while fixing the reported x axis labels and surfacing elements that can be modified. 
- `bcipy/helpers/task.py`: linting, spelling correction
- `bcipy/helpers/tests/test_task.py`: removed unneeded import
- `bcipy/signal/model/offline_analysis.py`: updated to use new plotting method, cleanup

## Test

- `make test-all`
- [mean_erp.pdf](https://github.com/CAMBI-tech/BciPy/files/7469213/mean_erp.pdf)
- [average_erp.pdf](https://github.com/CAMBI-tech/BciPy/files/7469216/average_erp.pdf)


## Documentation

- Updated docstrings where applicable
