### PR TITLE
Fix inquiry reshaper

### DIFF
--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -392,7 +392,7 @@ class InquiryReshaper(Reshaper):
             labels_excluded (Set[str]): labels to exclude. Defaults to empty set.
 
         Returns:
-            reshaped_data (np.ndarray): inquiry data of shape (Channels, Inquiries, Samples)
+            reshaped_data (np.ndarray): inquiry data of shape (Inquiries, Channels, Samples)
             labels (np.ndarray): integer label for each inquiry. With `trials_per_inquiry=K`,
                 a label of [0, K-1] indicates the position of `target_label`, or label of K indicates
                 `target_label` was not present.

--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -401,9 +401,6 @@ class InquiryReshaper(Reshaper):
         channels_to_remove = [idx for idx, value in enumerate(channel_map) if value == 0]
         eeg_data = np.delete(eeg_data, channels_to_remove, axis=0)
 
-        # Number of samples we are interested per inquiry
-        num_samples = int(trial_length * fs * trials_per_inquiry)
-
         # Remove unwanted elements from target info and timing info
         tmp_labels, tmp_timing = [], []
         for label, timing in zip(trial_labels, timing_info):
@@ -414,32 +411,29 @@ class InquiryReshaper(Reshaper):
         timing_info = tmp_timing
 
         n_inquiry = len(timing_info) // trials_per_inquiry
+        trial_duration_samples = int(trial_length * fs)
 
         # triggers in seconds are mapped to triggers in number of samples.
         triggers = list(map(lambda x: int((x + offset) * fs), timing_info))
 
-        # shape (Channels, Inquiries, Samples)
-        reshaped_data = np.zeros((len(eeg_data), n_inquiry, num_samples))
-
         # Label for every inquiry
-        labels = np.zeros(n_inquiry)
-        for inquiry_idx, chunk in enumerate(grouper(zip(trial_labels, triggers), trials_per_inquiry)):
+        labels = np.zeros(n_inquiry, dtype=np.long)
+        reshaped_data = []
+        for inquiry_idx, trials_within_inquiry in enumerate(grouper(zip(trial_labels, triggers), trials_per_inquiry)):
             # label is the index of the "target", or else the length of the inquiry
             inquiry_label = trials_per_inquiry
-            first_trigger = None
-            for trial_idx, (trial_label, trigger) in enumerate(chunk):
-                if first_trigger is None:
-                    first_trigger = trigger
-
+            for trial_idx, (trial_label, trigger) in enumerate(trials_within_inquiry):
                 if trial_label == target_label:
                     inquiry_label = trial_idx
 
+            # Inquiry lasts from first trial onset until final trial onset + trial_length
+            first_trigger = trials_within_inquiry[0][1]
+            last_trigger = trials_within_inquiry[-1][1]
             labels[inquiry_idx] = inquiry_label
 
-            # For every channel append filtered channel data to trials
-            reshaped_data[:, inquiry_idx, :] = eeg_data[:, first_trigger: first_trigger + num_samples]
+            reshaped_data.append(eeg_data[:, first_trigger: last_trigger + trial_duration_samples])
 
-        return reshaped_data, labels
+        return np.stack(reshaped_data), labels
 
 
 class TrialReshaper(Reshaper):

--- a/bcipy/helpers/tests/test_task.py
+++ b/bcipy/helpers/tests/test_task.py
@@ -77,20 +77,24 @@ class TestInquiryReshaper(unittest.TestCase):
         self.n_channel = 7
         self.trial_length = 0.5
         self.trials_per_inquiry = 3
+        self.n_inquiry = 4
         self.fs = 10
         self.target_info = [
-            "first_pres_target", "fixation", "target", "nontarget", "nontarget",
-            "first_pres_target", "fixation", "nontarget", "nontarget", "nontarget",
-            "first_pres_target", "fixation", "nontarget", "target", "nontarget",
+            "prompt", "fixation", "target", "nontarget", "nontarget",
+            "prompt", "fixation", "nontarget", "nontarget", "nontarget",
+            "prompt", "fixation", "nontarget", "target", "nontarget",
         ]
+        self.true_labels = [0, 3, 1]
         self.timing_info = [
             1.0, 1.2, 1.4, 1.6, 1.8,
             2.0, 2.2, 2.4, 2.6, 2.8,
             3.0, 3.2, 3.4, 3.6, 3.8,
         ]
+        # Inquiry lasts from onset of first trial, to onset of last trial + trial_length
+        self.inquiry_duration_s = 1.8 - 1.4 + self.trial_length
 
-        # total duration = 4s
-        self.eeg = np.random.randn(self.n_channel, int(self.fs * (4 + self.trial_length) * 2))
+        # total duration = 3.8s + final trial_length
+        self.eeg = np.random.randn(self.n_channel, int(self.fs * (3.8 + self.trial_length)))
         self.channel_map = [1] * self.n_channel
 
     def test_inquiry_reshaper(self):
@@ -103,10 +107,10 @@ class TestInquiryReshaper(unittest.TestCase):
             channel_map=self.channel_map,
             trial_length=self.trial_length,
         )
-        expected_shape = (self.n_channel, self.trials_per_inquiry, int(
-            self.trial_length * self.fs) * self.trials_per_inquiry)
+        samples_per_inquiry = int(self.fs * self.inquiry_duration_s)
+        expected_shape = (self.trials_per_inquiry, self.n_channel, samples_per_inquiry)
         self.assertTrue(reshaped_data.shape == expected_shape)
-        self.assertTrue(all(labels == [0, 3, 1]))
+        self.assertTrue(np.all(labels == self.true_labels))
 
 
 class TestCalculateStimulationFreq(unittest.TestCase):


### PR DESCRIPTION
# Overview

Fix `InquiryReshaper` to use the correct window of time for each inquiry.

Sidenote - this now returns data with shape `(inquiries, channels, samples)`.
The point of using this is to get data to feed into neural net for classifying entire inquiries, and that will expect to have batch dimension in front.
If it is preferred to be more consistent with `TrialReshaper` (which returns shape `(channels, trials, samples)`), we could adjust this PR (but future code will have to do
`data.transpose([1,0,2])`).

## Ticket

https://www.pivotaltracker.com/story/show/181349027

## Contributions

- Change how the time for an inquiry is calculated

## Test

- Updated the unit test for InquiryReshaper

## Documentation

- Docstring updated
