### PR TITLE
Bug fix for Preview button evidence

### DIFF
--- a/bcipy/helpers/parameters.py
+++ b/bcipy/helpers/parameters.py
@@ -183,6 +183,8 @@ class Parameters(dict):
             raise Exception(
                 f"Type not supported for key: {entry_name}, type: {entry['type']}"
             )
+        if entry['type'] == "bool" and entry['value'] not in ['true', 'false']:
+            raise Exception(f"Invalid value for key: {entry_name}. Must be either 'true' or 'false'")
 
     def source_location(self) -> Tuple[Path, str]:
         """Location of the source json data if source was provided.

--- a/bcipy/helpers/tests/test_parameters.py
+++ b/bcipy/helpers/tests/test_parameters.py
@@ -427,6 +427,20 @@ class TestParameters(unittest.TestCase):
         with self.assertRaises(Exception):
             parameters.check_valid_entry("fake_data", True)
 
+    def test_check_entry_bool_type(self):
+        """Test that invalid bool types are rejected"""
+        parameters = Parameters(source=None, cast_values=False)
+        with self.assertRaises(Exception):
+            parameters.check_valid_entry(
+                "fake_data", {
+                    "value": True,
+                    "section": "bci_config",
+                    "readableName": "Fake Data Sessions",
+                    "helpTip": "If true, fake data server used",
+                    "recommended_values": "",
+                    "type": "bool"
+                })
+
     def test_alternate_constructor(self):
         """Test alternate constructor from cast values"""
         parameters = Parameters.from_cast_values(myint=1,

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -134,7 +134,7 @@ class RSVPCopyPhraseTask(Task):
         self.parameters.add_entry(
             'preview_only',
             {
-                'value': True if self.parameters['preview_inquiry_progress_method'] == 0 else False,
+                'value': 'true' if self.parameters['preview_inquiry_progress_method'] == 0 else 'false',
                 'section': '',
                 'readableName': '',
                 'helpTip': '',


### PR DESCRIPTION
# Overview

Fixed a bug that was providing button evidence when user selected the parameter to show the Preview Only in the Copy Phrase Task.

## Ticket

https://www.pivotaltracker.com/story/show/181427286

## Contributions

- Fixed the value attribute of the parameter so it was cast to the correct boolean type.

## Test

- Ran the Copy Phrase task to confirm. Inspected the parameter using the debugging tools.
