### PR TITLE
Show target phrase at start of copy spelling and on pause screen

### DIFF
--- a/bcipy/display/README.md
+++ b/bcipy/display/README.md
@@ -1,17 +1,22 @@
 ﻿# Display Module
 
-This is the Display module for the BCI Suite
+The Display module defines the visual presentation logic needed for any tasks in BciPy. Most displays take in a large number of user-configured parameters (including text size and font) and handle
+	passing back timestamps from their stimuli presentations for classification. 
 
 ### Structure
 `display`
 	`main`: Initializes a display window and contains useful display objects
-		`rsvp`:  RSVP related display objects and functions.
-			`mode`: defines task specific displays
+		`paradigm`: top level module holding all bcipy related display objects
+			`rsvp`:  RSVP related display objects and functions.
+				`mode`: defines task specific displays
+			`matrix`:  matrix related display objects and functions. Currently, only single character presentation is available.
+				`mode`: defines task specific displays
 		`tests`: tests for display module
 		`demo`: demo code for the display module
 
 ### Guidelines
 
-- Add new modes in their own directory
+- Add new modes in their own submodule
+- Inherit base classes defined in display.py where possible
 - Test timing between your code and the devices you're using
 	- consult psychopy (or other display codebase) for best practices for your OS

--- a/bcipy/display/paradigm/rsvp/mode/copy_phrase.py
+++ b/bcipy/display/paradigm/rsvp/mode/copy_phrase.py
@@ -1,6 +1,7 @@
 from psychopy import visual
-from bcipy.display.paradigm.rsvp.display import RSVPDisplay
+from bcipy.display.paradigm.rsvp.display import RSVPDisplay, BCIPY_LOGO_PATH
 from bcipy.helpers.task import SPACE_CHAR
+from bcipy.helpers.stimuli import resize_image
 
 """Note:
 
@@ -36,23 +37,14 @@ class CopyPhraseDisplay(RSVPDisplay):
             preview_inquiry=None,
             full_screen=False):
         """ Initializes Copy Phrase Task Objects """
-
-        tmp = visual.TextStim(win=window, font=task_display.task_font,
-                              text=static_task_text)
-        static_task_pos = (
-            tmp.boundingBox[0] / window.size[0] - 1, 1 - task_display.task_height)
+        self.target_text = static_task_text
+        static_task_pos = (0, 1 - task_display.task_height)
 
         info.info_color.append(static_task_color)
         info.info_font.append(task_display.task_font)
         info.info_text.append(static_task_text)
-        info.info_pos.append(task_display.task_pos)
+        info.info_pos.append(static_task_pos)
         info.info_height.append(task_display.task_height)
-
-        # Adjust task position wrt. static task position. Definition of
-        # dummy texts are required. Place the task on bottom
-        tmp2 = visual.TextStim(win=window, font=task_display.task_font, text=task_display.task_text)
-        x_task_pos = tmp2.boundingBox[0] / window.size[0] - 1
-        task_display.task_pos = (x_task_pos, static_task_pos[1] - task_display.task_height)
 
         super(CopyPhraseDisplay, self).__init__(
             window, clock,
@@ -70,12 +62,54 @@ class CopyPhraseDisplay(RSVPDisplay):
             appending to the right.
             Args:
                 text(string): new text for task state
-                color_list(list[string]): list of colors for each """
-        # An empty string will cause an error when we attempt to find its
-        # bounding box.
-        txt = text if len(text) > 0 else ' '
-        tmp2 = visual.TextStim(win=self.window, font=self.task.font, text=txt)
-        x_task_pos = tmp2.boundingBox[0] / self.window.size[0] - 1
-        task_pos = (x_task_pos, self.info.info_pos[-1][1] - self.task.height)
-
+                color_list(list[string]): list of colors for each
+        """
+        # Add padding to attempt aligning the task and information text. *Note:* this only works with monospaced fonts
+        padding = abs(len(self.target_text) - len(text))
+        text += ' ' * padding
+        task_pos = (0, self.info.info_pos[-1][1] - self.task.height)
         self.update_task(text=text, color_list=color_list, pos=task_pos)
+
+    def wait_screen(self, message: str, message_color: str) -> None:
+        """Wait Screen.
+
+        Args:
+            message(string): message to be displayed while waiting
+            message_color(string): color of the message to be displayed
+        """
+
+        self.draw_static()
+
+        # Construct the wait message
+        wait_message = visual.TextStim(win=self.window,
+                                       font=self.stimuli_font,
+                                       text=message,
+                                       height=.1,
+                                       color=message_color,
+                                       pos=(0, -.55),
+                                       wrapWidth=2,
+                                       colorSpace='rgb',
+                                       opacity=1,
+                                       depth=-6.0)
+
+        # try adding the BciPy logo to the wait screen
+        try:
+            wait_logo = visual.ImageStim(
+                self.window,
+                image=BCIPY_LOGO_PATH,
+                pos=(0, 0),
+                mask=None,
+                ori=0.0)
+            wait_logo.size = resize_image(
+                BCIPY_LOGO_PATH,
+                self.window.size,
+                1)
+            wait_logo.draw()
+
+        except Exception as e:
+            self.logger.exception(f'Cannot load logo image from path=[{BCIPY_LOGO_PATH}]')
+            raise e
+
+        # Draw and flip the screen.
+        wait_message.draw()
+        self.window.flip()

--- a/bcipy/feedback/demo/demo_visual_feedback.py
+++ b/bcipy/feedback/demo/demo_visual_feedback.py
@@ -11,11 +11,9 @@ clock = Clock()
 # Start Visual Feedback
 visual_feedback = VisualFeedback(
     display=display, parameters=parameters, clock=clock)
-stimulus = 'A'
-message = 'Selected:'
+stimulus = 'Selected: A'
 visual_feedback.message_color = 'white'
-timing = visual_feedback.administer(
-    stimulus, message=message)
+timing = visual_feedback.administer(stimulus)
 print(timing)
 print(visual_feedback._type())
 display.close()

--- a/bcipy/feedback/tests/visual/test_visual_feedback.py
+++ b/bcipy/feedback/tests/visual/test_visual_feedback.py
@@ -15,7 +15,7 @@ class TestVisualFeedback(unittest.TestCase):
             'feedback_font': 'Arial',
             'feedback_stim_height': 1,
             'feedback_stim_width': 1,
-            'feedback_message_color': 'white',
+            'feedback_color': 'white',
             'feedback_pos_x': 0,
             'feedback_pos_y': 0,
             'feedback_flash_time': 2,
@@ -41,21 +41,6 @@ class TestVisualFeedback(unittest.TestCase):
         feedback_type = self.visual_feedback._type()
         self.assertEqual(feedback_type, 'Visual Feedback')
 
-    def test_construct_message_returns_text_stimuli(self):
-        message = 'test_message'
-        stim_mock = mock()
-        when(psychopy.visual).TextStim(
-            win=self.display,
-            font=self.visual_feedback.font_stim,
-            text=message,
-            height=self.visual_feedback.message_height,
-            pos=self.visual_feedback.message_pos,
-            color=self.visual_feedback.message_color
-        ).thenReturn(stim_mock)
-
-        response = self.visual_feedback._construct_message(message)
-        self.assertEqual(stim_mock, response)
-
     def test_construct_stimulus_image(self):
         image_mock = mock()
         image_mock.size = 0
@@ -67,7 +52,7 @@ class TestVisualFeedback(unittest.TestCase):
             ori=any()
         ).thenReturn(image_mock)
         # mock the resize behavior for the image
-        when(self.visual_feedback)._resize_image(any(), any(), any()).thenReturn(0)
+        when(self.visual_feedback)._resize_image(any(), any(), any()).thenReturn()
 
         response = self.visual_feedback._construct_stimulus(
             'test_stim.png',
@@ -103,26 +88,24 @@ class TestVisualFeedback(unittest.TestCase):
         when(stimuli_mock).draw().thenReturn(None)
         when(self.display).flip().thenReturn(None)
 
-        self.visual_feedback._show_stimuli(stimuli_mock)
+        response = self.visual_feedback._show_stimuli(stimuli_mock)  # TODO assertion
 
         verify(stimuli_mock, times=1).draw()
         verify(self.display, times=1).flip()
 
     def test_administer_default(self):
-
         stimulus = mock()
-        timestamp = 1000
+        timestamp = [self.visual_feedback.feedback_timestamp_label, 1000]
         when(self.visual_feedback)._construct_stimulus(
             stimulus,
             self.visual_feedback.pos_stim,
-            'blue',
+            self.visual_feedback.color,
             FeedbackType.TEXT
         ).thenReturn(stimulus)
-        when(self.visual_feedback)._show_stimuli(stimulus).thenReturn()
-        when(self.clock).getTime().thenReturn(timestamp)
+        when(self.visual_feedback)._show_stimuli(stimulus).thenReturn(timestamp)
         when(psychopy.core).wait(self.visual_feedback.feedback_length).thenReturn()
         response = self.visual_feedback.administer(stimulus)
-        expected = [[self.visual_feedback.feedback_timestamp_label, timestamp]]
+        expected = [timestamp]
         self.assertEqual(response, expected)
 
 

--- a/bcipy/feedback/visual/visual_feedback.py
+++ b/bcipy/feedback/visual/visual_feedback.py
@@ -29,7 +29,6 @@ class VisualFeedback(Feedback):
         self.parameters = parameters
         self.font_stim = self.parameters['feedback_font']
         self.height_stim = self.parameters['feedback_stim_height']
-        self.width_stim = self.parameters['feedback_stim_width']
 
         pos_x = self.parameters['feedback_pos_x']
         pos_y = self.parameters['feedback_pos_y']
@@ -37,51 +36,40 @@ class VisualFeedback(Feedback):
         self.pos_stim = (pos_x, pos_y)
 
         self.feedback_length = self.parameters['feedback_flash_time']
+        self.color = self.parameters['feedback_color']
 
         # Clock
         self.clock = clock
-
-        self.message_color = self.parameters['feedback_message_color']
-        self.message_pos = (-.3, .5)
-        self.message_height = 0.3
-        self.feedback_line_width = self.parameters['feedback_line_width']
 
         self.feedback_timestamp_label = 'visual_feedback'
 
     def administer(
             self,
             stimulus,
-            fill_color='blue',
-            message=None,
             stimuli_type=FeedbackType.TEXT):
         """Administer.
 
         Administer visual feedback. Timing information from parameters,
             current feedback given by stimulus.
         """
-        timing = []
-
-        if message:
-            message = self._construct_message(message)
-            message.draw()
 
         stim = self._construct_stimulus(
             stimulus,
             self.pos_stim,
-            fill_color,
+            self.color,
             stimuli_type)
 
-        self._show_stimuli(stim)
-        time = [self.feedback_timestamp_label, self.clock.getTime()]
+        time = self._show_stimuli(stim)
 
         core.wait(self.feedback_length)
-        timing.append(time)
 
-        return timing
+        return [time]
 
     def _show_stimuli(self, stimulus) -> None:
         stimulus.draw()
+        time = [self.feedback_timestamp_label, self.clock.getTime()]  # TODO: use callback for better precision
         self.display.flip()
+        return time
 
     def _resize_image(self, stimuli, display_size, stimuli_height):
         return resize_image(
@@ -107,15 +95,6 @@ class VisualFeedback(Feedback):
                 pos=pos,
                 color=fill_color)
 
-    def _construct_message(self, message):
-        return visual.TextStim(
-            win=self.display,
-            font=self.font_stim,
-            text=message,
-            height=self.message_height,
-            pos=self.message_pos,
-            color=self.message_color)
-
 
 if __name__ == "__main__":
     import argparse
@@ -139,6 +118,6 @@ if __name__ == "__main__":
         display=display, parameters=parameters, clock=clock)
     stimulus = 'Test'
     timing = visual_feedback.administer(
-        stimulus, fill_color='blue', stimuli_type=FeedbackType.TEXT)
+        stimulus, stimuli_type=FeedbackType.TEXT)
     print(timing)
     print(visual_feedback._type())

--- a/bcipy/helpers/load.py
+++ b/bcipy/helpers/load.py
@@ -78,8 +78,6 @@ def extract_mode(bcipy_data_directory: str) -> str:
         return 'calibration'
     elif 'copy' in directory:
         return 'copy_phrase'
-    elif 'free_spell' in directory:
-        return 'free_spell'
     raise BciPyCoreException(f'No valid mode could be extracted from [{directory}]')
 
 

--- a/bcipy/helpers/tests/test_copy_phrase_wrapper.py
+++ b/bcipy/helpers/tests/test_copy_phrase_wrapper.py
@@ -123,7 +123,6 @@ class TestCopyPhraseWrapper(unittest.TestCase):
         self.assertEqual(len(letters), len(labels))
 
         triggers = [
-            ("calibration_trigger", 0.0),
             ("+", 0.1),
             ("H", 0.5670222830376588),
             ("D", 0.8171830819919705),
@@ -137,7 +136,6 @@ class TestCopyPhraseWrapper(unittest.TestCase):
             ("E", 2.833274284028448),
         ]
         target_info = [
-            "calib",
             "fixation",
             "nontarget",
             "nontarget",

--- a/bcipy/helpers/tests/test_load.py
+++ b/bcipy/helpers/tests/test_load.py
@@ -204,12 +204,6 @@ class TestExtractMode(unittest.TestCase):
         response = extract_mode(data_save_path)
         self.assertEqual(expected_mode, response)
 
-    def test_extract_mode_free_spell(self):
-        data_save_path = 'data/default/user/user_RSVP_Free_Spell_Mon_01_Mar_2021_11hr19min49sec_-0800'
-        expected_mode = 'free_spell'
-        response = extract_mode(data_save_path)
-        self.assertEqual(expected_mode, response)
-
     def test_extract_mode_without_mode_defined(self):
         invalid_data_save_dir = 'data/default/user/user_bad_dir'
         with self.assertRaises(BciPyCoreException):

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -410,16 +410,14 @@
     "type": "float"
   },
   "stim_font": {
-    "value": "Arial",
+    "value": "Consolas",
     "section": "bci_config",
     "readableName": "Stimulus Font",
     "helpTip": "Specifies the font used for text stimuli. Default: Arial",
     "recommended_values": [
-      "Verdana",
-      "Arial",
       "Courier New",
-      "Georgia",
-      "Times"
+      "Lucida Sans",
+      "Consolas"
     ],
     "type": "str"
   },
@@ -534,16 +532,14 @@
     "type": "str"
   },
   "info_font": {
-    "value": "Arial",
+    "value": "Consolas",
     "section": "bci_config",
     "readableName": "Font Text",
     "helpTip": "Font Text",
     "recommended_values": [
-      "Verdana",
-      "Arial",
       "Courier New",
-      "Georgia",
-      "Times"
+      "Lucida Sans",
+      "Consolas"
     ],
     "type": "str"
   },
@@ -564,24 +560,30 @@
     "type": "str"
   },
   "task_font": {
-    "value": "Arial",
+    "value": "Consolas",
     "section": "bci_config",
     "readableName": "Task Text Font",
     "helpTip": "Specifies the font used for task-specific text, e.g. #/100 in calibration and target phrase in copy/spelling. Default: Arial",
     "recommended_values": [
-      "Verdana",
-      "Arial",
       "Courier New",
-      "Georgia",
-      "Times"
+      "Lucida Sans",
+      "Consolas"
     ],
+    "type": "str"
+  },
+  "task_text": {
+    "value": "HELLO_WORLD",
+    "section": "bci_config",
+    "readableName": "Target Phrase",
+    "helpTip": "Specifies the target phrase displayed at the top of the screen during text-stimuli copy/spelling tasks.",
+    "recommended_values": "",
     "type": "str"
   },
   "task_height": {
     "value": "0.1",
     "section": "bci_config",
     "readableName": "Task Text Size",
-    "helpTip": "Specifies the height (in ???) of task-specific text, e.g. #/100 in calibration and target phrase in copy/spelling. Possible values range from X to X. Default: 0.1",
+    "helpTip": "Specifies the height (in ???) of task-specific text, e.g. #/100 in calibration and target phrase in copy/spelling. Possible values range from 0 to 1. Default: 0.1",
     "recommended_values": [
       "0.1"
     ],
@@ -725,14 +727,6 @@
     "recommended_values": "",
     "type": "bool"
   },
-  "task_text": {
-    "value": "HELLO_WORLD",
-    "section": "bci_config",
-    "readableName": "Target Phrase",
-    "helpTip": "Specifies the target phrase displayed at the top of the screen during text-stimuli copy/spelling tasks.",
-    "recommended_values": "",
-    "type": "str"
-  },
   "spelled_letters_count": {
     "value": "0",
     "section": "bci_config",
@@ -844,8 +838,8 @@
   "show_feedback": {
     "value": "true",
     "section": "feedback_config",
-    "readableName": "Calibration Feedback On/Off",
-    "helpTip": "If ‘true’, feedback will be displayed in the feedback calibration task.",
+    "readableName": "Task Feedback On/Off",
+    "helpTip": "If ‘true’, feedback in tasks that support it.",
     "recommended_values": "",
     "type": "bool"
   },
@@ -866,7 +860,7 @@
     "type": "float"
   },
   "feedback_pos_x": {
-    "value": "-0.72",
+    "value": "0",
     "section": "feedback_config",
     "readableName": "Feedback Position Horizontal",
     "helpTip": "Specifies the position of the left edge of the feedback display on the screen. Possible values range from -1 to 1, with 0 representing the center. Default: -0.72",
@@ -882,18 +876,38 @@
     "type": "float"
   },
   "feedback_stim_height": {
-    "value": "0.35",
+    "value": "0.2",
     "section": "feedback_config",
-    "readableName": "Feedback Box Height",
-    "helpTip": "Specifies the height of the feedback boxes (in ???). Default: 0.35",
+    "readableName": "Feedback Stimuli Height",
+    "helpTip": "Specifies the height of the feedback stimuli. Default: 0.2",
     "recommended_values": "",
     "type": "float"
+  },
+  "feedback_font": {
+    "value": "Consolas",
+    "section": "feedback_config",
+    "readableName": "feedback_font",
+    "helpTip": "feedback_font",
+    "recommended_values": [
+      "Courier New",
+      "Lucida Sans",
+      "Consolas"
+    ],
+    "type": "str"
+  },
+  "feedback_color": {
+    "value": "white",
+    "section": "feedback_config",
+    "readableName": "feedback_color",
+    "helpTip": "feedback_color",
+    "recommended_values": "",
+    "type": "str"
   },
   "feedback_stim_width": {
     "value": "0.35",
     "section": "feedback_config",
     "readableName": "Feedback Box Width",
-    "helpTip": "Specifies the width of the feedback boxes (in ???). Default: 0.35",
+    "helpTip": "Specifies the width of the LevelFeedback boxes in pixels. Default: 0.35",
     "recommended_values": "",
     "type": "float"
   },
@@ -901,31 +915,15 @@
     "value": "1",
     "section": "feedback_config",
     "readableName": "Feedback Box Outline Width",
-    "helpTip": "Specifies the stroke width of the feedback box outline. Default: 1",
+    "helpTip": "Specifies the stroke width of the LevelFeedback box outline. Default: 1",
     "recommended_values": "",
     "type": "float"
-  },
-  "feedback_font": {
-    "value": "Arial",
-    "section": "feedback_config",
-    "readableName": "feedback_font",
-    "helpTip": "feedback_font",
-    "recommended_values": "",
-    "type": "str"
-  },
-  "feedback_message_color": {
-    "value": "white",
-    "section": "feedback_config",
-    "readableName": "feedback_message_color",
-    "helpTip": "feedback_message_color",
-    "recommended_values": "",
-    "type": "str"
   },
   "feedback_line_color": {
     "value": "white",
     "section": "feedback_config",
     "readableName": "Feedback Box Outline Color",
-    "helpTip": " Specifies the color of the feedback box outline. Default: white",
+    "helpTip": " Specifies the color of the LevelFeedback box outline. Default: white",
     "recommended_values": "",
     "type": "str"
   },
@@ -933,7 +931,7 @@
     "value": "0.37",
     "section": "feedback_config",
     "readableName": "Feedback Box Spacing",
-    "helpTip": "Specifies the distance (in ???) between feedback boxes. Default: 0.37",
+    "helpTip": "Specifies the distance between LevelFeedback boxes. Default: 0.37",
     "recommended_values": "",
     "type": "float"
   },
@@ -941,7 +939,7 @@
     "value": "100",
     "section": "feedback_config",
     "readableName": "Feedback Target Outline Width",
-    "helpTip": "Specifies the stroke width of the target feedback box outline. Default: 100",
+    "helpTip": "Specifies the stroke width of the target feedback box outline using LevelFeedback. Default: 100",
     "recommended_values": "",
     "type": "int"
   },

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -74,8 +74,8 @@ class RSVPCopyPhraseTask(Task):
     PARAMETERS_USED = [
         'backspace_always_shown', 'decision_threshold', 'down_sampling_rate',
         'eeg_buffer_len', 'feedback_flash_time', 'feedback_font',
-        'feedback_line_width', 'feedback_message_color', 'feedback_pos_x',
-        'feedback_pos_y', 'feedback_stim_height', 'feedback_stim_width',
+        'feedback_color', 'feedback_pos_x',
+        'feedback_pos_y', 'feedback_stim_height',
         'filter_high', 'filter_low', 'filter_order', 'fixation_color',
         'info_color', 'info_font', 'info_height', 'info_text', 'is_txt_stim',
         'lm_backspace_prob', 'max_inq_len', 'max_inq_per_series',
@@ -114,6 +114,22 @@ class RSVPCopyPhraseTask(Task):
         self.evidence_types = [EvidenceType.LM, EvidenceType.ERP]
         if self.parameters['show_preview_inquiry']:
             self.evidence_types.append(EvidenceType.BTN)
+
+        self.file_save = file_save
+
+        self.trigger_handler = TriggerHandler(self.file_save, parameters['trigger_file_name'], FlushFrequency.EVERY)
+        self.session_save_location = f"{self.file_save}/{parameters['session_file_name']}"
+        self.copy_phrase = parameters['task_text']
+
+        self.fake = fake
+        self.language_model = language_model
+        self.signal_model = signal_model
+        self.evidence_precision = 5
+        self.feedback = VisualFeedback(self.window, self.parameters,
+                                       self.experiment_clock)
+
+        self.setup()
+
         # set a preview_only parameter
         self.parameters.add_entry(
             'preview_only',
@@ -127,18 +143,12 @@ class RSVPCopyPhraseTask(Task):
             }
         )
 
-        self.rsvp = _init_copy_phrase_display(self.parameters, self.window,
-                                              self.static_clock, self.experiment_clock)
-        self.file_save = file_save
-
-        self.trigger_handler = TriggerHandler(self.file_save, parameters['trigger_file_name'], FlushFrequency.EVERY)
-        self.session_save_location = f"{self.file_save}/{parameters['session_file_name']}"
-        self.copy_phrase = parameters['task_text']
-
-        self.fake = fake
-        self.language_model = language_model
-        self.signal_model = signal_model
-        self.evidence_precision = 5
+        self.rsvp = _init_copy_phrase_display(
+            self.parameters,
+            self.window,
+            self.static_clock,
+            self.experiment_clock,
+            self.spelled_text)
 
     def setup(self) -> None:
         """Initialize/reset parameters used in the execute run loop."""
@@ -296,12 +306,7 @@ class RSVPCopyPhraseTask(Task):
         - correct : whether or not the correct stim was chosen
         """
         if self.parameters['show_feedback']:
-            feedback = VisualFeedback(self.window, self.parameters,
-                                      self.experiment_clock)
-            feedback.administer(
-                selection,
-                message='Selected:',
-                fill_color=self.parameters['feedback_message_color'])
+            self.feedback.administer(f'Selected: {selection}')
 
     def check_stop_criteria(self) -> bool:
         """Returns True if experiment is currently within params and the task
@@ -346,8 +351,6 @@ class RSVPCopyPhraseTask(Task):
         data save location (triggers.txt, session.json)
         """
         self.logger.debug('Starting Copy Phrase Task!')
-        self.setup()
-
         run = self.await_start()
 
         while run and self.user_wants_to_continue(
@@ -783,7 +786,7 @@ class TaskSummary:
         ]
 
 
-def _init_copy_phrase_display(parameters, win, static_clock, experiment_clock):
+def _init_copy_phrase_display(parameters, win, static_clock, experiment_clock, starting_spelled_text):
     preview_inquiry = PreviewInquiryProperties(
         preview_only=parameters['preview_only'],
         preview_inquiry_length=parameters['preview_inquiry_length'],
@@ -806,11 +809,13 @@ def _init_copy_phrase_display(parameters, win, static_clock, experiment_clock):
                                 stim_colors=[parameters['stim_color']] * parameters['stim_length'],
                                 stim_timing=[10] * parameters['stim_length'],
                                 is_txt_stim=parameters['is_txt_stim'])
+    padding = abs(len(parameters['task_text']) - len(starting_spelled_text))
+    starting_spelled_text += ' ' * padding
     task_display = TaskDisplayProperties(task_color=[parameters['task_color']],
-                                         task_pos=(-.8, .85),
+                                         task_pos=(0, 1 - (2 * parameters['task_height'])),
                                          task_font=parameters['task_font'],
                                          task_height=parameters['task_height'],
-                                         task_text='*')
+                                         task_text=starting_spelled_text)
     return CopyPhraseDisplay(win,
                              static_clock,
                              experiment_clock,


### PR DESCRIPTION
# Overview

Added a custom `wait_message` method to RSVP `CopyPhraseDisplay` to support display of target text during sessions.

## Ticket

- https://www.pivotaltracker.com/story/show/180154991

## Contributions

- `display/rsvp/mode/copy_phrase.py`: custom wait_message that draws static. Updated the location of the task bar / information & task text. I created a ticket to refactor and formalize this space. See https://www.pivotaltracker.com/story/show/180881866
- `task/paradigm/rsvp/copy_phrase.py`: update the initial task text

## Test

- `bcipy` to ensure no changes to calibration
- `bcipy --task "RSVP Copy Phrase"` to ensure the copy text is present at top, run the task, pause and ensure the same text appears
-   `make test-all`

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? N/A
