### PR TITLE
Prevent GUI Double Clicks

### DIFF
--- a/bcipy/acquisition/datastream/mock/switch.py
+++ b/bcipy/acquisition/datastream/mock/switch.py
@@ -5,7 +5,7 @@ import sys
 from pylsl import StreamInfo, StreamOutlet
 
 from bcipy.acquisition.devices import DeviceSpec, IRREGULAR_RATE
-from bcipy.gui.gui_main import BCIGui, app
+from bcipy.gui.main import BCIGui, app
 
 log = logging.getLogger(__name__)
 

--- a/bcipy/gui/experiments/ExperimentField.py
+++ b/bcipy/gui/experiments/ExperimentField.py
@@ -14,7 +14,7 @@ from PyQt5.QtWidgets import (
     QWidget,
 )
 
-from bcipy.gui.gui_main import (
+from bcipy.gui.main import (
     AlertMessageType,
     AlertMessageResponse,
     AlertResponse,

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -1,7 +1,7 @@
 import sys
 import subprocess
 
-from bcipy.gui.gui_main import BCIGui, app, AlertMessageType, AlertMessageResponse, ScrollableFrame, LineItems
+from bcipy.gui.main import BCIGui, app, AlertMessageType, AlertMessageResponse, ScrollableFrame, LineItems
 
 from bcipy.helpers.load import load_experiments, load_fields
 from bcipy.helpers.save import save_experiment_data

--- a/bcipy/gui/experiments/FieldRegistry.py
+++ b/bcipy/gui/experiments/FieldRegistry.py
@@ -1,5 +1,5 @@
 import sys
-from bcipy.gui.gui_main import BCIGui, app, AlertMessageType, AlertMessageResponse
+from bcipy.gui.main import BCIGui, app, AlertMessageType, AlertMessageResponse
 
 from bcipy.helpers.load import load_fields
 from bcipy.helpers.save import save_field_data

--- a/bcipy/gui/main.py
+++ b/bcipy/gui/main.py
@@ -541,6 +541,8 @@ class BCIGui(QWidget):
         self.vbox = QVBoxLayout()
         self.setStyleSheet(f'background-color: {self.background_color};')
 
+        self.timer = QTimer()
+
         self.title = title
 
         # determines height/width of window

--- a/bcipy/gui/parameters/params_form.py
+++ b/bcipy/gui/parameters/params_form.py
@@ -9,7 +9,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import (QApplication, QFileDialog, QHBoxLayout,
                              QPushButton, QScrollArea, QVBoxLayout, QWidget)
 
-from bcipy.gui.gui_main import (
+from bcipy.gui.main import (
     BoolInput,
     DirectoryInput,
     FileInput,

--- a/bcipy/gui/viewer/data_viewer.py
+++ b/bcipy/gui/viewer/data_viewer.py
@@ -16,7 +16,7 @@ from PyQt5.QtWidgets import (QApplication, QCheckBox, QComboBox, QHBoxLayout,
 
 from bcipy.acquisition.device_info import DeviceInfo
 from bcipy.acquisition.util import StoppableProcess
-from bcipy.gui.gui_main import static_text_control
+from bcipy.gui.main import static_text_control
 from bcipy.gui.viewer.data_source.data_source import QueueDataSource
 from bcipy.gui.viewer.data_source.lsl_data_source import LslDataSource
 from bcipy.gui.viewer.ring_buffer import RingBuffer


### PR DESCRIPTION
# Overview

Added a BCIGui timer that is used in BCInterface to prevent double-clicking behavior. 

## Ticket

- https://www.pivotaltracker.com/story/show/182039256

## Contributions

- `gui.main.py`: add timer
- `gui.gui_main.py --> gui.main.py`: refactor to match other modules while in release canditate
- `gui.BCInterfacy.py`: added an `action_disabled` and `_disable_action` methods to create a timer that would disable actions for a time (self.timeout). Add the `action_disabled` check to all clickable events in the GUI.

## Test

- `make test-all`
- Run the BCInterface.py GUI and try double-clicking buttons. Ensure that the defined timeout actions are possible again after the timeout.

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here. N/A

## Changelog

- Is the CHANGELOG.md updated with your detailed changes?  I will once approved! :D 
