### PR TITLE
Fixed backspace prob

### DIFF
--- a/bcipy/helpers/copy_phrase_wrapper.py
+++ b/bcipy/helpers/copy_phrase_wrapper.py
@@ -7,7 +7,7 @@ from bcipy.helpers.acquisition import analysis_channels
 from bcipy.helpers.exceptions import BciPyCoreException
 from bcipy.helpers.language_model import (
     histogram,
-    sym_appended,
+    with_min_prob,
 )
 from bcipy.helpers.stimuli import InquirySchedule, StimuliOrder
 from bcipy.helpers.task import BACKSPACE_CHAR
@@ -296,7 +296,7 @@ class CopyPhraseWrapper:
             if BACKSPACE_CHAR in self.alp:
                 # Apply configured backspace probability.
                 sym = (BACKSPACE_CHAR, self.backspace_prob)
-                lm_letter_prior = sym_appended(lm_letter_prior, sym)
+                lm_letter_prior = with_min_prob(lm_letter_prior, sym)
 
             # convert to format needed for evidence fusion;
             # probability value only in alphabet order.

--- a/bcipy/helpers/copy_phrase_wrapper.py
+++ b/bcipy/helpers/copy_phrase_wrapper.py
@@ -294,7 +294,7 @@ class CopyPhraseWrapper:
             lm_letter_prior = self.lmodel.predict(list(update))
 
             if BACKSPACE_CHAR in self.alp:
-                # Append backspace if missing.
+                # Apply configured backspace probability.
                 sym = (BACKSPACE_CHAR, self.backspace_prob)
                 lm_letter_prior = sym_appended(lm_letter_prior, sym)
 

--- a/bcipy/helpers/language_model.py
+++ b/bcipy/helpers/language_model.py
@@ -63,7 +63,8 @@ def sym_appended(symbol_probs: List[Tuple[str, float]],
     """Returns a new list of probabilities with the addition of a new symbol
     with the given probability for that symbol. Existing values are adjusted
     equally such that the sum of the probabilities in the resulting list sum
-    to approx. 1.0. Only adds the symbol if it is not already in the list.
+    to approx. 1.0. If the symbol already exists within the list its value
+    will be updated and the rest of the values will be adjusted.
 
     Used to add the backspace symbol to the LM output.
 
@@ -72,16 +73,17 @@ def sym_appended(symbol_probs: List[Tuple[str, float]],
         symbol_probs - list of symbol, probability pairs
         sym_prob - (symbol, probability) pair to append
     """
-    if sym_prob[0] in dict(symbol_probs):
-        return symbol_probs
+    new_sym, new_prob = sym_prob
 
-    # Slit out symbols and probabilities into separate lists
-    symbols = [prob[0] for prob in symbol_probs]
-    probabilities = np.array([prob[1] for prob in symbol_probs])
+    # Split out symbols and probabilities into separate lists, excluding the
+    # symbol to be adjusted.
+    filtered = [tup for tup in symbol_probs if tup[0] != new_sym]
+    symbols = [prob[0] for prob in filtered]
+    probabilities = np.array([prob[1] for prob in filtered])
 
     # Add new symbol and its probability
-    all_probs = np.append(probabilities, sym_prob[1] / (1 - sym_prob[1]))
-    all_symbols = symbols + [sym_prob[0]]
+    all_probs = np.append(probabilities, new_prob / (1 - new_prob))
+    all_symbols = symbols + [new_sym]
 
     normalized = all_probs / sum(all_probs)
 

--- a/bcipy/helpers/tests/test_language_model.py
+++ b/bcipy/helpers/tests/test_language_model.py
@@ -94,16 +94,25 @@ class TestLanguageModelRelated(unittest.TestCase):
         """Test insertion of an additional symbol to a normalized list of
         symbols."""
 
-        syms = [('A', 0.25), ('B', 0.25), ('C', 0.25), ('D', 0.25)]
+        syms = [('A', 0.25), ('B', 0.25), ('C', 0.25), ('D', 0.25), ('E', 0.0)]
         self.assertEqual(1.0, sum([prob for _, prob in syms]))
 
-        new_list = sym_appended(syms, ('D', 0.25))
-        self.assertEqual(syms, new_list, "Value already present")
+        new_list = sym_appended(syms, ('E', 0.15))
+        expected = [('A', 0.2125), ('B', 0.2125), ('C', 0.2125), ('D', 0.2125),
+                    ('E', 0.15)]
+        self.assertEqual(new_list, expected, "Values should be adjusted.")
+        self.assertEqual(syms, [('A', 0.25), ('B', 0.25), ('C', 0.25),
+                                ('D', 0.25), ('E', 0.0)],
+                         "Original list should not be modified.")
 
-        new_list = sym_appended(syms, ('D', 0.2))
-        self.assertEqual(syms,
-                         new_list,
-                         msg="Changing the probability does not matter")
+        # inverse operation
+        new_list = sym_appended(expected, ('E', 0.0))
+        self.assertEqual(syms, new_list)
+
+    def test_insert_sym_on_empty_list(self):
+        """Test that it handles the edge case of an empty list."""
+        self.assertEqual(sym_appended([], ('A', 0.25)), [('A', 1.0)])
+        self.assertEqual(sym_appended([], ('A', 1.5)), [('A', 1.0)])
 
     def test_small_probs(self):
         """When very small values are returned from the LM, inserting a letter

--- a/bcipy/language/tests/test_uniform.py
+++ b/bcipy/language/tests/test_uniform.py
@@ -2,8 +2,8 @@
 
 import unittest
 
-from bcipy.language.uniform import (BACKSPACE_CHAR, ResponseType,
-                                    UniformLanguageModel, equally_probable)
+from bcipy.language.uniform import (ResponseType, UniformLanguageModel,
+                                    equally_probable)
 
 
 class TestUniformLanguageModel(unittest.TestCase):
@@ -13,24 +13,9 @@ class TestUniformLanguageModel(unittest.TestCase):
         """Test default parameters"""
         lmodel = UniformLanguageModel()
         self.assertEqual(lmodel.response_type, ResponseType.SYMBOL)
-        self.assertIsNone(lmodel.backspace_prob)
         self.assertEqual(
             len(lmodel.symbol_set), 28,
             "Should be the alphabet plus the backspace and space chars")
-
-    def test_config(self):
-        """Test configuration parameters."""
-        lmodel = UniformLanguageModel(lm_backspace_prob=0.05)
-        self.assertEqual(lmodel.backspace_prob, 0.05)
-
-    def test_required_parameters(self):
-        """Test that missing parameters raise an exception"""
-
-        with self.assertRaises(AssertionError):
-            UniformLanguageModel(lm_backspace_prob=-3)
-
-        with self.assertRaises(AssertionError):
-            UniformLanguageModel(lm_backspace_prob=1.1)
 
     def test_predict(self):
         """Test the predict method"""
@@ -39,18 +24,6 @@ class TestUniformLanguageModel(unittest.TestCase):
 
         self.assertEqual(len(set(probs)), 1, "All values should be the same")
         self.assertTrue(0 < probs[0] < 1)
-        self.assertAlmostEqual(sum(probs), 1)
-
-    def test_predict_with_fixed_backspace(self):
-        """Test predict with a fixed backspace probability."""
-        lmodel = UniformLanguageModel(lm_backspace_prob=0.05)
-        symbol_probs = lmodel.predict(evidence=[])
-        self.assertTrue((BACKSPACE_CHAR, 0.05) in symbol_probs)
-
-        probs = [prob for sym, prob in symbol_probs]
-        self.assertEqual(len(set(probs)), 2,
-                         "Backspace probability should be different")
-        self.assertTrue(0.05 in probs)
         self.assertAlmostEqual(sum(probs), 1)
 
     def test_equally_probable(self):

--- a/bcipy/language/uniform.py
+++ b/bcipy/language/uniform.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Tuple, Union, Optional
 
 import numpy as np
 
-from bcipy.helpers.task import BACKSPACE_CHAR
 from bcipy.language.main import LanguageModel, ResponseType
 
 
@@ -15,18 +14,12 @@ class UniformLanguageModel(LanguageModel):
     ----------
         response_type - SYMBOL only
         symbol_set - optional specify the symbol set, otherwise uses DEFAULT_SYMBOL_SET
-        backspace symbol. Probabilities for other symbols will be adjusted.
     """
 
     def __init__(self,
                  response_type: Optional[ResponseType] = None,
-                 symbol_set: Optional[List[str]] = None,
-                 lm_backspace_prob: float = None):
+                 symbol_set: Optional[List[str]] = None):
         super().__init__(response_type=response_type, symbol_set=symbol_set)
-        if lm_backspace_prob:
-            assert 0 <= lm_backspace_prob < 1, "Backspace probability must be between 0 and 1"
-
-        self.backspace_prob = lm_backspace_prob
 
     def supported_response_types(self) -> List[ResponseType]:
         return [ResponseType.SYMBOL]
@@ -44,10 +37,7 @@ class UniformLanguageModel(LanguageModel):
         -------
             list of (symbol, probability) tuples
         """
-        overrides = None
-        if self.backspace_prob:
-            overrides = {BACKSPACE_CHAR: self.backspace_prob}
-        probs = equally_probable(self.symbol_set, overrides)
+        probs = equally_probable(self.symbol_set)
         return list(zip(self.symbol_set, probs))
 
     def update(self) -> None:


### PR DESCRIPTION
# Overview

Modified Copy Phrase Wrapper to always use the configured backspace probability, overriding the value provided by the language model.

## Ticket

[https://www.pivotaltracker.com/story/show/181350204](https://www.pivotaltracker.com/story/show/181350204)

## Contributions

- Updated the behavior of the `sym_appended` to update the provided probability when the list of probs already contains that value.
- Updated the `UniformLanguageModel` to remove redundant code for configuring the backspace probability.
- Added unit tests to cover edge cases.

## Test

- Ran all unit tests.
- Ran the Copy Phrase task with both GPT2 and Uniform language models to ensure that the configured backspace probability was used and the other probabilities were adjusted.
