### PR TITLE
added ssvep to cvep method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 ### Added
 
 - `helpers/visualization.py`: added methods for visualized MNE Epochs and better visualizing EEG data in BciPy. #220 `visualize_joint_average` and `visualize_evokeds`.
-- `helpers/stimuli.py`: added a method for converting MNE RawArray to Epochs. #220 Added stimuli flash time jitter to calibration and inq_generation methods #233
+- `helpers/stimuli.py`: added a method for converting MNE RawArray to Epochs. #220 Added stimuli flash time jitter to calibration and inq_generation methods #233 Added ssvep_to_code method #232
 - `helpers/convert.py`: added a convert to mne method that returns an MNE RawArray. Assumes standard_1020 eeg montage by default.#220
 - Better handling of the `fake_data` parameter to avoid erroneous recordings. Added a confirmation dialog when the `fake_data` parameter is set to `True` to alert users that they are in a system test mode. #219
 - `task/data.py`: session data contains more contextual data for interpreting the results, including the `symbol_set` and the `decision_threshold` used.

--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -705,23 +705,41 @@ def get_fixation(is_txt: bool) -> str:
         return DEFAULT_FIXATION_PATH
 
 
-def ssvep_to_cvep(refresh_rate: int = 60, flicker_rate: float = 10.0):
-    if flicker_rate > refresh_rate:
-        raise Exception("flicker rate cannot be greater than refresh rate")
+def ssvep_to_code(refresh_rate: int = 60, flicker_rate: int = 10) -> List[int]:
+    """Convert SSVEP to Code.
 
+    Converts a SSVEP (steady state visual evoked potential; ex. 10 Hz) to a code (0,1)
+    given the refresh rate of the monitor (Hz) provided and a desired flicker rate (Hz).
+
+    Parameters:
+    -----------
+        refresh_rate: int, refresh rate of the monitor (Hz)
+        flicker_rate: int, desired flicker rate (Hz)
+    Returns:
+    --------
+        list of 0s and 1s that represent the code for the SSVEP on the monitor.
+    """
+    if flicker_rate > refresh_rate:
+        raise BciPyCoreException('flicker rate cannot be greater than refresh rate')
+    if flicker_rate <= 1:
+        raise BciPyCoreException('flicker rate must be greater than 1')
+
+    # get the number of frames per flicker
     length_flicker = refresh_rate / flicker_rate
 
-    # determine if lenth_flickerr is an integer using .is_integer()
-    if not length_flicker.is_integer():
-        raise Exception("Provided flicker rate must divide into refresh rate.")
+    if length_flicker.is_integer():
+        length_flicker = int(length_flicker)
+    else:
+        err_message = f'flicker rate={flicker_rate} is not an integer multiple of refresh rate={refresh_rate}'
+        log.exception(err_message)
+        raise BciPyCoreException(err_message)
 
+    # start the first frames as off (0) for length of flicker;
+    # it will then toggle on (1)/ off (0) for length of flicker until all frames are filled for refresh rate.
     t = 0
-    test_array = []
-    for _ in range(int(length_flicker)):
-        for _ in range(int(length_flicker)):
-            test_array.append(t)
-        if t > 0:
-            t = 0
-        else:
-            t = 1
-    return test_array
+    codes = []
+    for _ in range(flicker_rate):
+        codes += [t] * length_flicker
+        t = 1 - t
+
+    return codes

--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -703,3 +703,25 @@ def get_fixation(is_txt: bool) -> str:
         return '+'
     else:
         return DEFAULT_FIXATION_PATH
+
+
+def ssvep_to_cvep(refresh_rate: int = 60, flicker_rate: float = 10.0):
+    if flicker_rate > refresh_rate:
+        raise Exception("flicker rate cannot be greater than refresh rate")
+
+    length_flicker = refresh_rate / flicker_rate
+
+    # determine if lenth_flickerr is an integer using .is_integer()
+    if not length_flicker.is_integer():
+        raise Exception("Provided flicker rate must divide into refresh rate.")
+
+    t = 0
+    test_array = []
+    for _ in range(int(length_flicker)):
+        for _ in range(int(length_flicker)):
+            test_array.append(t)
+        if t > 0:
+            t = 0
+        else:
+            t = 1
+    return test_array

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -26,6 +26,7 @@ from bcipy.helpers.stimuli import (
     distributed_target_positions,
     soundfiles,
     StimuliOrder,
+    ssvep_to_cvep,
     TargetPositions
 )
 
@@ -697,6 +698,37 @@ class TestInquiryReshaper(unittest.TestCase):
         expected_shape = (self.n_channel, self.n_inquiry, samples_per_inquiry)
         self.assertTrue(reshaped_data.shape == expected_shape)
         self.assertTrue(np.all(labels == self.true_labels))
+
+
+class SSVEPStimuli(unittest.TestCase):
+
+    def test_default_flicker_and_refresh_rate_return_codes(self):
+        response = ssvep_to_cvep()
+        self.assertIsInstance(response, list)
+        self.assertEqual(response[0], 0)
+
+    def test_ssvep_to_cvep_raises_exception_when_refresh_rate_less_than_flicker_rate(self):
+        flicker_rate = 300
+        refresh_rate = 1
+
+        with self.assertRaises(Exception):
+            ssvep_to_cvep(refresh_rate, flicker_rate)
+
+    def test_when_division_of_refresh_rate_by_flicker_rate_raise_exception_if_noninteger(self):
+        # flicker_rate = 11.43 refresh_rate = 60
+        flicker_rate = 11.43
+        refresh_rate = 60
+
+        with self.assertRaises(Exception):
+            ssvep_to_cvep(refresh_rate, flicker_rate)
+
+    def test_ssvep_to_cvep_returns_expected_codes(self):
+        flicker_rate = 2
+        refresh_rate = 4
+        response = ssvep_to_cvep(flicker_rate=flicker_rate, refresh_rate=refresh_rate)
+        expected_output = [0, 0, 1, 1]
+        self.assertEqual(response, expected_output)
+
 
 
 class TestSoundStimuli(unittest.TestCase):

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -26,7 +26,7 @@ from bcipy.helpers.stimuli import (
     distributed_target_positions,
     soundfiles,
     StimuliOrder,
-    ssvep_to_cvep,
+    ssvep_to_code,
     TargetPositions
 )
 
@@ -703,32 +703,49 @@ class TestInquiryReshaper(unittest.TestCase):
 class SSVEPStimuli(unittest.TestCase):
 
     def test_default_flicker_and_refresh_rate_return_codes(self):
-        response = ssvep_to_cvep()
+        response = ssvep_to_code()
         self.assertIsInstance(response, list)
         self.assertEqual(response[0], 0)
 
-    def test_ssvep_to_cvep_raises_exception_when_refresh_rate_less_than_flicker_rate(self):
+    def test_ssvep_to_codes_returns_the_length_of_refresh_rate(self):
+        refresh_rate = 40
+        flicker_rate = 2
+        response = ssvep_to_code(flicker_rate=flicker_rate, refresh_rate=refresh_rate)
+        self.assertTrue(len(response) == refresh_rate)
+        self.assertEqual(response[0], 0)
+        self.assertEqual(response[-1], 1)
+
+    def test_ssvep_to_code_raises_exception_when_refresh_rate_less_than_flicker_rate(self):
         flicker_rate = 300
         refresh_rate = 1
 
-        with self.assertRaises(Exception):
-            ssvep_to_cvep(refresh_rate, flicker_rate)
+        with self.assertRaises(BciPyCoreException):
+            ssvep_to_code(refresh_rate, flicker_rate)
 
     def test_when_division_of_refresh_rate_by_flicker_rate_raise_exception_if_noninteger(self):
-        # flicker_rate = 11.43 refresh_rate = 60
-        flicker_rate = 11.43
+        flicker_rate = 11
         refresh_rate = 60
 
-        with self.assertRaises(Exception):
-            ssvep_to_cvep(refresh_rate, flicker_rate)
+        with self.assertRaises(BciPyCoreException):
+            ssvep_to_code(refresh_rate, flicker_rate)
 
-    def test_ssvep_to_cvep_returns_expected_codes(self):
+    def test_ssvep_to_code_returns_expected_codes(self):
         flicker_rate = 2
         refresh_rate = 4
-        response = ssvep_to_cvep(flicker_rate=flicker_rate, refresh_rate=refresh_rate)
+        response = ssvep_to_code(flicker_rate=flicker_rate, refresh_rate=refresh_rate)
         expected_output = [0, 0, 1, 1]
         self.assertEqual(response, expected_output)
 
+    def test_ssvep_to_code_raises_exception_when_flicker_rate_one_or_less(self):
+        flicker_rate = 1
+        refresh_rate = 2
+        with self.assertRaises(BciPyCoreException):
+            ssvep_to_code(refresh_rate, flicker_rate)
+
+        flicker_rate = 0
+        refresh_rate = 2
+        with self.assertRaises(BciPyCoreException):
+            ssvep_to_code(refresh_rate, flicker_rate)
 
 
 class TestSoundStimuli(unittest.TestCase):


### PR DESCRIPTION
# Overview

A method that uses the refresh rate on the monitor and returns a code for SSVEP. every frame of / on for x seconds.

## Ticket 

[Ticket 2](https://www.pivotaltracker.com/n/projects/2460065/stories/182492679)

## Contributions

- Created method that uses the refresh rate on the monitor and returns a code for SSVEP. every frame of / on for x seconds.

## Test

- Unit tested.

## Documentation

Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.

## Changelog

Is the CHANGELOG.md updated with your detailed changes? N/a