### PR TITLE
Signal Model Path Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Better handling of the `fake_data` parameter to avoid erroneous recordings. Added a confirmation dialog when the `fake_data` parameter is set to `True` to alert users that they are in a system test mode. #219
 - `task/data.py`: session data contains more contextual data for interpreting the results, including the `symbol_set` and the `decision_threshold` used.
 - `parameters/parameters.json`: added `summarize_session` parameter is used to output richer session summaries after a Copy Phrase task.
+- `parameters/parameters.json`: added the `signal_model_path` parameter. When set this can be used for loading the pre-trained signal model during typing sessions.
 
 
 ### Updated

--- a/bcipy/gui/file_dialog.py
+++ b/bcipy/gui/file_dialog.py
@@ -25,7 +25,7 @@ class FileDialog(QWidget):
         self.options = QFileDialog.Options()
         self.options |= QFileDialog.DontUseNativeDialog
 
-    def ask_file(self, file_types: str = DEFAULT_FILE_TYPES) -> str:
+    def ask_file(self, file_types: str = DEFAULT_FILE_TYPES, directory: str = "") -> str:
         """Opens a file dialog window.
         Returns
         -------
@@ -33,7 +33,7 @@ class FileDialog(QWidget):
         """
         filename, _ = QFileDialog.getOpenFileName(self,
                                                   "Select File",
-                                                  "",
+                                                  directory,
                                                   file_types,
                                                   options=self.options)
         return filename
@@ -50,13 +50,14 @@ class FileDialog(QWidget):
                                                 options=self.options)
 
 
-def ask_filename(file_types: str = DEFAULT_FILE_TYPES) -> str:
+def ask_filename(file_types: str = DEFAULT_FILE_TYPES, directory: str = "") -> str:
     """Prompt for a file.
 
     Parameters
     ----------
     - file_types : optional file type filters; Examples: 'Text files (*.txt)'
     or 'Image files (*.jpg *.gif)' or '*.csv;;*.pkl'
+    - directory : optional directory
 
     Returns
     -------
@@ -64,7 +65,7 @@ def ask_filename(file_types: str = DEFAULT_FILE_TYPES) -> str:
     """
     app = QApplication(sys.argv)
     dialog = FileDialog()
-    filename = dialog.ask_file(file_types)
+    filename = dialog.ask_file(file_types, directory)
 
     # Alternatively, we could use `app.closeAllWindows()`
     app.quit()

--- a/bcipy/helpers/load.py
+++ b/bcipy/helpers/load.py
@@ -171,9 +171,8 @@ def load_signal_model(model_class: SignalModel,
         SignalModel: Model after loading pretrained parameters.
     """
     # use python's internal gui to call file explorers and get the filename
-
-    if not filename:
-        filename = ask_filename('*.pkl')
+    if not filename or Path(filename).is_dir():
+        filename = ask_filename('*.pkl', filename)
 
     # load the signal_model with pickle
     signal_model = model_class(**model_kwargs)

--- a/bcipy/main.py
+++ b/bcipy/main.py
@@ -108,8 +108,9 @@ def execute_task(task: TaskType, parameters: dict, save_folder: str) -> bool:
         if not fake:
             try:
                 signal_model, _filename = load_signal_model(
-                    model_class=PcaRdaKdeModel, model_kwargs={
-                        'k_folds': parameters['k_folds']})
+                    model_class=PcaRdaKdeModel,
+                    model_kwargs={'k_folds': parameters['k_folds']},
+                    filename=parameters['signal_model_path'])
             except Exception as e:
                 log.exception(f'Cannot load signal model. Exiting. {e}')
                 raise e

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -97,6 +97,14 @@
     "recommended_values": "",
     "type": "filepath"
   },
+  "signal_model_path": {
+    "value": "",
+    "section": "bci_config",
+    "readableName": "Signal Model Path",
+    "helpTip": "Directory of the pre-trained signal model. This is often the the calibration session directory.",
+    "recommended_values": "",
+    "type": "directorypath"
+  },
   "filter_high": {
     "value": "20",
     "section": "signal_config",

--- a/bcipy/tests/test_bci_main.py
+++ b/bcipy/tests/test_bci_main.py
@@ -26,7 +26,8 @@ class TestBciMain(unittest.TestCase):
     parameters = {
         'data_save_loc': data_save_location,
         'log_name': 'test_log',
-        'fake_data': False
+        'fake_data': False,
+        'signal_model_path': ''
     }
     system_info = {
         'bcipy_version': 'test_version'
@@ -152,7 +153,8 @@ class TestExecuteTask(unittest.TestCase):
         self.parameters = {
             'fake_data': True,
             'k_folds': 10,
-            'is_txt_stim': True
+            'is_txt_stim': True,
+            'signal_model_path': ''
         }
         self.save_folder = '/'
         self.task = TaskType(1)
@@ -248,6 +250,8 @@ class TestExecuteTask(unittest.TestCase):
 
     def test_execute_task_non_calibration_real_data(self) -> None:
         self.parameters['fake_data'] = False
+        model_path = "data/mycalib/"
+        self.parameters['signal_model_path'] = model_path
         self.task = TaskType(2)
         signal_model = mock()
         language_model = mock()
@@ -263,7 +267,7 @@ class TestExecuteTask(unittest.TestCase):
         when(main).print_message(self.display_mock, any())
         when(main).load_signal_model(model_class=any(), model_kwargs={
             'k_folds': self.parameters['k_folds']
-        }).thenReturn(load_model_response)
+        }, filename=model_path).thenReturn(load_model_response)
         when(main).init_language_model(self.parameters).thenReturn(language_model)
         when(main).start_task(
             self.display_mock,
@@ -297,7 +301,7 @@ class TestExecuteTask(unittest.TestCase):
         )
         verify(main, times=1).load_signal_model(model_class=any(), model_kwargs={
             'k_folds': self.parameters['k_folds']
-        })
+        }, filename=model_path)
         verify(main, times=1)._clean_up_session(self.display_mock, self.daq, self.server)
 
     def test_execute_task_invalid_task(self) -> None:
@@ -345,7 +349,7 @@ class TestExecuteTask(unittest.TestCase):
         when(main).print_message(self.display_mock, any())
         when(main).load_signal_model(model_class=any(), model_kwargs={
             'k_folds': self.parameters['k_folds']
-        }).thenReturn(load_model_response)
+        }, filename='').thenReturn(load_model_response)
         when(main).start_task(
             self.display_mock,
             self.daq,
@@ -378,7 +382,7 @@ class TestExecuteTask(unittest.TestCase):
         )
         verify(main, times=1).load_signal_model(model_class=any(), model_kwargs={
             'k_folds': self.parameters['k_folds']
-        })
+        }, filename='')
         verify(main, times=1).init_language_model(self.parameters)
         verify(main, times=1)._clean_up_session(self.display_mock, self.daq, self.server)
 


### PR DESCRIPTION
# Overview

Added a parameter to specify the `signal_model_path`. If provided, this path is used when loading the signal model for typing tasks.

## Ticket

https://www.pivotaltracker.com/story/show/182005453

## Contributions

- New parameter to specify the signal model path.
- Updated the `ask_file` utility to accept an optional directory parameter from which to start.
- Updated the `load` helper.

## Test

- Ran Copy Phrase task without the parameter set to ensure that the original behavior did not change.
- Ran a copy Copy Phrase task with the new parameter set to my calibration directory. Confirmed that the dialog displayed this directory when initialized.
