### PR TITLE
assign zero probability for symbols not returned by gpt2

### DIFF
--- a/bcipy/language/model/gpt2.py
+++ b/bcipy/language/model/gpt2.py
@@ -68,6 +68,11 @@ class GPT2LanguageModel(LanguageModel):
         for char in char_to_prob:
             char_to_prob[char] /= sum_char_prob
 
+        # assign probability of 0.0 for symbols not returned by the language model
+        for char in self.symbol_set:
+            if char not in char_to_prob:
+                char_to_prob[char] = 0.0
+
         # build a list of tuples (char, prob)
         char_prob_tuples = list(
             sorted(char_to_prob.items(),


### PR DESCRIPTION
# Overview

Fixed the bug discovered during testing. For symbols not returned by the GPT2 language model, assign probability of 0.0 in the prediction results.

## Ticket

[https://www.pivotaltracker.com/n/projects/2460065/stories/181181927](url)

## Contributions

- Fixed a bug discovered during testing
- Assign probability of 0.0 for symbols not returned by the GPT2 language model.

## Test

- Need to pass all existing unit tests.

