### PR TITLE
#182106570 ; Acquisition Channel Specifications

### DIFF
--- a/bcipy/acquisition/README.md
+++ b/bcipy/acquisition/README.md
@@ -6,7 +6,7 @@ The data acquisition module is responsible for interfacing with hardware to obta
 
 The acquisition module connects with hardware devices using the [Lab Streaming Layer (LSL)](https://labstreaminglayer.readthedocs.io/index.html) library. Each device should provide its own LSL driver / application to use for streaming data. The LSL website maintains a list of [available apps](https://labstreaminglayer.readthedocs.io/info/supported_devices.html). If your device does not have a supported app see [https://labstreaminglayer.readthedocs.io/dev/app_build.html](https://labstreaminglayer.readthedocs.io/dev/app_build.html). The streamer should be started prior to running the `bcipy` application.
 
-Within BciPy users must specify the details of the device they wish to use by providing a `DeviceSpec`. A list of preconfigured devices is defined in `devices.json`. A new device can be added to that file manually, or programmatically registered with the `device_info` module.
+Within BciPy users must specify the details of the device they wish to use by providing a `DeviceSpec`. A list of preconfigured devices is defined in `devices.json`. A new device can be added to that file manually, or programmatically registered with the `devices` module.
 
     from bcipy.acquisition.devices import DeviceSpec, register
     my_device = DeviceSpec(name="DSI-VR300",
@@ -14,6 +14,8 @@ Within BciPy users must specify the details of the device they wish to use by pr
                            sample_rate=300.0,
                            content_type="EEG")
     register(my_device)
+
+`DeviceSpec` channel data can be provided as a list of channel names or specified as a list of `ChannelSpec` entries. These will be validated against the metadata from the LSL data stream. If provided, `ChannelSpecs` allow users to customize the channel labels and override the values provided by the LSL metadata.
 
 ## Client
 

--- a/bcipy/acquisition/datastream/lsl_server.py
+++ b/bcipy/acquisition/datastream/lsl_server.py
@@ -69,11 +69,11 @@ class LslDataServer(StoppableThread):
                 unit = 'microvolts'
                 channel_type = 'EEG'
             meta_channels = info.desc().append_child('channels')
-            for channel in device_spec.channels:
+            for channel in device_spec.channel_specs:
                 meta_channels.append_child('channel') \
-                    .append_child_value('label', channel) \
-                    .append_child_value('unit', unit) \
-                    .append_child_value('type', channel_type)
+                    .append_child_value('label', channel.name) \
+                    .append_child_value('unit', channel.units or unit) \
+                    .append_child_value('type', channel.type or channel_type)
 
         self.outlet = StreamOutlet(info)
 

--- a/bcipy/acquisition/protocols/lsl/lsl_client.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_client.py
@@ -85,7 +85,8 @@ class LslAcquisitionClient:
         if self.save_directory:
             self.recorder = LslRecordingThread(stream_info,
                                                self.save_directory,
-                                               self.raw_data_file_name)
+                                               self.raw_data_file_name,
+                                               self.device_spec)
             self.recorder.start()
 
         self.buffer = RingBuffer(size_max=self.max_samples)

--- a/bcipy/acquisition/protocols/lsl/lsl_connector.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_connector.py
@@ -73,12 +73,12 @@ def check_device(device_spec: DeviceSpec, metadata: pylsl.StreamInfo):
     acquired from the device."""
     channels = channel_names(metadata)
     # Confirm that provided channels match metadata, or meta is empty.
-    if channels and device_spec.channels != channels:
+    if channels and device_spec.channel_names != channels:
         print(f"device channels: {channels}")
-        print(device_spec.channels)
+        print(device_spec.channel_names)
         raise Exception("Channels read from the device do not match "
                         "the provided parameters.")
-    assert len(device_spec.channels) == metadata.channel_count(
+    assert device_spec.channel_count == metadata.channel_count(
     ), "Channel count error"
 
     if device_spec.sample_rate != metadata.nominal_srate():

--- a/bcipy/helpers/tests/test_task.py
+++ b/bcipy/helpers/tests/test_task.py
@@ -7,7 +7,7 @@ from mockito import unstub, mock, when, verify, verifyStubbedInvocationsAreUsed
 import numpy as np
 import psychopy
 
-from bcipy.acquisition.client import DataAcquisitionClient
+from bcipy.acquisition.protocols.lsl.lsl_client import LslAcquisitionClient
 from bcipy.acquisition.record import Record
 from bcipy.task.exceptions import InsufficientDataException
 
@@ -243,7 +243,7 @@ class TestGetDataForDecision(unittest.TestCase):
 
     def setUp(self) -> None:
         self.inquiry_timing = [('A', 1), ('B', 2), ('C', 3)]
-        self.daq = mock(spec=DataAcquisitionClient)
+        self.daq = mock(spec=LslAcquisitionClient)
         self.daq.device_info = mock()
         self.daq.device_info.fs = 10
         self.mock_eeg = mock_get_data_response(samples=1000, high=1000, low=-1000, channels=4)

--- a/bcipy/tests/test_bci_main.py
+++ b/bcipy/tests/test_bci_main.py
@@ -45,6 +45,7 @@ class TestBciMain(unittest.TestCase):
     def test_bci_main_default_experiment(self) -> None:
         mock_execute_response = mock()
         when(main).validate_experiment(self.experiment).thenReturn(True)
+        when(main).validate_bcipy_session(self.parameters).thenReturn(True)
         when(main).load_json_parameters(self.parameter_location, value_cast=True).thenReturn(
             self.parameters
         )


### PR DESCRIPTION
# Overview

Added functionality for configuration channel specifications for a given device.

## Ticket

https://www.pivotaltracker.com/story/show/182106570

## Contributions

- Refactored `devices` module to allow channels to be specified as either a list of names or a list of `ChannelSpec` objects, which provide additional information about a channel including the option to override the label when used in BciPy.
- Refactored `LslRecordingThread` to use overridden channel labels if provided.
- Refactored `lsl_server` to use the additional channel metadata if provided.
- Added unit tests

## Test

- Ran all unit tests
- Created a new entry in the devices.json file with additional channel metadata. Used this device for mocking a data server. Ran a calibration session with the device, confirming that the LSL metadata logged used the channel names and the raw_data used the channel labels. Ran offline_analysis on the data and proceeded with a Copy Phrase task.

```
    {
        "name": "Demo_channel_spec",
        "content_type": "EEG",
        "channels": [
            {"name": "ch1", "label": "P4", "type": "EEG", "units": "microvolts"},
            {"name": "ch2", "label": "Fz", "type": "EEG", "units": "microvolts"},
            {"name": "ch3", "label": "Pz", "type": "EEG", "units": "microvolts"},
            {"name": "ch4", "label": "F7", "type": "EEG", "units": "microvolts"},
            {"name": "ch5", "label": "PO8", "type": "EEG", "units": "microvolts"},
            {"name": "ch6", "label": "PO7", "type": "EEG", "units": "microvolts"},
            {"name": "ch7", "label": "Oz", "type": "EEG", "units": "microvolts"},
            {"name": "ch8", "label": "TRG","type": "EEG", "units": "microvolts"}
        ],
        "sample_rate": 300.0,
        "connection_methods": ["TCP", "LSL"],
        "description": "Alias to DSI-VR300 for backwards compatibility.",
        "excluded_from_analysis": ["TRG"]
    }
```

## Documentation

- Added some additional documentation in the README file for the acquisition module.