### PR TITLE
[Bug fix] Two presses needed to start copy phrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - New MNE based plotting for EEG data #220
 - Prevent GUI double clicks #218
 - Better Fake Data Handling #219
+- Bug fixes #225
 
 ### Added
 
@@ -26,6 +27,7 @@
 
 ### Removed
 
+- `task/paradigm/rsvp/copy_phrase.py`: removed await_start to prevent two space hits for the task to start #225
 
 
 # 2.0.0-rc.1

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -243,16 +243,6 @@ class RSVPCopyPhraseTask(Task):
             stim_length=self.parameters['stim_length'],
             stim_order=StimuliOrder(self.parameters['stim_order']))
 
-    def await_start(self) -> bool:
-        """Wait on the splash screen for the user to either exit or start."""
-        self.logger.debug('Awaiting user start.')
-        should_continue = get_user_input(
-            self.rsvp,
-            self.parameters['wait_screen_message'],
-            self.parameters['wait_screen_message_color'],
-            first_run=self.first_run)
-        return should_continue
-
     def user_wants_to_continue(self) -> bool:
         """Check if user wants to continue or terminate.
 
@@ -380,12 +370,10 @@ class RSVPCopyPhraseTask(Task):
         data save location (triggers.txt, session.json)
         """
         self.logger.debug('Starting Copy Phrase Task!')
-        run = self.await_start()
 
-        self.wait()  # buffer for data
+        self.wait()  # buffer for data processing
 
-        while run and self.user_wants_to_continue(
-        ) and self.current_inquiry:
+        while self.user_wants_to_continue() and self.current_inquiry:
             target_stimuli = self.next_target()
             stim_times, proceed = self.present_inquiry(
                 self.current_inquiry)

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -174,7 +174,7 @@ class RSVPCopyPhraseTask(Task):
     def validate_parameters(self) -> None:
         """Validate.
 
-        Confirm Task is configurated with correct parameters and within operating limits.
+        Confirm Task is configured with correct parameters and within operating limits.
         """
 
         # ensure all required parameters are provided
@@ -370,10 +370,10 @@ class RSVPCopyPhraseTask(Task):
         data save location (triggers.txt, session.json)
         """
         self.logger.debug('Starting Copy Phrase Task!')
-
+        run = True
         self.wait()  # buffer for data processing
 
-        while self.user_wants_to_continue() and self.current_inquiry:
+        while run and self.user_wants_to_continue() and self.current_inquiry:
             target_stimuli = self.next_target()
             stim_times, proceed = self.present_inquiry(
                 self.current_inquiry)

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -245,7 +245,7 @@ class TestCopyPhrase(unittest.TestCase):
                                   fake=True)
 
         # Execute a single inquiry then `escape` to stop
-        user_input_mock.side_effect = [True, True, False]
+        user_input_mock.side_effect = [True, False]
 
         timings_gen = mock_inquiry_timings()
         when(self.display).do_inquiry().thenReturn(next(timings_gen))
@@ -284,7 +284,7 @@ class TestCopyPhrase(unittest.TestCase):
                                   fake=True)
 
         # Don't provide any `escape` input from the user
-        user_input_mock.side_effect = [True, True, True, True, True, True]
+        user_input_mock.return_value = True
 
         timings_gen = mock_inquiry_timings()
         when(self.display).do_inquiry().thenReturn(next(timings_gen))
@@ -325,7 +325,7 @@ class TestCopyPhrase(unittest.TestCase):
                                   fake=True)
 
         # Don't provide any `escape` input from the user
-        user_input_mock.side_effect = [True, True, True, True, True, True]
+        user_input_mock.return_value = True
 
         timings_gen = mock_inquiry_timings()
         when(self.display).do_inquiry().thenReturn(next(timings_gen))
@@ -453,7 +453,7 @@ class TestCopyPhrase(unittest.TestCase):
                                   fake=True)
 
         # Execute a single inquiry then `escape` to stop
-        user_input_mock.side_effect = [True, True, False]
+        user_input_mock.side_effect = [True, False]
         when(self.copy_phrase_wrapper).add_evidence(any, any).thenReturn([])
 
         timings_gen = mock_inquiry_timings()
@@ -565,7 +565,7 @@ class TestCopyPhrase(unittest.TestCase):
                                   fake=False)
 
         # Execute a single inquiry then `escape` to stop
-        user_input_mock.side_effect = [True, True, False]
+        user_input_mock.side_effect = [True, False]
 
         # mock data for single inquiry
         process_data_mock.return_value = mock_process_data()
@@ -585,8 +585,6 @@ class TestCopyPhrase(unittest.TestCase):
         with open(Path(task.session_save_location), 'r', encoding=DEFAULT_ENCODING) as json_file:
             session = Session.from_dict(json.load(json_file))
             self.assertEqual(1, session.total_number_series)
-
-    # TODO: test feedback; patch VisualFeedback constructor, returning a mock; verify(feedback, times=1).administer(...)
 
 
 def mock_inquiry_data():


### PR DESCRIPTION
# Overview

Removed `RSVPCopyPhrase.await_start` to prevent two presses from being necessary to start the copy phrase task.

## Ticket

https://www.pivotaltracker.com/story/show/182228537

## Contributions

- `task/paradigm/rsvp/copy_phrase.py`: removed await_start

## Test

- `Make test-all`
- bcipy --task "RSVP Copy Phrase"

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here. N/a

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? Yes!
