### PR TITLE
use a better default timeout

### DIFF
--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -32,7 +32,7 @@ class BCInterface(BCIGui):
     btn_height = 40
     max_length = 25
     min_length = 1
-    timeout = 10
+    timeout = 3
 
     def __init__(self, *args, **kwargs):
         super(BCInterface, self).__init__(*args, **kwargs)


### PR DESCRIPTION
# Overview

Updated the default timeout to 3 seconds (from 10 seconds). 

## Ticket

https://www.pivotaltracker.com/story/show/182228549
 
## Contributions

- `gui/BCInterface.py`: updated the default timeout to 3 seconds (from 10 seconds). 

## Test

- Loaded the GUI and ensured timeout still worked.

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? N/a
