### PR TITLE
Clear events before getting key presses in inquiry preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ The details (incomplete, our apologies!):
 - `CODE_OF_CONDUCT.md`: to latest version of the Contributor Covenant
 - `README.md`: Add new glossary terms: mode, session and task #126 #127 and cleanup #129
 - `bcipy/main.py`: formally, `bci_main.py`. To give a better console entry point and infrastructure for integration testing. In the terminal, you can now run `bcipy` instead of `python bci_main.py` 
-- `parameters.json`: add stim_order #153 add max selections #175 remove max_inq_per_trial in favor of max_inq_per_series #176 add inquiry preview #177
+- `parameters.json`: add stim_order #153 add max selections #175 remove max_inq_per_trial in favor of max_inq_per_series #176 add inquiry preview #177 with relevant stimuli units in help text, better starting stim_height, and inquiry preview keys #216
 - `demo_stimuli_generation.py`: update imports and add a case showing the new ordering functionality. #153
 - `copy_phrase_wrapper`: update logging and exception handling. add stim order. #153 BUGFIX: return transformed sampling rate #159
 - `random_rsvp_calibration_inq_gen`: rename to `calibration_inquiry_generator` #153

--- a/bcipy/display/paradigm/rsvp/display.py
+++ b/bcipy/display/paradigm/rsvp/display.py
@@ -2,7 +2,7 @@ import logging
 import os.path as path
 from typing import List, Optional, Tuple
 
-from psychopy import core, visual
+from psychopy import core, visual, event
 
 from bcipy.helpers.clock import Clock
 from bcipy.helpers.task import SPACE_CHAR, get_key_press
@@ -243,6 +243,7 @@ class RSVPDisplay(Display):
         timer = core.CountdownTimer(self._preview_inquiry.preview_inquiry_length)
         response = False
 
+        event.clearEvents(eventType='keyboard')
         while timer.getTime() > 0:
             # wait for a key press event
             response = get_key_press(

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -533,7 +533,7 @@
     "value": "0.1",
     "section": "bci_config",
     "readableName": "Text below main presentation height",
-    "helpTip": "Specifies the height of iinfo text stimuli. See https://www.psychopy.org/general/units.html. Default: 0.1",
+    "helpTip": "Specifies the height of info text stimuli. See https://www.psychopy.org/general/units.html. Default: 0.1",
     "recommended_values": [
       "0.1"
     ],

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -286,7 +286,7 @@
     "value": "500",
     "section": "bci_config",
     "readableName": "Task Window Height",
-    "helpTip": "Specifies the height (in pixels) of the task window when not in full screen mode (Full Screen Mode On/Off must be set to ‘false’). Default: 500",
+    "helpTip": "Specifies the height (in norm units) of the task window when not in full screen mode (Full Screen Mode On/Off must be set to ‘false’). See https://www.psychopy.org/general/units.html. Default: 500",
     "recommended_values": "",
     "type": "int"
   },
@@ -294,7 +294,7 @@
     "value": "500",
     "section": "bci_config",
     "readableName": "Task Window Width",
-    "helpTip": "Specifies the width (in pixels) of the task window when not in full screen mode (Full Screen Mode On/Off must be set to ‘false’). Default: 500",
+    "helpTip": "Specifies the width (in norm units) of the task window when not in full screen mode (Full Screen Mode On/Off must be set to ‘false’). See https://www.psychopy.org/general/units.html. Default: 500",
     "recommended_values": "",
     "type": "int"
   },
@@ -442,10 +442,10 @@
     "type": "str"
   },
   "stim_height": {
-    "value": "0.6",
+    "value": "0.5",
     "section": "bci_config",
     "readableName": "Stimulus Size",
-    "helpTip": "Specifies the height (in ???) of text stimuli. Possible values range from X to X. Default: 0.6",
+    "helpTip": "Specifies the height of text stimuli. See https://www.psychopy.org/general/units.html. Default: 0.5",
     "recommended_values": "",
     "type": "float"
   },
@@ -532,8 +532,8 @@
   "info_height": {
     "value": "0.1",
     "section": "bci_config",
-    "readableName": "Text Height",
-    "helpTip": "Text Height",
+    "readableName": "Text below main presentation height",
+    "helpTip": "Specifies the height of iinfo text stimuli. See https://www.psychopy.org/general/units.html. Default: 0.1",
     "recommended_values": [
       "0.1"
     ],
@@ -603,7 +603,7 @@
     "value": "0.1",
     "section": "bci_config",
     "readableName": "Task Text Size",
-    "helpTip": "Specifies the height (in ???) of task-specific text, e.g. #/100 in calibration and target phrase in copy/spelling. Possible values range from 0 to 1. Default: 0.1",
+    "helpTip": "Specifies the height of task-specific text, e.g. #/100 in calibration and target phrase in copy/spelling. See https://www.psychopy.org/general/units.html. Default: 0.1",
     "recommended_values": [
       "0.1"
     ],
@@ -811,13 +811,14 @@
     "type": "float"
   },
   "preview_inquiry_key_input": {
-    "value": "space",
+    "value": "return",
     "section": "bci_config",
     "readableName": "Preview Inquiry Display Key Input Method",
     "helpTip": "Defines the key used to engage with inquiry preview.",
     "recommended_values": [
       "space",
-      "escape"
+      "escape",
+      "return"
     ],
     "type": "str"
   },
@@ -873,7 +874,7 @@
     "value": "0.2",
     "section": "feedback_config",
     "readableName": "Feedback Stimuli Height",
-    "helpTip": "Specifies the height of the feedback stimuli. Default: 0.2",
+    "helpTip": "Specifies the height of the feedback stimuli. See https://www.psychopy.org/general/units.html. Default: 0.2",
     "recommended_values": "",
     "type": "float"
   },


### PR DESCRIPTION
# Overview

Clear events before getting key presses in inquiry preview. Add better psychopy unit definitions and 'return' as a recommended option

## Ticket

[Link a pivotal ticket here](https://www.pivotaltracker.com/story/show/182003375)

## Contributions

- [bcipy/display/paradigm/rsvp/display.py](https://github.com/CAMBI-tech/BciPy/compare/1.5.1...ip_key_events_fix?expand=1#diff-f8e158b8f1a845ab686c646708cb8c4a800f1d79672253a42861e3802e00eb12) - added events.clearEvents() before waiting for key events
- [bcipy/parameters/parameters.json](https://github.com/CAMBI-tech/BciPy/compare/1.5.1...ip_key_events_fix?expand=1#diff-cdfbb7d72199b3190811241422513c89f1e0b3ae42c9f5d11eb56b8abc7b3d33) - add psychopy documentation for units and a better default stim height. Add return as an inquiry preview key press recommended value.

## Test

- `Make test-all`
- Ran Copy Phrase in fake data mode with inquiry preview on, press to confirm & skip, key as return --> ensure any presses to return did not trigger the Inquiry Preview.

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here. N/A
