### PR TITLE
#182406904 ; Session Summary Bug

### DIFF
--- a/bcipy/helpers/session.py
+++ b/bcipy/helpers/session.py
@@ -102,7 +102,9 @@ def evidence_records(session: Session) -> List[EvidenceRecord]:
     for series_index, inquiry_list in enumerate(session.series):
         for inq_index, inquiry in enumerate(inquiry_list):
             evidence = inquiry.stim_evidence(symbol_set=session.symbol_set)
-
+            stimuli = inquiry.stimuli
+            if len(stimuli) == 1 and isinstance(stimuli[0], list):
+                stimuli = stimuli[0]
             for stim, _likelihood_ev in evidence['likelihood'].items():
                 records.append(
                     EvidenceRecord(
@@ -113,10 +115,10 @@ def evidence_records(session: Session) -> List[EvidenceRecord]:
                         eeg=evidence['eeg_evidence'].get(stim, ''),
                         btn=evidence.get('btn_evidence', {}).get(stim, ''),
                         cumulative=evidence['likelihood'][stim],
-                        inq_position=inquiry.stimuli.index(stim)
-                        if stim in inquiry.stimuli else None,
+                        inq_position=stimuli.index(stim)
+                        if stim in stimuli else None,
                         is_target=int(inquiry.target_letter == stim),
-                        presented=int(stim in inquiry.stimuli),
+                        presented=int(stim in stimuli),
                         above_threshold=int(evidence['likelihood'][stim] >
                                             session.decision_threshold)))
     return records

--- a/bcipy/helpers/session.py
+++ b/bcipy/helpers/session.py
@@ -103,6 +103,7 @@ def evidence_records(session: Session) -> List[EvidenceRecord]:
         for inq_index, inquiry in enumerate(inquiry_list):
             evidence = inquiry.stim_evidence(symbol_set=session.symbol_set)
             stimuli = inquiry.stimuli
+            # Flatten if stimuli is structured as a nested list.
             if len(stimuli) == 1 and isinstance(stimuli[0], list):
                 stimuli = stimuli[0]
             for stim, _likelihood_ev in evidence['likelihood'].items():
@@ -115,8 +116,7 @@ def evidence_records(session: Session) -> List[EvidenceRecord]:
                         eeg=evidence['eeg_evidence'].get(stim, ''),
                         btn=evidence.get('btn_evidence', {}).get(stim, ''),
                         cumulative=evidence['likelihood'][stim],
-                        inq_position=stimuli.index(stim)
-                        if stim in stimuli else None,
+                        inq_position=stimuli.index(stim) if stim in stimuli else None,
                         is_target=int(inquiry.target_letter == stim),
                         presented=int(stim in stimuli),
                         above_threshold=int(evidence['likelihood'][stim] >


### PR DESCRIPTION

# Overview

Fixed bug when generating a spreadsheet at the end of a spelling task. 

The code worked correctly when generating the spreadsheet using the `demo_session_tools.py` due to the way it was parsing the `session.json` file. The active `Session` object used in the Copy Phrase task had a slightly different value for each Inquiry's stimuli property, which was causing the issue.

## Ticket

https://www.pivotaltracker.com/story/show/182406904

## Contributions

- Fix bug when converting a Session Object to a list of EvidenceRecords used in generating the spreadsheet.

## Test

- Ran Copy Phrase task and inspected the generated spreadsheet to confirm the correct numbers. Also generated the spreadsheet using the demo code (helpers/demo/demo_session_tools.py) to confirm the same values.