### PR TITLE
Session data refinements

### DIFF
--- a/bcipy/acquisition/tests/protocols/lsl/test_lsl_client.py
+++ b/bcipy/acquisition/tests/protocols/lsl/test_lsl_client.py
@@ -5,12 +5,13 @@ import time
 import unittest
 from pathlib import Path
 
+import pytest
+
 from bcipy.acquisition.connection_method import ConnectionMethod
 from bcipy.acquisition.datastream.lsl_server import LslDataServer
 from bcipy.acquisition.devices import (IRREGULAR_RATE, DeviceSpec,
                                        preconfigured_device)
 from bcipy.acquisition.protocols.lsl.lsl_client import LslAcquisitionClient
-
 from bcipy.helpers.clock import Clock
 
 DEVICE_NAME = 'DSI'
@@ -123,6 +124,7 @@ class TestDataAcquisitionClient(unittest.TestCase):
                                start,
                                delta=0.002)
 
+    @pytest.mark.slow
     def test_event_offset(self):
         """Test the offset in seconds of a given event relative to the first
         sample time."""

--- a/bcipy/helpers/session.py
+++ b/bcipy/helpers/session.py
@@ -164,8 +164,8 @@ def session_db(data_dir: str, db_name='session.db', alp=None):
                         is_target=(target == stim) if target else None,
                         presented=stim in inquiry.stimuli,
                         above_threshold=evidence['likelihood'][stim] >
-                        threshold) for stim, _likelihood_ev in
-                    evidence['likelihood'].items()
+                        threshold)
+                    for stim, _likelihood_ev in evidence['likelihood'].items()
                 ]
 
                 conn.executemany(
@@ -310,6 +310,8 @@ def session_excel(db_name='session.db',
             chart.series[0].title = openpyxl.chart.series.SeriesLabel(v="lm")
             chart.series[1].title = openpyxl.chart.series.SeriesLabel(v="eeg")
             chart.series[2].title = openpyxl.chart.series.SeriesLabel(
+                v="btn")
+            chart.series[3].title = openpyxl.chart.series.SeriesLabel(
                 v="combined")
 
             chart.set_categories(categories)

--- a/bcipy/task/data.py
+++ b/bcipy/task/data.py
@@ -130,13 +130,10 @@ class Inquiry:
             for name, value in data.items() if name.endswith(EVIDENCE_SUFFIX)
         }
 
-        computed = [
-            attr for attr in dir(cls)
-            if isinstance(getattr(cls, attr), property)
-        ]
         non_evidence_data = {
             name: value
-            for name, value in data.items() if name not in computed
+            for name, value in data.items()
+            if not name.endswith(EVIDENCE_SUFFIX)
         }
         inquiry = cls(**non_evidence_data)
         if len(data['stimuli']) == 1 and isinstance(data['stimuli'][0], list):

--- a/bcipy/task/data.py
+++ b/bcipy/task/data.py
@@ -290,11 +290,12 @@ class Session:
 
         if data['series']:
             session.series.clear()
-            for series_counter in sorted(data['series'].keys()):
+
+            for series_key in sorted(data['series'].keys(), key=int):
                 session.series.append([])
-                for sequence_counter in sorted(data['series'][series_counter]):
-                    sequence_dict = data['series'][series_counter][
-                        sequence_counter]
-                    session.add_sequence(Inquiry.from_dict(sequence_dict))
+
+                for inquiry_key in sorted(data['series'][series_key], key=int):
+                    inquiry_dict = data['series'][series_key][inquiry_key]
+                    session.add_sequence(Inquiry.from_dict(inquiry_dict))
 
         return session

--- a/bcipy/task/data.py
+++ b/bcipy/task/data.py
@@ -80,6 +80,7 @@ class Inquiry:
                  target_letter: str = None,
                  current_text: str = None,
                  target_text: str = None,
+                 selection: str = None,
                  next_display_state: str = None,
                  likelihood: List[float] = None):
         super().__init__()
@@ -90,6 +91,7 @@ class Inquiry:
         self.target_letter = target_letter
         self.current_text = current_text
         self.target_text = target_text
+        self.selection = selection
         self.next_display_state = next_display_state
 
         self.evidences: Dict[EvidenceType, List[float]] = {}
@@ -123,15 +125,18 @@ class Inquiry:
         """
         # partition into evidence data and other data.
 
-        suffix = EVIDENCE_SUFFIX
         evidences = {
             EvidenceType.deserialized(name): value
-            for name, value in data.items() if name.endswith(suffix)
+            for name, value in data.items() if name.endswith(EVIDENCE_SUFFIX)
         }
 
+        computed = [
+            attr for attr in dir(cls)
+            if isinstance(getattr(cls, attr), property)
+        ]
         non_evidence_data = {
             name: value
-            for name, value in data.items() if not name.endswith(suffix)
+            for name, value in data.items() if name not in computed
         }
         inquiry = cls(**non_evidence_data)
         if len(data['stimuli']) == 1 and isinstance(data['stimuli'][0], list):
@@ -150,6 +155,7 @@ class Inquiry:
             'target_letter': self.target_letter,
             'current_text': self.current_text,
             'target_text': self.target_text,
+            'selection': self.selection,
             'next_display_state': self.next_display_state
         }
 

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -365,7 +365,7 @@ class RSVPCopyPhraseTask(Task):
                 data = self.new_data_record(stim_times,
                                             target_letter,
                                             current_text=self.spelled_text,
-                                            next_state=decision.spelled_text,
+                                            decision=decision,
                                             evidence_types=evidence_types)
                 self.update_session_data(data,
                                          save=True,
@@ -414,7 +414,9 @@ class RSVPCopyPhraseTask(Task):
 
         decision_made, new_sti = self.copy_phrase_task.decide()
         spelled_text = self.copy_phrase_task.decision_maker.displayed_state
-        selection = self.copy_phrase_task.decision_maker.last_selection
+        selection = ''
+        if decision_made:
+            selection = self.copy_phrase_task.decision_maker.last_selection
 
         return Decision(decision_made, selection, spelled_text, new_sti)
 
@@ -525,7 +527,7 @@ class RSVPCopyPhraseTask(Task):
                         stim_times: List[List],
                         target_letter: str,
                         current_text: str,
-                        next_state: str,
+                        decision: Decision,
                         evidence_types: List[EvidenceType] = []) -> Inquiry:
         """Construct a new inquiry data record.
 
@@ -534,7 +536,7 @@ class RSVPCopyPhraseTask(Task):
         - stim_times : list of [stim, clock_time] pairs returned from display.
         - target_letter : stim the user is currently attempting to spell.
         - current_text : spelled text before the inquiry
-        - next_state : spelled text after consulting the decision maker
+        - decision : decision made by the decision maker
         - evidence_types : evidence provided to the decision-maker during the
         current inquiry.
 
@@ -552,7 +554,8 @@ class RSVPCopyPhraseTask(Task):
                        target_letter=target_letter,
                        current_text=current_text,
                        target_text=self.copy_phrase,
-                       next_display_state=next_state)
+                       selection=decision.selection,
+                       next_display_state=decision.spelled_text)
         data.precision = self.evidence_precision
 
         if not self.fake:

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -137,6 +137,7 @@ class RSVPCopyPhraseTask(Task):
         self.fake = fake
         self.language_model = language_model
         self.signal_model = signal_model
+        self.evidence_precision = 5
 
     def setup(self) -> None:
         """Initialize/reset parameters used in the execute run loop."""
@@ -552,6 +553,7 @@ class RSVPCopyPhraseTask(Task):
                        current_text=current_text,
                        target_text=self.copy_phrase,
                        next_display_state=next_state)
+        data.precision = self.evidence_precision
 
         if not self.fake:
             latest_evidence = self.copy_phrase_task.conjugator.latest_evidence

--- a/bcipy/task/tests/core/test_data.py
+++ b/bcipy/task/tests/core/test_data.py
@@ -22,6 +22,7 @@ def sample_stim_seq(include_evidence: bool = False):
         target_letter="H",
         current_text="",
         target_text="HELLO_WORLD",
+        selection="H",
         next_display_state="H")
 
     if include_evidence:
@@ -75,7 +76,7 @@ class TestSessionData(unittest.TestCase):
 
         expected_keys = [
             'stimuli', 'timing', 'triggers', 'target_info', 'target_letter',
-            'current_text', 'target_text', 'next_display_state'
+            'current_text', 'target_text', 'selection', 'next_display_state'
         ]
 
         for key in expected_keys:

--- a/bcipy/task/tests/core/test_data.py
+++ b/bcipy/task/tests/core/test_data.py
@@ -64,14 +64,6 @@ def sample_stim_seq(include_evidence: bool = False):
 class TestSessionData(unittest.TestCase):
     """Tests for session data."""
 
-    def setUp(self):
-        """Override; set up the needed path for load functions."""
-        pass
-
-    def tearDown(self):
-        """Override"""
-        pass
-
     def test_stim_sequence(self):
         """Test stim sequence can be created and serialized to dict."""
         stim_seq = sample_stim_seq()
@@ -98,7 +90,8 @@ class TestSessionData(unittest.TestCase):
         stim_seq = sample_stim_seq(include_evidence=True)
         serialized = stim_seq.as_dict()
         self.assertTrue('lm_evidence' in serialized.keys())
-        self.assertEqual(serialized['lm_evidence'], stim_seq.evidences[EvidenceType.LM])
+        self.assertEqual(serialized['lm_evidence'],
+                         stim_seq.evidences[EvidenceType.LM])
 
         deserialized = Inquiry.from_dict(serialized)
 
@@ -111,7 +104,8 @@ class TestSessionData(unittest.TestCase):
         self.assertEqual(stim_seq.target_text, deserialized.target_text)
         self.assertEqual(stim_seq.next_display_state,
                          deserialized.next_display_state)
-        self.assertEqual(stim_seq.evidences[EvidenceType.LM], deserialized.evidences[EvidenceType.LM])
+        self.assertEqual(stim_seq.evidences[EvidenceType.LM],
+                         deserialized.evidences[EvidenceType.LM])
 
     def test_stim_sequence_evidence(self):
         """Test simplified evidence view"""
@@ -125,6 +119,22 @@ class TestSessionData(unittest.TestCase):
         evidence = stim_seq.stim_evidence(alp, n_most_likely=5)
         self.assertEqual(len(evidence['most_likely']), 5)
         self.assertAlmostEqual(evidence['most_likely']['<'], 0.05, places=2)
+
+    def test_evidence_precision(self):
+        """Test that evidence can be serialized with a given precision."""
+
+        stim_seq = sample_stim_seq(include_evidence=True)
+        stim_seq.precision = 3
+        serialized = stim_seq.as_dict()
+        self.assertEqual(serialized['lm_evidence'][0], 0.035)
+        self.assertEqual(serialized['eeg_evidence'][0], 1.077)
+        self.assertEqual(serialized['likelihood'][0], 0.038)
+
+        stim_seq.precision = 4
+        serialized = stim_seq.as_dict()
+        self.assertEqual(serialized['lm_evidence'][0], 0.0352)
+        self.assertEqual(serialized['eeg_evidence'][0], 1.0772)
+        self.assertEqual(serialized['likelihood'][0], 0.0381)
 
     def test_empty_session(self):
         """Test initial session creation"""


### PR DESCRIPTION
# Overview

Added some refinements to the session data (for Copy Phrase): limited the evidence precision for better readability; added the selected letter for each inquiry.

## Ticket

- https://www.pivotaltracker.com/story/show/180155037
- https://www.pivotaltracker.com/story/show/180154885

## Contributions

- Limited precision for evidence values in the session data to 5 decimal places.
- Added the selected character to each inquiry in the session data.

## Test

- Ran all unit tests.
- Ran the Copy Phrase task and examined the resulting session.json data to ensure that all evidence values are rounded appropriately and the selected value is correct. Looked at scenarios where a letter was spelled and also where backspace was used to delete a letter.