### PR TITLE
Button press fix

### DIFF
--- a/bcipy/signal/model/inquiry_preview.py
+++ b/bcipy/signal/model/inquiry_preview.py
@@ -1,7 +1,7 @@
 from typing import List
 
 
-def compute_probs_after_preview(
+def _OLD_compute_probs_after_preview(
     inquiry: List[str], symbol_set: List[str], user_error_prob: float, proceed: bool
 ) -> List[float]:
     """
@@ -29,3 +29,103 @@ def compute_probs_after_preview(
         other_letter_value = (1 - user_error_prob) / (sym_set_len - inq_len)
 
     return [shown_letter_value if letter in inquiry else other_letter_value for letter in symbol_set]
+
+
+def compute_probs_after_preview(
+    query: List[str], alphabet: List[str], user_error_prob: float, proceed: bool
+) -> List[float]:
+    """
+    Notation:
+    - "want" = desired letter
+    - "show" = shown letters
+    - "+" = user selected
+    - "-" = user not selected
+
+    Assumptions:
+    1. "want" independent of "show".
+        - if we start from uniform alphabet, and treat each query as independent event, this is true
+        - this is false if our shown letters are very enriched (in that case, we would bet on the displayed letters!)
+        - used to say p(want | show) = p(want)
+        - To avoid this assumption, we need info on past queries and responses somehow!
+    2. User's errors are symmetric. p(+ | want not in show) = p(- | want in show) = user_error_prob
+
+    Args:
+        query - the symbols presented in the query preview
+        alphabet - the full alphabet of symbols
+        proceed - whether or not the user wants to proceed with this query
+        user_error_prob - the probability that the user selects incorrectly during preview
+    """
+    if not 0 <= user_error_prob <= 1:
+        raise ValueError(f"invalid user error prob: {user_error_prob}")
+
+    uniform_prior = 1 / len(alphabet)
+
+    if proceed:
+        """suppose user_error_prob = 0.05, and len(alphabet) = 28. suppose we present AB (random 2 of 28 letters).
+        the user responds positively ("+")
+            p(want=A | +, show=AB) = p(+ | want=A, show=AB) p(want=A | show=AB) / p(+ | show=AB)
+                                   = p(+ | want in show) p(want=A) / p(+ | show=AB)                 # Use assumption 1
+                                   = 0.95 * (1/28) / [
+                                        p(+ | want=A, show=AB) p(want=A)
+                                        + p(+ | want=B, show=AB) p(want=B)
+                                        + p(+ | want=C, show=AB) p(want=C)
+                                        ...
+                                        + p(+ | want=Z, show=AB) p(want=Z)
+                                    ]
+
+        We can compute this from just 2 terms:
+            shown_term = p(+ | want=shown_letter, show=[....,shown_letter,...]) p(want=shown_letter)
+            unshown_term = p(+ | want=unshown_letter, show=[...]) p(want=unshown_letter)
+
+        Then we can update as follows:
+            p(shown_letter | +, show=[...]) = shown_term / [
+                                                len(show) * shown_term
+                                                + (len(alphabet) - len(show)) * unshown_term
+                                            ]
+
+            p(unshown_letter | +, show=[...]) = unshown_term / [
+                                                len(show) * shown_term
+                                                + (len(alphabet) - len(show)) * unshown_term
+                                            ]"""
+        shown_term = uniform_prior * (1 - user_error_prob)
+        unshown_term = uniform_prior * user_error_prob
+
+        # p(+ | show=inquiry) - the denominator for bayes rule
+        n_shown = len(query)
+        n_unshown = len(alphabet) - n_shown
+        marginal = n_shown * shown_term + n_unshown * unshown_term
+
+        shown_letter_value = shown_term / marginal
+        other_letter_value = unshown_term / marginal
+
+    else:
+        """Same assumptions as above, but now user responds "-"
+            p(want=A | -, show=AB) = p(- | want=A, show=AB) p(want=A | show=AB) / p(- | show=AB)
+                                   = p(- | want in show) p(want=A) / p(- | show=AB)                 # Use assumption 1
+
+        We can compute this from just 2 terms:
+            shown_term = p(- | want=shown_letter, show=[....,shown_letter,...]) p(want=shown_letter)
+            unshown_term = p(- | want=unshown_letter, show=[...]) p(want=unshown_letter)
+
+        Then we can update as follows:
+            p(shown_letter | -, show=[...]) = shown_term / [
+                                                len(show) * shown_term
+                                                + (len(alphabet) - len(show)) * unshown_term
+                                            ]
+
+            p(unshown_letter | -, show=[...]) = unshown_term / [
+                                                len(show) * shown_term
+                                                + (len(alphabet) - len(show)) * unshown_term
+                                            ]"""
+        shown_term = uniform_prior * user_error_prob
+        unshown_term = uniform_prior * (1 - user_error_prob)
+
+        # p(- | show=inquiry) - denominator for bayes rule
+        n_shown = len(query)
+        n_unshown = len(alphabet) - n_shown
+        marginal = n_shown * shown_term + n_unshown * unshown_term
+
+        shown_letter_value = shown_term / marginal
+        other_letter_value = unshown_term / marginal
+
+    return [shown_letter_value if letter in query else other_letter_value for letter in alphabet]

--- a/bcipy/signal/model/inquiry_preview.py
+++ b/bcipy/signal/model/inquiry_preview.py
@@ -2,7 +2,7 @@ from typing import List
 
 
 def compute_probs_after_preview(
-    query: List[str], alphabet: List[str], user_error_prob: float, proceed: bool
+    inquiry: List[str], symbol_set: List[str], user_error_prob: float, proceed: bool
 ) -> List[float]:
     r"""
     Notation:
@@ -21,14 +21,14 @@ def compute_probs_after_preview(
        The user's behavior is fully determined by their desired letter and the shown letters.
        Only some edge effects such as frustration or fatigue are ignored by this.
 
-    We're interested in the alphabet posterior overall:
+    We're interested in the symbol_set posterior overall:
 
         p(want | button, show, past) = p(button | want, show, past) p(want | show, past) / p(button | show, past)
                                     # Use assumption 2.
                                     = p(button | want, show) p(want | show, past) / p(button | show, past)
                                     # Given past, show does not affect want
                                     = p(button | want, show) p(want | past) / p(button | show, past)
-                                    # Will normalize over alphabet anyway. Can ignore normalization const.
+                                    # Will normalize over symbol_set anyway. Can ignore normalization const.
                                     \propto p(button | want, show) p(want | past)
                                     # Leave out the prior - this is handled outside by evidence fusion.
                                     \propto p(button | want, show)
@@ -60,7 +60,7 @@ def compute_probs_after_preview(
     Thus, for a "+" response, the total probability given to the shown letters should grow as the inquiry length grows.
 
     >>> def example(N, L):
-    ...     # Show N letters from an alphabet of length L
+    ...     # Show N letters from an symbol_set of length L
     ...     probs = np.array([0.95]*N + [0.05] * (L-N))
     ...     probs /= probs.sum()
     ...     # Check the effect of a "+" response on the N shown letters
@@ -74,9 +74,9 @@ def compute_probs_after_preview(
     0.99
 
     Args:
-        query - the symbols presented in the query preview
-        alphabet - the full alphabet of symbols
-        proceed - whether or not the user wants to proceed with this query
+        inquiry - the symbols presented in the inquiry preview
+        symbol_set - the full symbol_set of symbols
+        proceed - whether or not the user wants to proceed with this inquiry
         user_error_prob - the probability that the user selects incorrectly during preview
     """
     if not 0 <= user_error_prob <= 1:
@@ -89,4 +89,4 @@ def compute_probs_after_preview(
         shown_letter_value = user_error_prob
         other_letter_value = 1 - user_error_prob
 
-    return [shown_letter_value if letter in query else other_letter_value for letter in alphabet]
+    return [shown_letter_value if letter in inquiry else other_letter_value for letter in symbol_set]

--- a/bcipy/signal/model/inquiry_preview.py
+++ b/bcipy/signal/model/inquiry_preview.py
@@ -1,53 +1,77 @@
 from typing import List
 
 
-def _OLD_compute_probs_after_preview(
-    inquiry: List[str], symbol_set: List[str], user_error_prob: float, proceed: bool
-) -> List[float]:
-    """
-    When the user responds to an inquiry preview, we compute a likelihood term for each symbol
-    based on their response. These likelihood terms will be multiplied with the prior probabilities of
-    each symbol and then normalized, in order to update the symbol probabilities.
-
-    Args:
-        inquiry - the symbols presented in the inquiry preview
-        symbol_set - the full alphabet of symbols
-        proceed - whether or not the user wants to proceed with this inquiry
-        user_error_prob - the probability that the user selects incorrectly during preview
-    """
-    inq_len = len(inquiry)
-    sym_set_len = len(symbol_set)
-    if not 0 <= user_error_prob <= 1:
-        raise ValueError(f"invalid user error prob: {user_error_prob}")
-
-    if proceed:  # user liked the inquiry; presented letters are upgraded and others are downgraded
-        shown_letter_value = (1 - user_error_prob) / inq_len
-        other_letter_value = user_error_prob / (sym_set_len - inq_len)
-
-    else:  # user disliked the inquiry; presented are downgraded and others are upgraded
-        shown_letter_value = user_error_prob / inq_len
-        other_letter_value = (1 - user_error_prob) / (sym_set_len - inq_len)
-
-    return [shown_letter_value if letter in inquiry else other_letter_value for letter in symbol_set]
-
-
 def compute_probs_after_preview(
     query: List[str], alphabet: List[str], user_error_prob: float, proceed: bool
 ) -> List[float]:
-    """
+    r"""
     Notation:
     - "want" = desired letter
     - "show" = shown letters
-    - "+" = user selected
-    - "-" = user not selected
+    - "button" = user's button response. "+" = user selected, "-" = user not selected
+    - "past" = prior from language model and possibly previous button evidence
 
     Assumptions:
-    1. "want" independent of "show".
-        - if we start from uniform alphabet, and treat each query as independent event, this is true
-        - this is false if our shown letters are very enriched (in that case, we would bet on the displayed letters!)
-        - used to say p(want | show) = p(want)
-        - To avoid this assumption, we need info on past queries and responses somehow!
-    2. User's errors are symmetric. p(+ | want not in show) = p(- | want in show) = user_error_prob
+    1. User's errors are symmetric. p(+ | want not in show) = p(- | want in show) = user_error_prob
+       This lets us use a single error rate to describe the user behavior for all cases
+       (desired letter shown/not shown, response of + or -)
+       The alternative would be determining one rate of accidental presses and another rate of accidental misses.
+
+    2. Given the shown letters and user's desired letter, their response is independent of previous events.
+       The user's behavior is fully determined by their desired letter and the shown letters.
+       Only some edge effects such as frustration or fatigue are ignored by this.
+
+    We're interested in the alphabet posterior overall:
+
+        p(want | button, show, past) = p(button | want, show, past) p(want | show, past) / p(button | show, past)
+                                    # Use assumption 2.
+                                    = p(button | want, show) p(want | show, past) / p(button | show, past)
+                                    # Given past, show does not affect want
+                                    = p(button | want, show) p(want | past) / p(button | show, past)
+                                    # Will normalize over alphabet anyway. Can ignore normalization const.
+                                    \propto p(button | want, show) p(want | past)
+                                    # Leave out the prior - this is handled outside by evidence fusion.
+                                    \propto p(button | want, show)
+                                            ~~~~~~~~~~~~~~~~~~~~~~
+                                                    |
+                                    These are the multiplicative updates we'll return.
+
+
+    For shown letters, if the user gives a positive button response, we have terms like:
+
+        p(want=A | +, show=ABC, past) \propto p(+ | want=A, show=ABC)
+                                      \propto p(+ | want in show) = "probability of correct button press"
+
+    And for shown letters, a negative response gives us terms like this:
+
+        p(want=A | -, show=ABC, past) \propto p(- | want=A, show=ABC)
+                                      \propto p(- | want in show) = "probability of incorrect button press"
+
+    For unshown letter, positive button response:
+
+        p(want=Z | +, show=ABC, past) \propto p(+ | want not in show) = "probability of incorrect button press"
+
+    For unshown letter, negative button response:
+
+        p(want=Z | -, show=ABC, past) \propto p(- | want not in show) = "probability of correct button press"
+
+    Note that this simple rule, followed by normalizing the result vector, has the desired scaling property;
+    with larger inquiries, the prior probability of a "+" reponse is larger.
+    Thus, for a "+" response, the total probability given to the shown letters should grow as the inquiry length grows.
+
+    >>> def example(N, L):
+    ...     # Show N letters from an alphabet of length L
+    ...     probs = np.array([0.95]*N + [0.05] * (L-N))
+    ...     probs /= probs.sum()
+    ...     # Check the effect of a "+" response on the N shown letters
+    ...     res = probs[:N].sum()
+    ...     print(format(res, "0.2f"))
+    >>> example(2, 10)
+    0.83
+    >>> example(5, 10)
+    0.95
+    >>> example(8, 10)
+    0.99
 
     Args:
         query - the symbols presented in the query preview
@@ -58,70 +82,11 @@ def compute_probs_after_preview(
     if not 0 <= user_error_prob <= 1:
         raise ValueError(f"invalid user error prob: {user_error_prob}")
 
-    """suppose user_error_prob = 0.05, and len(alphabet) = 28. suppose we present AB (random 2 of 28 letters).
-    the user responds positively ("+")
-        p(want=A | +, show=AB) = p(+ | want=A, show=AB) p(want=A | show=AB) / p(+ | show=AB)
-                                = p(+ | want in show) p(want=A) / p(+ | show=AB)                 # Use assumption 1
-                                = 0.95 * (1/28) / [
-                                    p(+ | want=A, show=AB) p(want=A)
-                                    + p(+ | want=B, show=AB) p(want=B)
-                                    + p(+ | want=C, show=AB) p(want=C)
-                                    ...
-                                    + p(+ | want=Z, show=AB) p(want=Z)
-                                ]
-
-    We can compute this from just 2 terms:
-        shown_term = p(+ | want=shown_letter, show=[....,shown_letter,...]) p(want=shown_letter)
-        unshown_term = p(+ | want=unshown_letter, show=[...]) p(want=unshown_letter)
-
-    Then we can update as follows:
-        p(shown_letter | +, show=[...]) = shown_term / [
-                                            len(show) * shown_term
-                                            + (len(alphabet) - len(show)) * unshown_term
-                                        ]
-
-        p(unshown_letter | +, show=[...]) = unshown_term / [
-                                            len(show) * shown_term
-                                            + (len(alphabet) - len(show)) * unshown_term
-                                        ]
-
-    If user responds negatively ("-"):
-    Same assumptions as above, but now user responds "-"
-        p(want=A | -, show=AB) = p(- | want=A, show=AB) p(want=A | show=AB) / p(- | show=AB)
-                                = p(- | want in show) p(want=A) / p(- | show=AB)                 # Use assumption 1
-
-    We can compute this from just 2 terms:
-        shown_term = p(- | want=shown_letter, show=[....,shown_letter,...]) p(want=shown_letter)
-        unshown_term = p(- | want=unshown_letter, show=[...]) p(want=unshown_letter)
-
-    Then we can update as follows:
-        p(shown_letter | -, show=[...]) = shown_term / [
-                                            len(show) * shown_term
-                                            + (len(alphabet) - len(show)) * unshown_term
-                                        ]
-
-        p(unshown_letter | -, show=[...]) = unshown_term / [
-                                            len(show) * shown_term
-                                            + (len(alphabet) - len(show)) * unshown_term
-                                        ]"""
-
     if proceed:
-        shown_term = 1 - user_error_prob
-        unshown_term = user_error_prob
+        shown_letter_value = 1 - user_error_prob
+        other_letter_value = user_error_prob
     else:
-        shown_term = user_error_prob
-        unshown_term = 1 - user_error_prob
-
-    # the denominator for bayes rule.
-    # If inquiry is very long, the prior prob of selecting the inquiry is high.
-    # Normalizing here accounts for this.
-    n_shown = len(query)
-    n_unshown = len(alphabet) - n_shown
-    marginal = n_shown * shown_term + n_unshown * unshown_term
-
-    # shown_letter_value = shown_term / marginal
-    # other_letter_value = unshown_term / marginal
-    shown_letter_value = shown_term
-    other_letter_value = unshown_term
+        shown_letter_value = user_error_prob
+        other_letter_value = 1 - user_error_prob
 
     return [shown_letter_value if letter in query else other_letter_value for letter in alphabet]

--- a/bcipy/signal/tests/model/test_inquiry_preview.py
+++ b/bcipy/signal/tests/model/test_inquiry_preview.py
@@ -1,33 +1,29 @@
+from abc import ABC
 import unittest
 import numpy as np
 from bcipy.signal.model.inquiry_preview import compute_probs_after_preview
+from string import ascii_uppercase
 
 
-class TestInquiryPreview(unittest.TestCase):
-    def setUp(self):
-        self.inquiry = ["A", "E", "I", "O", "U"]
-        self.symbol_set = self.inquiry + ["Y"]
-        self.error_prob = 0.05
+class InqPreviewBaseTest(ABC):
+    def _compare(self, results, p_shown, p_not_shown):
+        expected = np.array(self.show_first * [p_shown] + (len(self.symbol_set) - self.show_first) * [p_not_shown])
+        expected /= expected.sum()
+        self.assertTrue(np.allclose(results, expected))
 
     def test_user_likes_inquiry(self):
-        proceed = True
-        results = compute_probs_after_preview(self.inquiry, self.symbol_set, self.error_prob, proceed)
-
-        p_shown = 0.19  # (1 - 0.05) / 5
-        p_not_shown = 0.05  # 0.05 / (6 - 1)
-        expected = [p_shown, p_shown, p_shown, p_shown, p_shown, p_not_shown]
-
-        self.assertTrue(np.allclose(results, expected))
+        # Upvote the shown letters
+        results = compute_probs_after_preview(self.inquiry, self.symbol_set, self.error_prob, proceed=True)
+        p_shown = self.uniform_prior * (1 - self.error_prob)
+        p_not_shown = self.uniform_prior * self.error_prob
+        self._compare(results, p_shown, p_not_shown)
 
     def test_user_dislikes_inquiry(self):
-        proceed = False
-        results = compute_probs_after_preview(self.inquiry, self.symbol_set, self.error_prob, proceed)
-
-        p_shown = 0.01  # 0.05 / 5
-        p_not_shown = 0.95  # (1 - 0.05) / 1
-        expected = [p_shown, p_shown, p_shown, p_shown, p_shown, p_not_shown]
-
-        self.assertTrue(np.allclose(results, expected))
+        # Downvote the shown letters
+        results = compute_probs_after_preview(self.inquiry, self.symbol_set, self.error_prob, proceed=False)
+        p_shown = self.uniform_prior * self.error_prob
+        p_not_shown = self.uniform_prior * (1 - self.error_prob)
+        self._compare(results, p_shown, p_not_shown)
 
     def test_invalid_error_prob(self):
         with self.assertRaises(ValueError):
@@ -35,6 +31,44 @@ class TestInquiryPreview(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             compute_probs_after_preview(self.inquiry, self.symbol_set, 1.01, True)
+
+    def test_user_likes_with_LM(self):
+        results = compute_probs_after_preview(self.inquiry, self.symbol_set, self.error_prob, proceed=True)
+        p_shown = self.uniform_prior * (1 - self.error_prob)
+        p_not_shown = self.uniform_prior * self.error_prob
+
+        # Dummy LM only uses 2 values (V and 2*V, such that the alphabet is normalized
+        # Its large value is used for some shown, and some unshown letters. Its small value also used for both.
+        lm_prior = np.ones(len(self.symbol_set))
+        lm_prior[0 : self.show_first - 1] = 2
+        lm_prior[-1] = 2
+        lm_prior /= lm_prior.sum()
+
+        update = np.array(self.show_first * [p_shown] + (len(self.symbol_set) - self.show_first) * [p_not_shown])
+        update /= update.sum()
+
+        expected = update * lm_prior
+        expected /= expected.sum()
+        breakpoint()
+
+    def test_user_dislikes_with_LM(self):
+        results = compute_probs_after_preview(self.inquiry, self.symbol_set, self.error_prob, proceed=False)
+
+
+class TestShortAlphabet(unittest.TestCase, InqPreviewBaseTest):
+    def setUp(self):
+        self.symbol_set = list("ABCDEFG")
+        self.inquiry, self.show_first = list("ABC"), 3
+        self.error_prob = 0.05
+        self.uniform_prior = 1 / len(self.symbol_set)
+
+
+class TestLongAlphabet(unittest.TestCase, InqPreviewBaseTest):
+    def setUp(self):
+        self.symbol_set = list(ascii_uppercase)
+        self.inquiry, self.show_first = list("ABCDE"), 5
+        self.error_prob = 0.05
+        self.uniform_prior = 1 / len(self.symbol_set)
 
 
 if __name__ == "__main__":

--- a/bcipy/signal/tests/model/test_inquiry_preview.py
+++ b/bcipy/signal/tests/model/test_inquiry_preview.py
@@ -1,76 +1,46 @@
-from abc import ABC
 import unittest
 import numpy as np
 from bcipy.signal.model.inquiry_preview import compute_probs_after_preview
 from string import ascii_uppercase
 
 
-class InqPreviewBaseTest(ABC):
-    def _compare(self, results, p_shown, p_not_shown):
-        expected = np.array(self.show_first * [p_shown] + (len(self.symbol_set) - self.show_first) * [p_not_shown])
-        expected /= expected.sum()
-        self.assertTrue(np.allclose(results, expected))
-
-    def test_user_likes_inquiry(self):
-        # Upvote the shown letters
-        results = compute_probs_after_preview(self.inquiry, self.symbol_set, self.error_prob, proceed=True)
-        p_shown = self.uniform_prior * (1 - self.error_prob)
-        p_not_shown = self.uniform_prior * self.error_prob
-        breakpoint()
-        self._compare(results, p_shown, p_not_shown)
-
-    def test_user_dislikes_inquiry(self):
-        # Downvote the shown letters
-        results = compute_probs_after_preview(self.inquiry, self.symbol_set, self.error_prob, proceed=False)
-        p_shown = self.uniform_prior * self.error_prob
-        p_not_shown = self.uniform_prior * (1 - self.error_prob)
-        self._compare(results, p_shown, p_not_shown)
-
-    def test_invalid_error_prob(self):
-        with self.assertRaises(ValueError):
-            compute_probs_after_preview(self.inquiry, self.symbol_set, -0.01, True)
-
-        with self.assertRaises(ValueError):
-            compute_probs_after_preview(self.inquiry, self.symbol_set, 1.01, True)
-
-    def test_user_likes_with_LM(self):
-        return
-        results = compute_probs_after_preview(self.inquiry, self.symbol_set, self.error_prob, proceed=True)
-        p_shown = self.uniform_prior * (1 - self.error_prob)
-        p_not_shown = self.uniform_prior * self.error_prob
-
-        # Dummy LM only uses 2 values (V and 2*V, such that the alphabet is normalized
-        # Its large value is used for some shown, and some unshown letters. Its small value also used for both.
-        lm_prior = np.ones(len(self.symbol_set))
-        lm_prior[0 : self.show_first - 1] = 2
-        lm_prior[-1] = 2
-        lm_prior /= lm_prior.sum()
-
-        update = np.array(self.show_first * [p_shown] + (len(self.symbol_set) - self.show_first) * [p_not_shown])
-        update /= update.sum()
-
-        expected = update * lm_prior
-        expected /= expected.sum()
-        breakpoint()
-
-    def test_user_dislikes_with_LM(self):
-        results = compute_probs_after_preview(self.inquiry, self.symbol_set, self.error_prob, proceed=False)
-
-
-class TestShortAlphabet(unittest.TestCase, InqPreviewBaseTest):
-    def setUp(self):
-        self.symbol_set = list("ABCDEFG")
-        self.inquiry, self.show_first = list("ABC"), 3
-        self.error_prob = 0.05
-        self.uniform_prior = 1 / len(self.symbol_set)
-
-
-class TestLongAlphabet(unittest.TestCase, InqPreviewBaseTest):
+class TestInquiryPreview(unittest.TestCase):
     def setUp(self):
         self.symbol_set = list(ascii_uppercase)
-        self.inquiry, self.show_first = list("ABCDE"), 5
-        self.error_prob = 0.05
-        self.uniform_prior = 1 / len(self.symbol_set)
+
+    def _test(self, inquiry_len, error_prob, user_likes: bool):
+        if user_likes:
+            p_shown = 1 - error_prob
+            p_not_shown = error_prob
+        else:
+            p_shown = error_prob
+            p_not_shown = 1 - error_prob
+
+        inquiry = self.symbol_set[:inquiry_len]
+        results = compute_probs_after_preview(inquiry, self.symbol_set, error_prob, user_likes)
+
+        expected = np.array(inquiry_len * [p_shown] + (len(self.symbol_set) - inquiry_len) * [p_not_shown])
+        self.assertTrue(np.allclose(results, expected))
+
+    def test_user_likes_short_inquiry(self):
+        self._test(5, 0.95, True)
+
+    def test_user_likes_long_inquiry(self):
+        self._test(15, 0.95, True)
+
+    def test_user_dislikes_short_inquiry(self):
+        self._test(5, 0.95, False)
+
+    def test_user_dislikes_long_inquiry(self):
+        self._test(15, 0.95, False)
+
+    def test_invalid_error_prob(self):
+        inquiry = self.symbol_set[:10]
+        with self.assertRaises(ValueError):
+            compute_probs_after_preview(inquiry, self.symbol_set, -0.01, True)
+
+        with self.assertRaises(ValueError):
+            compute_probs_after_preview(inquiry, self.symbol_set, 1.01, True)
 
 
 if __name__ == "__main__":

--- a/bcipy/signal/tests/model/test_inquiry_preview.py
+++ b/bcipy/signal/tests/model/test_inquiry_preview.py
@@ -16,6 +16,7 @@ class InqPreviewBaseTest(ABC):
         results = compute_probs_after_preview(self.inquiry, self.symbol_set, self.error_prob, proceed=True)
         p_shown = self.uniform_prior * (1 - self.error_prob)
         p_not_shown = self.uniform_prior * self.error_prob
+        breakpoint()
         self._compare(results, p_shown, p_not_shown)
 
     def test_user_dislikes_inquiry(self):
@@ -33,6 +34,7 @@ class InqPreviewBaseTest(ABC):
             compute_probs_after_preview(self.inquiry, self.symbol_set, 1.01, True)
 
     def test_user_likes_with_LM(self):
+        return
         results = compute_probs_after_preview(self.inquiry, self.symbol_set, self.error_prob, proceed=True)
         p_shown = self.uniform_prior * (1 - self.error_prob)
         p_not_shown = self.uniform_prior * self.error_prob


### PR DESCRIPTION
# Overview

Slightly adjust logic for button press evidence

## Ticket

https://www.pivotaltracker.com/story/show/180860945

## Contributions

- Adjust how button press evidence is used to compute likelihood updates. 
- Add more documentation and tests.

## Test

`xvfb-run --auto-servernum pytest bcipy/signal/tests/model/test_inquiry_preview.py --disable-warnings`

## Documentation

- Added doc strings