### PR TITLE
Integrate GPT2 Language Model

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build-ubuntu:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     strategy:
       fail-fast: false
       matrix:
@@ -45,7 +45,7 @@ jobs:
     - name: Unit test
       run: |
         xvfb-run coverage run --branch --source=bcipy -m pytest --mpl -k "not slow"
-        
+
   build-windows:
 
     runs-on: windows-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build-ubuntu:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/bcipy/helpers/copy_phrase_wrapper.py
+++ b/bcipy/helpers/copy_phrase_wrapper.py
@@ -7,7 +7,6 @@ from bcipy.helpers.acquisition import analysis_channels
 from bcipy.helpers.exceptions import BciPyCoreException
 from bcipy.helpers.language_model import (
     histogram,
-    norm_domain,
     sym_appended,
 )
 from bcipy.helpers.stimuli import InquirySchedule, StimuliOrder
@@ -293,11 +292,6 @@ class CopyPhraseWrapper:
 
             # update the lmodel and get back the priors
             lm_letter_prior = self.lmodel.predict(list(update))
-
-            # normalize to probability domain if needed
-            normalized = getattr(self.lmodel, 'normalized', False)
-            if not normalized:
-                lm_letter_prior = norm_domain(lm_letter_prior)
 
             if BACKSPACE_CHAR in self.alp:
                 # Append backspace if missing.

--- a/bcipy/helpers/exceptions.py
+++ b/bcipy/helpers/exceptions.py
@@ -61,3 +61,10 @@ class InvalidFieldException(FieldException):
     """
 
     ...
+
+
+class UnsupportedResponseType(BciPyCoreException):
+    """Unsupported ResponseType
+
+    Thrown when attempting to set the response type of a language model to an
+    unsupported value."""

--- a/bcipy/helpers/language_model.py
+++ b/bcipy/helpers/language_model.py
@@ -3,10 +3,21 @@ import math
 import inspect
 from typing import Dict, List, Tuple
 import numpy as np
-from bcipy.language_model.lm_modes import LmType
+from bcipy.language.main import LanguageModel, ResponseType
+from bcipy.helpers.system_utils import import_submodules
+from bcipy.helpers.task import alphabet
+
+import_submodules('bcipy.language')
+# TODO: remove this import: https://www.pivotaltracker.com/story/show/178695472
+import_submodules('bcipy.language_model')
 
 
-def init_language_model(parameters: dict):
+def language_models_by_name() -> Dict[str, LanguageModel]:
+    """Returns available language models indexed by name."""
+    return {lm.name(): lm for lm in LanguageModel.__subclasses__()}
+
+
+def init_language_model(parameters: dict) -> LanguageModel:
     """
     Init Language Model configured in the parameters.
 
@@ -17,19 +28,22 @@ def init_language_model(parameters: dict):
 
     Returns
     -------
-        instance of a LanguageModel.
+        instance of a LanguageModel
     """
+    language_models = language_models_by_name()
     if not parameters['lang_model_enabled']:
-        model = LmType['UNIFORM'].model
+        model = language_models['UNIFORM']
     else:
-        model = LmType[parameters.get("lang_model_type", "PRELM")].model
+        model = language_models[parameters.get("lang_model_type", "GPT2")]
 
     # introspect the model arguments to determine what parameters to pass.
     args = inspect.signature(model).parameters.keys()
 
     # select the relevant parameters into a dict.
     params = {key: parameters[key] for key in args & parameters.keys()}
-    return model(**params)
+    return model(response_type=ResponseType.SYMBOL,
+                 symbol_set=alphabet(parameters),
+                 **params)
 
 
 def norm_domain(priors: List[Tuple[str, float]]) -> List[Tuple[str, float]]:
@@ -77,33 +91,6 @@ def sym_appended(symbol_probs: List[Tuple[str, float]],
     return list(zip(all_symbols, normalized))
 
 
-def equally_probable(alphabet: List[str],
-                     specified: Dict[str, float] = None) -> List[float]:
-    """Returns a list of probabilities which correspond to the provided
-    alphabet. Unless overridden by the specified values, all items will
-    have the same probability. All probabilities sum to 1.0.
-
-    Parameters:
-    ----------
-        alphabet - list of symbols; a probability will be generated for each.
-        specified - dict of symbol => probability values for which we want to
-            override the default probability.
-    Returns:
-    --------
-        list of probabilities (floats)
-    """
-    n_letters = len(alphabet)
-    if not specified:
-        return np.full(n_letters, 1 / n_letters)
-
-    # copy specified dict ignoring non-alphabet items
-    overrides = {k: specified[k] for k in alphabet if k in specified}
-
-    prob = (1 - sum(overrides.values())) / (n_letters - len(overrides))
-    # override specified values
-    return [overrides[sym] if sym in overrides else prob for sym in alphabet]
-
-
 def histogram(letter_prior: List[Tuple[str, float]]) -> str:
     """Given a list of letter, prob tuples, generate a histogram that can be
     output to the console.
@@ -120,5 +107,6 @@ def histogram(letter_prior: List[Tuple[str, float]]) -> str:
     lines = []
     for letter, prob in sorted(letter_prior):
         units = int(round(prob * 100))
-        lines.append(letter + ' (' + "%03.2f" % (prob) + ") :" + margin + (units * star))
+        lines.append(letter + ' (' + "%03.2f" % (prob) + ") :" + margin +
+                     (units * star))
     return '\n'.join(lines)

--- a/bcipy/helpers/language_model.py
+++ b/bcipy/helpers/language_model.py
@@ -4,12 +4,15 @@ import inspect
 from typing import Dict, List, Tuple
 import numpy as np
 from bcipy.language.main import LanguageModel, ResponseType
-from bcipy.helpers.system_utils import import_submodules
 from bcipy.helpers.task import alphabet
-
-import_submodules('bcipy.language')
+# pylint: disable=unused-import
+# flake8: noqa
+from bcipy.language.uniform import UniformLanguageModel
+# flake8: noqa
+from bcipy.language.model.gpt2 import GPT2LanguageModel
 # TODO: remove this import: https://www.pivotaltracker.com/story/show/178695472
-import_submodules('bcipy.language_model')
+# flake8: noqa
+from bcipy.language_model.prelm_language_model import PrelmLanguageModel
 
 
 def language_models_by_name() -> Dict[str, LanguageModel]:
@@ -31,10 +34,7 @@ def init_language_model(parameters: dict) -> LanguageModel:
         instance of a LanguageModel
     """
     language_models = language_models_by_name()
-    if not parameters['lang_model_enabled']:
-        model = language_models['UNIFORM']
-    else:
-        model = language_models[parameters.get("lang_model_type", "GPT2")]
+    model = language_models[parameters.get("lang_model_type", "UNIFORM")]
 
     # introspect the model arguments to determine what parameters to pass.
     args = inspect.signature(model).parameters.keys()

--- a/bcipy/helpers/system_utils.py
+++ b/bcipy/helpers/system_utils.py
@@ -166,7 +166,7 @@ def import_submodules(package, recursive=True):
     -------
         dict[str, types.ModuleType]
     """
-    if isinstance(package, str) or isinstance(package, unicode):
+    if isinstance(package, str):
         package = importlib.import_module(package)
     results = {}
     for loader, name, is_pkg in pkgutil.walk_packages(package.__path__):

--- a/bcipy/helpers/tests/test_copy_phrase_wrapper.py
+++ b/bcipy/helpers/tests/test_copy_phrase_wrapper.py
@@ -12,6 +12,7 @@ from bcipy.helpers.load import load_json_parameters
 from bcipy.helpers.task import alphabet
 from bcipy.signal.model import PcaRdaKdeModel
 from bcipy.task.data import EvidenceType
+from bcipy.language.uniform import UniformLanguageModel
 
 
 class TestCopyPhraseWrapper(unittest.TestCase):
@@ -65,6 +66,7 @@ class TestCopyPhraseWrapper(unittest.TestCase):
         cp = CopyPhraseWrapper(
             min_num_inq=1,
             max_num_inq=50,
+            lmodel=None,
             signal_model=None,
             fs=25,
             k=2,
@@ -169,6 +171,7 @@ class TestCopyPhraseWrapper(unittest.TestCase):
         copy_phrase_task = CopyPhraseWrapper(
             min_num_inq=1,
             max_num_inq=50,
+            lmodel=UniformLanguageModel(symbol_set=alp),
             signal_model=self.model,
             fs=self.device_spec.sample_rate,
             k=1,

--- a/bcipy/helpers/tests/test_language_model.py
+++ b/bcipy/helpers/tests/test_language_model.py
@@ -1,11 +1,13 @@
+"""Unit test for language model helper"""
 import unittest
 
 from collections import Counter
-from bcipy.helpers.language_model import norm_domain, sym_appended, \
-    equally_probable, histogram
+from bcipy.helpers.language_model import norm_domain, sym_appended, histogram
 
 
 class TestLanguageModelRelated(unittest.TestCase):
+    """Tests for language model helper"""
+
     def test_norm_domain(self):
         """Test conversion from negative log likelihood to prob."""
         letters = [('S', 0.25179717717251715), ('U', 1.656395297172517),
@@ -81,10 +83,10 @@ class TestLanguageModelRelated(unittest.TestCase):
 
         new_list_dict = dict(new_list)
         prev_list_dict = dict(syms)
-        for s, _ in syms:
-            self.assertTrue(s in new_list_dict)
-            self.assertTrue(new_list_dict[s] < prev_list_dict[s])
-            self.assertEqual(0.2, new_list_dict[s])
+        for sym, _ in syms:
+            self.assertTrue(sym in new_list_dict)
+            self.assertTrue(new_list_dict[sym] < prev_list_dict[sym])
+            self.assertEqual(0.2, new_list_dict[sym])
         self.assertTrue(new_sym[0] in new_list_dict)
         self.assertEqual(new_sym[1], new_list_dict[new_sym[0]])
 
@@ -99,57 +101,9 @@ class TestLanguageModelRelated(unittest.TestCase):
         self.assertEqual(syms, new_list, "Value already present")
 
         new_list = sym_appended(syms, ('D', 0.2))
-        self.assertEqual(
-            syms, new_list, msg="Changing the probability does not matter")
-
-    def test_equally_probable(self):
-        """Test generation of equally probable values."""
-
-        # no overrides
-        alp = ['A', 'B', 'C', 'D']
-        probs = equally_probable(alp)
-        self.assertEqual(len(alp), len(probs))
-        for prob in probs:
-            self.assertEqual(0.25, prob)
-
-        # test with override
-        alp = ['A', 'B', 'C', 'D']
-        probs = equally_probable(alp, {'A': 0.4})
-        self.assertEqual(len(alp), len(probs))
-        self.assertAlmostEqual(1.0, sum(probs))
-        self.assertEqual(probs[0], 0.4)
-        self.assertAlmostEqual(probs[1], 0.2)
-        self.assertAlmostEqual(probs[2], 0.2)
-        self.assertAlmostEqual(probs[3], 0.2)
-
-        # test with 0.0 override
-        alp = ['A', 'B', 'C', 'D', 'E']
-        probs = equally_probable(alp, {'E': 0.0})
-        self.assertEqual(len(alp), len(probs))
-        self.assertAlmostEqual(1.0, sum(probs))
-        self.assertEqual(probs[0], 0.25)
-        self.assertAlmostEqual(probs[1], 0.25)
-        self.assertAlmostEqual(probs[2], 0.25)
-        self.assertAlmostEqual(probs[3], 0.25)
-        self.assertAlmostEqual(probs[4], 0.0)
-
-        # test with multiple overrides
-        alp = ['A', 'B', 'C', 'D']
-        probs = equally_probable(alp, {'B': 0.2, 'D': 0.3})
-        self.assertEqual(len(alp), len(probs))
-        self.assertAlmostEqual(1.0, sum(probs))
-        self.assertEqual(probs[0], 0.25)
-        self.assertAlmostEqual(probs[1], 0.2)
-        self.assertAlmostEqual(probs[2], 0.25)
-        self.assertAlmostEqual(probs[3], 0.3)
-
-        # test with override that's not in the alphabet
-        alp = ['A', 'B', 'C', 'D']
-        probs = equally_probable(alp, {'F': 0.4})
-        self.assertEqual(len(alp), len(probs))
-        self.assertAlmostEqual(1.0, sum(probs))
-        for prob in probs:
-            self.assertEqual(0.25, prob)
+        self.assertEqual(syms,
+                         new_list,
+                         msg="Changing the probability does not matter")
 
     def test_small_probs(self):
         """When very small values are returned from the LM, inserting a letter
@@ -200,8 +154,8 @@ class TestLanguageModelRelated(unittest.TestCase):
             "Should be sorted")
 
         self.assertTrue(lines[-1].startswith('_'))
-        c = Counter(lines[-1])
-        self.assertEqual(81, c['*'],
+        counter = Counter(lines[-1])
+        self.assertEqual(81, counter['*'],
                          "Should be 81 stars, indicating the percentage")
 
         total_stars = Counter(hist)['*']

--- a/bcipy/language/README.md
+++ b/bcipy/language/README.md
@@ -1,6 +1,6 @@
 # Language
 
-BciPy Language module provides an interface for word and character level predictions. 
+BciPy Language module provides an interface for word and character level predictions.
 
 The core methods of any `LanguageModel` include:
 
@@ -14,3 +14,6 @@ You may of course define other methods, however all integrated BciPy experiments
 
 The pretrained GPT2 language model is saved in [this folder on Google Drive](https://drive.google.com/drive/folders/1pkvwHA8SR7awxf7fj7Ds4FhY6SGxeGtX?usp=sharing). Download the files in the folder and put them in a local directory. Then use the path to the local directory to load the model. (Alternatively, just pass in the model name like "gpt2" as the language model path and the pretrained language model will be downloaded and stored in local cache)
 
+## Uniform Model
+
+The UniformLanguageModel provides equal probabilities for all symbols in the symbol set. This model is useful for evaluating other aspects of the system, such as EEG signal quality, without strong influence from a language model.

--- a/bcipy/language/demo/demo_gpt2.py
+++ b/bcipy/language/demo/demo_gpt2.py
@@ -6,7 +6,7 @@ from bcipy.language.main import ResponseType
 if __name__ == "__main__":
     symbol_set = alphabet()
     response_type = ResponseType.SYMBOL
-    lm = GPT2LanguageModel(response_type, symbol_set, "gpt2")
+    lm = GPT2LanguageModel(response_type, symbol_set)
 
     next_char_pred = lm.state_update(list("does_it_make_sen"))
     print(next_char_pred)

--- a/bcipy/language/main.py
+++ b/bcipy/language/main.py
@@ -1,18 +1,61 @@
+"""Defines the language model base class."""
 from abc import ABC, abstractmethod
-from typing import Tuple, List
 from enum import Enum
+from typing import List, Optional, Tuple
+
+from bcipy.helpers.exceptions import UnsupportedResponseType
+from bcipy.helpers.task import alphabet
+
+DEFAULT_SYMBOL_SET = alphabet()
 
 
 class ResponseType(Enum):
+    """Language model response type options."""
     SYMBOL = 'Symbol'
     WORD = 'Word'
 
+    def __str__(self):
+        return self.value
+
 
 class LanguageModel(ABC):
+    """Parent class for Language Models."""
 
-    response_type: ResponseType
-    symbol_set: List[str]
-    normalized: bool = False  # normalized to probability domain
+    _response_type: ResponseType = None
+    symbol_set: List[str] = None
+    # normalized to probability domain
+    normalized: bool = False
+
+    def __init__(self,
+                 response_type: Optional[ResponseType] = None,
+                 symbol_set: Optional[List[str]] = None):
+        self.response_type = response_type or ResponseType.SYMBOL
+        self.symbol_set = symbol_set or DEFAULT_SYMBOL_SET
+
+    @classmethod
+    def name(cls) -> str:
+        """Model name used for configuration"""
+        suffix = 'LanguageModel'
+        if cls.__name__.endswith(suffix):
+            return cls.__name__[0:-len(suffix)].upper()
+        return cls.__name__.upper()
+
+    @abstractmethod
+    def supported_response_types(self) -> List[ResponseType]:
+        """Returns a list of response types supported by this language model."""
+
+    @property
+    def response_type(self) -> ResponseType:
+        """Returns the current response type"""
+        return self._response_type
+
+    @response_type.setter
+    def response_type(self, value: ResponseType):
+        """Attempts to set the response type to the given value"""
+        if value not in self.supported_response_types():
+            raise UnsupportedResponseType(
+                f"{value} responses are not supported by this model")
+        self._response_type = value
 
     @abstractmethod
     def predict(self, evidence: List[str]) -> List[Tuple]:
@@ -42,4 +85,3 @@ class LanguageModel(ABC):
 
     def state_update(self, evidence: List[str]) -> List[Tuple]:
         """Update state by predicting and updating"""
-        ...

--- a/bcipy/language/main.py
+++ b/bcipy/language/main.py
@@ -23,8 +23,6 @@ class LanguageModel(ABC):
 
     _response_type: ResponseType = None
     symbol_set: List[str] = None
-    # normalized to probability domain
-    normalized: bool = False
 
     def __init__(self,
                  response_type: Optional[ResponseType] = None,

--- a/bcipy/language/model/gpt2.py
+++ b/bcipy/language/model/gpt2.py
@@ -12,7 +12,7 @@ from bcipy.language.main import LanguageModel, ResponseType
 class GPT2LanguageModel(LanguageModel):
     """Character language model based on GPT2."""
 
-    def __init__(self, response_type, symbol_set, lm_path="gpt2"):
+    def __init__(self, response_type, symbol_set, lm_path=None):
         """
         Initialize instance variables and load the language model with given path
         Args:
@@ -28,7 +28,7 @@ class GPT2LanguageModel(LanguageModel):
         self.vocab_size = 0
         self.idx_to_word = None
         self.curr_word_predicted_prob = None
-        self.lm_path = lm_path
+        self.lm_path = lm_path or "gpt2"
         self.load()
 
     def supported_response_types(self) -> List[ResponseType]:

--- a/bcipy/language/model/gpt2.py
+++ b/bcipy/language/model/gpt2.py
@@ -21,7 +21,6 @@ class GPT2LanguageModel(LanguageModel):
             lm_path - path to language model files
         """
         super().__init__(response_type=response_type, symbol_set=symbol_set)
-        self.normalized = True
         self.model = None
         self.tokenizer = None
         self.is_start_of_word = True

--- a/bcipy/language/tests/test_uniform.py
+++ b/bcipy/language/tests/test_uniform.py
@@ -1,7 +1,9 @@
 """Tests for Uniform Language Model"""
 
 import unittest
-from bcipy.language.uniform import UniformLanguageModel, ResponseType, BACKSPACE_CHAR
+
+from bcipy.language.uniform import (BACKSPACE_CHAR, ResponseType,
+                                    UniformLanguageModel, equally_probable)
 
 
 class TestUniformLanguageModel(unittest.TestCase):
@@ -24,8 +26,6 @@ class TestUniformLanguageModel(unittest.TestCase):
 
     def test_required_parameters(self):
         """Test that missing parameters raise an exception"""
-        with self.assertRaises(AssertionError):
-            UniformLanguageModel(is_txt_stim=False)
 
         with self.assertRaises(AssertionError):
             UniformLanguageModel(lm_backspace_prob=-3)
@@ -53,3 +53,52 @@ class TestUniformLanguageModel(unittest.TestCase):
                          "Backspace probability should be different")
         self.assertTrue(0.05 in probs)
         self.assertAlmostEqual(sum(probs), 1)
+
+    def test_equally_probable(self):
+        """Test generation of equally probable values."""
+
+        # no overrides
+        alp = ['A', 'B', 'C', 'D']
+        probs = equally_probable(alp)
+        self.assertEqual(len(alp), len(probs))
+        for prob in probs:
+            self.assertEqual(0.25, prob)
+
+        # test with override
+        alp = ['A', 'B', 'C', 'D']
+        probs = equally_probable(alp, {'A': 0.4})
+        self.assertEqual(len(alp), len(probs))
+        self.assertAlmostEqual(1.0, sum(probs))
+        self.assertEqual(probs[0], 0.4)
+        self.assertAlmostEqual(probs[1], 0.2)
+        self.assertAlmostEqual(probs[2], 0.2)
+        self.assertAlmostEqual(probs[3], 0.2)
+
+        # test with 0.0 override
+        alp = ['A', 'B', 'C', 'D', 'E']
+        probs = equally_probable(alp, {'E': 0.0})
+        self.assertEqual(len(alp), len(probs))
+        self.assertAlmostEqual(1.0, sum(probs))
+        self.assertEqual(probs[0], 0.25)
+        self.assertAlmostEqual(probs[1], 0.25)
+        self.assertAlmostEqual(probs[2], 0.25)
+        self.assertAlmostEqual(probs[3], 0.25)
+        self.assertAlmostEqual(probs[4], 0.0)
+
+        # test with multiple overrides
+        alp = ['A', 'B', 'C', 'D']
+        probs = equally_probable(alp, {'B': 0.2, 'D': 0.3})
+        self.assertEqual(len(alp), len(probs))
+        self.assertAlmostEqual(1.0, sum(probs))
+        self.assertEqual(probs[0], 0.25)
+        self.assertAlmostEqual(probs[1], 0.2)
+        self.assertAlmostEqual(probs[2], 0.25)
+        self.assertAlmostEqual(probs[3], 0.3)
+
+        # test with override that's not in the alphabet
+        alp = ['A', 'B', 'C', 'D']
+        probs = equally_probable(alp, {'F': 0.4})
+        self.assertEqual(len(alp), len(probs))
+        self.assertAlmostEqual(1.0, sum(probs))
+        for prob in probs:
+            self.assertEqual(0.25, prob)

--- a/bcipy/language/tests/test_uniform.py
+++ b/bcipy/language/tests/test_uniform.py
@@ -13,7 +13,6 @@ class TestUniformLanguageModel(unittest.TestCase):
         """Test default parameters"""
         lmodel = UniformLanguageModel()
         self.assertEqual(lmodel.response_type, ResponseType.SYMBOL)
-        self.assertTrue(lmodel.normalized)
         self.assertIsNone(lmodel.backspace_prob)
         self.assertEqual(
             len(lmodel.symbol_set), 28,

--- a/bcipy/language/uniform.py
+++ b/bcipy/language/uniform.py
@@ -27,7 +27,6 @@ class UniformLanguageModel(LanguageModel):
             assert 0 <= lm_backspace_prob < 1, "Backspace probability must be between 0 and 1"
 
         self.backspace_prob = lm_backspace_prob
-        self.normalized = True
 
     def supported_response_types(self) -> List[ResponseType]:
         return [ResponseType.SYMBOL]

--- a/bcipy/language/uniform.py
+++ b/bcipy/language/uniform.py
@@ -1,43 +1,36 @@
 """Uniform language model"""
-from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple, Union, Optional
 
 import numpy as np
 
-from bcipy.helpers.task import BACKSPACE_CHAR, alphabet
+from bcipy.helpers.task import BACKSPACE_CHAR
 from bcipy.language.main import LanguageModel, ResponseType
 
 
 class UniformLanguageModel(LanguageModel):
     """Language model in which probabilities for symbols are uniformly
-    distributed. Symbols can be text or images. If images are used the
-    path must be provided.
+    distributed.
 
     Parameters
     ----------
-        lm_backspace_prob - optionally used to set a fixed probability for the
-            backspace symbol. Probabilities for other symbols will be adjusted.
-        is_txt_stim - Symbols can be text or images. Set to False for images.
-        path_to_presentation_images - path to images
+        response_type - SYMBOL only
+        symbol_set - optional specify the symbol set, otherwise uses DEFAULT_SYMBOL_SET
+        backspace symbol. Probabilities for other symbols will be adjusted.
     """
 
     def __init__(self,
-                 lm_backspace_prob: float = None,
-                 is_txt_stim: bool = True,
-                 path_to_presentation_images: str = None):
+                 response_type: Optional[ResponseType] = None,
+                 symbol_set: Optional[List[str]] = None,
+                 lm_backspace_prob: float = None):
+        super().__init__(response_type=response_type, symbol_set=symbol_set)
         if lm_backspace_prob:
             assert 0 <= lm_backspace_prob < 1, "Backspace probability must be between 0 and 1"
-        if not is_txt_stim:
-            assert path_to_presentation_images, "Path must be provided for images."
 
         self.backspace_prob = lm_backspace_prob
-        self.response_type = ResponseType.SYMBOL
-        params = {
-            'is_txt_stim': is_txt_stim,
-            'path_to_presentation_images': path_to_presentation_images
-        }
-        self.symbol_set = alphabet(params)
         self.normalized = True
+
+    def supported_response_types(self) -> List[ResponseType]:
+        return [ResponseType.SYMBOL]
 
     def predict(self, evidence: Union[str, List[str]]) -> List[Tuple]:
         """
@@ -61,7 +54,7 @@ class UniformLanguageModel(LanguageModel):
     def update(self) -> None:
         """Update the model state"""
 
-    def load(self, path: Path) -> None:
+    def load(self) -> None:
         """Restore model state from the provided checkpoint"""
 
 

--- a/bcipy/language_model/demo/prelm_demo.py
+++ b/bcipy/language_model/demo/prelm_demo.py
@@ -1,32 +1,33 @@
-from bcipy.helpers.language_model import norm_domain
-from bcipy.language_model.prelm_language_model import LangModel
+"""Demo for the PRELM language model"""
 import sys
+from bcipy.helpers.language_model import norm_domain
+from bcipy.language_model.prelm_language_model import PrelmLanguageModel
 sys.path.append('.')
 
 
 def main():
     """Runs the demo"""
     # init LMWrapper
-    lmodel = LangModel(logfile="lmwrap.log")
+    lmodel = PrelmLanguageModel()
     print('\nNo History\n')
     # get initial priors
     print(lmodel.recent_priors())
     # get priors
     print('\nHistory: T\n')
-    priors = lmodel.state_update(['T'])
+    lmodel.state_update(['T'])
     # display priors
     print(lmodel.recent_priors())
     print('\nHistory: TH\n')
-    priors = lmodel.state_update(['H'])
+    lmodel.state_update(['H'])
     print(lmodel.recent_priors())
     print('\nHistory: THE\n')
-    priors = lmodel.state_update(['E'])
+    lmodel.state_update(['E'])
     print(lmodel.recent_priors())
     # reset history al together
     lmodel.reset()
     print("\n--------------RESET-------------\n")
     print('\nHistory: THE (fed as a single string)\n')
-    priors = lmodel.state_update(list('THE'))
+    lmodel.state_update(list('THE'))
     print(lmodel.recent_priors())
 
     print('\n\nLetters in the probability domain:\n')

--- a/bcipy/language_model/integration/prelm_itest.py
+++ b/bcipy/language_model/integration/prelm_itest.py
@@ -1,6 +1,6 @@
 import unittest
 
-from bcipy.language_model.prelm_language_model import LangModel
+from bcipy.language_model.prelm_language_model import PrelmLanguageModel
 from bcipy.language_model.errors import StatusCodeError
 
 
@@ -13,7 +13,7 @@ class TestPreLM(unittest.TestCase):
         input
         """
         # init LMWrapper
-        lmodel = LangModel(logfile="lmwrap.log")
+        lmodel = PrelmLanguageModel()
         # init LM
         lmodel.init()
         # get priors
@@ -33,7 +33,7 @@ class TestPreLM(unittest.TestCase):
         input
         """
         # init LMWrapper
-        lmodel = LangModel(logfile="lmwrap.log")
+        lmodel = PrelmLanguageModel()
         lmodel.init()
         # try to get priors
         with self.assertRaises(StatusCodeError):

--- a/bcipy/language_model/lm_modes.py
+++ b/bcipy/language_model/lm_modes.py
@@ -10,7 +10,7 @@ class LmType(Enum):
     Ex.
     >>> LmType.PRELM.model()
     """
-    PRELM = prelm_language_model.LangModel
+    PRELM = prelm_language_model.PrelmLanguageModel
     OCLM = oclm_language_model.LangModel
     UNIFORM = UniformLanguageModel
 

--- a/bcipy/language_model/prelm_language_model.py
+++ b/bcipy/language_model/prelm_language_model.py
@@ -1,28 +1,34 @@
+"""Defines the PRELM language model"""
 import logging
 import sys
-from typing import List, Tuple, Union
+from typing import List, Tuple, Union, Optional
 from collections import defaultdict
-from bcipy.helpers.task import alphabet, SPACE_CHAR
+from bcipy.helpers.task import SPACE_CHAR
+from bcipy.language.main import LanguageModel, ResponseType
 from bcipy.language_model import lm_server
 from bcipy.language_model.lm_server import LmServerConfig
 from bcipy.helpers.system_utils import dot
+
 log = logging.getLogger(__name__)
 sys.path.append('.')
-ALPHABET = alphabet()
 LM_SPACE = '#'
 
 
-class LangModel:
+class PrelmLanguageModel(LanguageModel):
+    """PRELM character language model."""
     DEFAULT_CONFIG = LmServerConfig(
         image="lmimage:version2.0",
         port=5000,
         docker_port=5000,
-        volumes={dot(__file__, 'fst', 'brown_closure.n5.kn.fst'):
-                 "/opt/lm/brown_closure.n5.kn.fst"})
+        volumes={
+            dot(__file__, 'fst', 'brown_closure.n5.kn.fst'):
+            "/opt/lm/brown_closure.n5.kn.fst"
+        })
 
     def __init__(self,
-                 lang_model_server_port: int = 5000,
-                 logfile: str = "lmwrap.log"):
+                 response_type: Optional[ResponseType] = None,
+                 symbol_set: Optional[List[str]] = None,
+                 lang_model_server_port: int = 5000):
         """
         Initiate the langModel class and starts the corresponding docker
         server for the given type.
@@ -31,14 +37,18 @@ class LangModel:
           lmtype - language model type
           logfile - a valid filename to function as a logger
         """
-        self.server_config = LangModel.DEFAULT_CONFIG
+        super().__init__(response_type=response_type, symbol_set=symbol_set)
+        self.server_config = PrelmLanguageModel.DEFAULT_CONFIG
         self.server_config.port = lang_model_server_port
 
         self.priors = defaultdict(list)
         log.setLevel(logging.INFO)
-        log.addHandler(logging.FileHandler(logfile))
+        log.addHandler(logging.FileHandler("lmwrap.log"))
         lm_server.start(self.server_config)
         self.init()
+
+    def supported_response_types(self):
+        return [ResponseType.SYMBOL]
 
     def init(self, nbest: int = 1):
         """
@@ -46,8 +56,9 @@ class LangModel:
         Input:
             nbest - top N symbols from evidence
         """
-        lm_server.post_json_request(
-            self.server_config, 'init', data={'nbest': nbest})
+        lm_server.post_json_request(self.server_config,
+                                    'init',
+                                    data={'nbest': nbest})
 
     def cleanup(self):
         """Stop the docker server"""
@@ -67,7 +78,13 @@ class LangModel:
         self.reset()
         return priors['letter']
 
-    def state_update(self, evidence: Union[str, List[str]], return_mode: str = 'letter'):
+    def update(self) -> None:
+        """Update the model state"""
+
+    def load(self) -> None:
+        """Restore model state from the provided checkpoint"""
+
+    def state_update(self, evidence: Union[str, List[str]]):
         """
         Provide a prior distribution of the language model
         in return to the system's decision regarding the
@@ -79,17 +96,15 @@ class LangModel:
             decision - a symbol or a string of symbols in encapsulated in a
             list
             the numbers are assumed to be in the log probability domain
-            return_mode - 'letter' or 'word' (available
-                          for oclm) strings
         Output:
             priors - a json dictionary with Normalized priors
                      in the Negative Log probability domain.
         """
-        assert return_mode == 'letter', "PRELM only allows letter output"
+
         # assert the input contains a valid symbol
         decision = evidence  # in prelm the we treat it as a decision
         for symbol in decision:
-            assert symbol in ALPHABET or ' ', \
+            assert symbol in self.symbol_set or ' ', \
                 "%r contains invalid symbol" % decision
         clean_evidence = []
         for symbol in decision:
@@ -97,12 +112,14 @@ class LangModel:
                 symbol = LM_SPACE
             clean_evidence.append(symbol.lower())
 
+        return_mode = 'letter'
         output = lm_server.post_json_request(self.server_config,
-                                             'state_update',
-                                             {'evidence': clean_evidence,
-                                              'return_mode': return_mode})
+                                             'state_update', {
+                                                 'evidence': clean_evidence,
+                                                 'return_mode': return_mode
+                                             })
 
-        return self.__return_priors(output, return_mode)
+        return self.__return_priors(output)
 
     def _logger(self):
         """
@@ -113,8 +130,8 @@ class LangModel:
         for k in self.priors.keys():
             priors = self.priors[k]
             log.info('\nThe priors for {0} type are:\n'.format(k))
-            for (symbol, pr) in priors:
-                log.info('{0} {1:.4f}'.format(symbol, pr))
+            for (symbol, prior) in priors:
+                log.info('{0} {1:.4f}'.format(symbol, prior))
 
     def recent_priors(self, return_mode='letter'):
         """
@@ -125,11 +142,11 @@ class LangModel:
             output = lm_server.post_json_request(self.server_config,
                                                  'recent_priors',
                                                  {'return_mode': return_mode})
-            return self.__return_priors(output, return_mode)
-        else:
-            return self.priors
+            return self.__return_priors(output)
 
-    def __return_priors(self, output, return_mode):
+        return self.priors
+
+    def __return_priors(self, output):
         """
         A helper function to provide the desired output
         depending on the return_mode.
@@ -137,8 +154,8 @@ class LangModel:
 
         self.priors = defaultdict(list)
         self.priors['letter'] = [
-            (letter.upper(), prob)
-            if letter != LM_SPACE  # hard coded (to deal with in future)
-            else ("_", prob)
-            for (letter, prob) in output['letter']]
+            (letter.upper(),
+             prob) if letter != LM_SPACE  # hard coded (to deal with in future)
+            else ("_", prob) for (letter, prob) in output['letter']
+        ]
         return self.priors

--- a/bcipy/language_model/prelm_language_model.py
+++ b/bcipy/language_model/prelm_language_model.py
@@ -1,5 +1,6 @@
 """Defines the PRELM language model"""
 import logging
+import math
 import sys
 from typing import List, Tuple, Union, Optional
 from collections import defaultdict
@@ -73,10 +74,13 @@ class PrelmLanguageModel(LanguageModel):
         log.info("\ncleaning history\n")
 
     def predict(self, evidence: Union[str, List[str]]) -> List[Tuple]:
-        """Performs `state_update` and subsequently resets the model."""
+        """Performs `state_update` and subsequently resets the model.
+        Returns probabilities for each symbol.
+        """
         priors = self.state_update(evidence=evidence)
         self.reset()
-        return priors['letter']
+        # convert from log likelihood to probabilities
+        return [(sym, math.exp(-prob)) for sym, prob in priors['letter']]
 
     def update(self) -> None:
         """Update the model state"""

--- a/bcipy/main.py
+++ b/bcipy/main.py
@@ -93,21 +93,21 @@ def execute_task(task: TaskType, parameters: dict, save_folder: str) -> bool:
     """
     signal_model = None
     language_model = None
-    filename = None
 
     fake = parameters['fake_data']
 
     # Init EEG Model, if needed. Calibration Tasks Don't require probabilistic
     # modules to be loaded.
-    if not fake and task not in TaskType.calibration_tasks():
+    if task not in TaskType.calibration_tasks():
         # Try loading in our signal_model and starting a langmodel(if enabled)
-        try:
-            signal_model, filename = load_signal_model(
-                model_class=PcaRdaKdeModel, model_kwargs={
-                    'k_folds': parameters['k_folds']})
-        except Exception as e:
-            log.exception(f'Cannot load signal model. Exiting. {e}')
-            raise e
+        if not fake:
+            try:
+                signal_model, _filename = load_signal_model(
+                    model_class=PcaRdaKdeModel, model_kwargs={
+                        'k_folds': parameters['k_folds']})
+            except Exception as e:
+                log.exception(f'Cannot load signal model. Exiting. {e}')
+                raise e
 
         language_model = init_language_model(parameters)
 

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -735,19 +735,11 @@
     "recommended_values": "",
     "type": "int"
   },
-  "lang_model_enabled": {
-    "value": "false",
-    "section": "lang_model_config",
-    "readableName": "Language Model On/Off",
-    "helpTip": "If ‘true’, the language model will be enabled, and language model evidence will be incorporated into calculation of posterior probabilities. If ‘false’, posterior probabilities will be calculated based on EEG evidence only.",
-    "recommended_values": "",
-    "type": "bool"
-  },
   "lang_model_type": {
-    "value": "GPT2",
+    "value": "UNIFORM",
     "section": "lang_model_config",
     "readableName": "Language Model Type",
-    "helpTip": "Specifies which language model to use. Default: GPT2",
+    "helpTip": "Specifies which language model to use. Default: UNIFORM",
     "recommended_values": [
       "GPT2",
       "PRELM",
@@ -756,12 +748,12 @@
     "type": "str"
   },
   "lm_path": {
-    "value": "gpt2",
+    "value": "",
     "section": "bci_config",
     "readableName": "Language Model Path",
-    "helpTip": "Pretrained model name or path. Default: gpt2",
+    "helpTip": "Pretrained model name or path.",
     "recommended_values": "",
-    "type": "str"
+    "type": "directorypath"
   },
   "lm_backspace_prob": {
     "value": "0.05",

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -744,14 +744,23 @@
     "type": "bool"
   },
   "lang_model_type": {
-    "value": "PRELM",
+    "value": "GPT2",
     "section": "lang_model_config",
     "readableName": "Language Model Type",
-    "helpTip": "Specifies which language model to use. Default: PRELM",
+    "helpTip": "Specifies which language model to use. Default: GPT2",
     "recommended_values": [
+      "GPT2",
       "PRELM",
       "UNIFORM"
     ],
+    "type": "str"
+  },
+  "lm_path": {
+    "value": "gpt2",
+    "section": "bci_config",
+    "readableName": "Language Model Path",
+    "helpTip": "Pretrained model name or path. Default: gpt2",
+    "recommended_values": "",
     "type": "str"
   },
   "lm_backspace_prob": {

--- a/bcipy/tests/test_bci_main.py
+++ b/bcipy/tests/test_bci_main.py
@@ -151,7 +151,7 @@ class TestExecuteTask(unittest.TestCase):
         self.parameters = {
             'fake_data': True,
             'k_folds': 10,
-            'lang_model_enabled': False
+            'is_txt_stim': True
         }
         self.save_folder = '/'
         self.task = TaskType(1)
@@ -324,7 +324,6 @@ class TestExecuteTask(unittest.TestCase):
 
     def test_execute_language_model_enabled(self) -> None:
         self.parameters['fake_data'] = False
-        self.parameters['lang_model_enabled'] = True
         self.task = TaskType(2)  # set to a noncalibration task
 
         # mock the signal and language models


### PR DESCRIPTION

# Overview

Integrated the new GPT2LanguageModel so BciPy users can select it and it will be used to support the Copy Phrase Task.

## Ticket

[https://www.pivotaltracker.com/story/show/181018867](https://www.pivotaltracker.com/story/show/181018867)

## Contributions

- Refactored parent LanguageModel to use stricter checking for supported response type and to include common functionality
- Refactored other existing language models to use the parent class
- Updated the language model helper code for selecting a language model and passing it the correct parameters.
- Cleanup

## Test

- Ran all unit tests
- Ran Copy Phrase task with each of the available language models (PRELM, GPT2, UNIFORM) and analyzed the log to confirm that the probability histogram changed appropriately with each model.
