### PR TITLE
#181489190 ; Session fixation labels

### DIFF
--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -1,15 +1,15 @@
 import logging
 import os
 import random
-
 from string import ascii_uppercase
 from typing import Any, List, Tuple, Union
 
-from bcipy.helpers.clock import Clock
-from bcipy.task.exceptions import InsufficientDataException
-
 import numpy as np
 from psychopy import core, event, visual
+
+from bcipy.helpers.clock import Clock
+from bcipy.helpers.stimuli import get_fixation
+from bcipy.task.exceptions import InsufficientDataException
 
 log = logging.getLogger(__name__)
 
@@ -125,24 +125,23 @@ def construct_triggers(inquiry_timing: List[List]) -> List[Tuple[str, float]]:
 
 
 def target_info(triggers: List[Tuple[str, float]],
-                target_letter: str = None) -> List[str]:
+                target_letter: str = None,
+                is_txt: bool = True) -> List[str]:
     """Targetness for each item in triggers.
 
     Parameters
     ----------
     - triggers : list of (stim, offset)
     - target_letter : letter the user is attempting to spell
+    - is_txt : bool indicating whether the triggers are text stimuli
 
     Returns
     -------
     list of ('target' | 'nontarget') for each trigger.
     """
-    if target_letter:
-        return [
-            'target' if trg[0] == target_letter else 'nontarget'
-            for trg in triggers
-        ]
-    return ['nontarget'] * len(triggers)
+    fixation = get_fixation(is_txt)
+    labels = {target_letter: 'target', fixation: 'fixation'}
+    return [labels.get(trg[0], 'nontarget') for trg in triggers]
 
 
 def get_data_for_decision(inquiry_timing,

--- a/bcipy/helpers/tests/test_task.py
+++ b/bcipy/helpers/tests/test_task.py
@@ -211,14 +211,14 @@ class TestTriggers(unittest.TestCase):
                     ('X', 1.9859995969745796), ('Y', 2.203130029985914),
                     ('W', 2.4198898100003134)]
         expected = [
-            'nontarget', 'nontarget', 'nontarget', 'target', 'nontarget',
+            'fixation', 'nontarget', 'nontarget', 'target', 'nontarget',
             'nontarget', 'nontarget', 'nontarget', 'nontarget', 'nontarget',
             'nontarget'
         ]
         self.assertEqual(expected, target_info(triggers, target_letter='Z'))
 
         expected = [
-            'nontarget', 'nontarget', 'nontarget', 'nontarget', 'nontarget',
+            'fixation', 'nontarget', 'nontarget', 'nontarget', 'nontarget',
             'nontarget', 'nontarget', 'nontarget', 'nontarget', 'nontarget',
             'nontarget'
         ]

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -542,7 +542,7 @@ class RSVPCopyPhraseTask(Task):
                         target_stimuli: str,
                         current_text: str,
                         decision: Decision,
-                        evidence_types: List[EvidenceType] = []) -> Inquiry:
+                        evidence_types: List[EvidenceType] = None) -> Inquiry:
         """Construct a new inquiry data record.
 
         Parameters
@@ -560,11 +560,13 @@ class RSVPCopyPhraseTask(Task):
         evidence for the provided evidence_types, leaving the other types empty
         """
         assert self.current_inquiry, "Current inquiry is required"
+        evidence_types = evidence_types or []
         triggers = construct_triggers(self.stims_for_decision(stim_times))
         data = Inquiry(stimuli=self.current_inquiry.stimuli,
                        timing=self.current_inquiry.durations,
                        triggers=triggers,
-                       target_info=target_info(triggers, target_stimuli),
+                       target_info=target_info(triggers, target_stimuli,
+                                               self.parameters['is_txt_stim']),
                        target_letter=target_stimuli,
                        current_text=current_text,
                        target_text=self.copy_phrase,


### PR DESCRIPTION
# Overview

Updated labels in Copy Phrase session data to ensure that fixation stimuli are labeled as 'fixation' rather than 'nontarget'.

## Ticket

https://www.pivotaltracker.com/story/show/181489190

## Contributions

- Updated the task helper method to provide the correct target labels
- Updated unit tests
- Fixed a warning for a dangerous default value in Copy Phrase

## Test

- Ran all unit tests
- Ran a sample Copy Phrase session to ensure that the session data was output correctly.