### PR TITLE
Jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@
 - New MNE based plotting for EEG data #220
 - Prevent GUI double clicks #218
 - Better Fake Data Handling #219
-- Bug fixes #225
-- Alerting for conditions that may affect system performance
+- Bug fixes #225, #228
+- Alerting for conditions that may affect system performance #227, #219
+- Flash time jitter parameter #233
 
 ### Added
 
 - `helpers/visualization.py`: added methods for visualized MNE Epochs and better visualizing EEG data in BciPy. #220 `visualize_joint_average` and `visualize_evokeds`.
-- `helpers/stimuli.py`: added a method for converting MNE RawArray to Epochs. #220
+- `helpers/stimuli.py`: added a method for converting MNE RawArray to Epochs. #220 Added stimuli flash time jitter to calibration and inq_generation methods #233
 - `helpers/convert.py`: added a convert to mne method that returns an MNE RawArray. Assumes standard_1020 eeg montage by default.#220
 - Better handling of the `fake_data` parameter to avoid erroneous recordings. Added a confirmation dialog when the `fake_data` parameter is set to `True` to alert users that they are in a system test mode. #219
 - `task/data.py`: session data contains more contextual data for interpreting the results, including the `symbol_set` and the `decision_threshold` used.

--- a/bcipy/helpers/copy_phrase_wrapper.py
+++ b/bcipy/helpers/copy_phrase_wrapper.py
@@ -55,8 +55,6 @@ class CopyPhraseWrapper:
     - is_txt_stim: Whether or not the stimuli are text objects
     - device_name: name of the EEG device
     - device_channels: list of device channel names
-    - stimuli_timing: seconds each stimuli is displayed; used for inquiry
-    generation
     - decision_threshold: Minimum likelihood value required for a decision
     - backspace_prob: default language model probability for the
     backspace character.
@@ -67,6 +65,9 @@ class CopyPhraseWrapper:
     - filter_order: filter setting used when evaluating EEG data
     - notch_filter_frequency: filter setting used when evaluating EEG data
     - stim_length(int): the number of stimuli to present in each inquiry
+    - stim_timing: seconds each stimuli is displayed; used for inquiry
+    generation
+    - stim_jitter: seconds that inquiry stimuli should be jittered (-/+ stim_timing[-1])
     """
 
     def __init__(self,
@@ -85,7 +86,6 @@ class CopyPhraseWrapper:
                  is_txt_stim: bool = True,
                  device_name: str = 'LSL',
                  device_channels: List[str] = None,
-                 stimuli_timing: List[float] = [1, .2],
                  decision_threshold: float = 0.8,
                  backspace_prob: float = 0.05,
                  backspace_always_shown: bool = False,
@@ -93,7 +93,9 @@ class CopyPhraseWrapper:
                  filter_low: int = 2,
                  filter_order: int = 2,
                  notch_filter_frequency: int = 60,
+                 stim_timing: List[float] = [1, .2],
                  stim_length: int = 10,
+                 stim_jitter: float = 0,
                  stim_order: StimuliOrder = StimuliOrder.RANDOM):
 
         self.lmodel = lmodel
@@ -120,7 +122,8 @@ class CopyPhraseWrapper:
             state=task_list[0][1],
             alphabet=alp,
             is_txt_stim=is_txt_stim,
-            stimuli_timing=stimuli_timing,
+            stimuli_jitter=stim_jitter,
+            stimuli_timing=stim_timing,
             stimuli_order=self.stim_order,
             inq_constants=inq_constants)
 

--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -7,7 +7,7 @@ import re
 from abc import ABC, abstractmethod
 from enum import Enum
 from os import path, sep
-from typing import Iterator, List, Tuple, NamedTuple
+from typing import Iterator, List, Tuple, NamedTuple, Optional
 
 from bcipy.helpers.exceptions import BciPyCoreException
 from bcipy.helpers.list import grouper
@@ -278,6 +278,7 @@ def inq_generator(query: List[str],
                   timing: List[float] = [1, 0.2],
                   color: List[str] = ['red', 'white'],
                   inquiry_count: int = 1,
+                  stim_jitter: float = 0,
                   stim_order: StimuliOrder = StimuliOrder.RANDOM,
                   is_txt: bool = True) -> InquirySchedule:
     """ Given the query set, prepares the stimuli, color and timing
@@ -312,9 +313,9 @@ def inq_generator(query: List[str],
         sample += [i for i in query]
         samples.append(sample)
 
-        # append timing
-        times.append([timing[i] for i in range(len(timing) - 1)] +
-                     [timing[-1]] * stim_length)
+        times.append([timing[i] for i in range(len(timing) - 1)])
+        base_timing = timing[-1]
+        times[-1] += jittered_timing(base_timing, stim_jitter, stim_length)
 
         # append colors
         colors.append([color[i] for i in range(len(color) - 1)] +
@@ -431,6 +432,7 @@ def best_case_rsvp_inq_gen(alp: list,
 def calibration_inquiry_generator(
         alp: List[str],
         timing: List[float] = [0.5, 1, 0.2],
+        jitter: Optional[int] = None,
         color: List[str] = ['green', 'red', 'white'],
         stim_number: int = 10,
         stim_length: int = 10,
@@ -438,13 +440,14 @@ def calibration_inquiry_generator(
         target_positions: TargetPositions = TargetPositions.RANDOM,
         nontarget_inquiries: int = 10,
         is_txt: bool = True) -> InquirySchedule:
-    """Random Calibration Inquiry Generator.
+    """Calibration Inquiry Generator.
 
-    Generates random inquiries with target letters in all possible positions.
+    Generates inquiries with target letters in all possible positions.
         Args:
             alp(list[str]): stimuli
             timing(list[float]): Task specific timing for generator.
                 [target, fixation, stimuli]
+            jitter(int): jitter for stimuli timing. If None, no jitter is applied.
             color(list[str]): Task specific color for generator
                 [target, fixation, stimuli]
             stim_number(int): number of trials in a inquiry
@@ -462,6 +465,11 @@ def calibration_inquiry_generator(
 
     target_indexes = []
     no_target = None
+
+    if len(timing) != 3 or len(color) != 3:
+        raise BciPyCoreException(
+            'Calibration Inquiry Generation Error: \n'
+            'Timing and Color must be a list of length three: [target, fixation, stimuli]')
 
     if (target_positions == target_positions.DISTRIBUTED):
         target_indexes = distributed_target_positions(stim_number, stim_length, nontarget_inquiries)
@@ -490,12 +498,31 @@ def calibration_inquiry_generator(
         sample = [target, get_fixation(is_txt=is_txt), *inquiry]
 
         samples.append(sample)
-        times.append([timing[i] for i in range(len(timing) - 1)] +
-                     [timing[-1]] * stim_length)
+
+        # timing for fixation and prompt
+        init_timing = [timing[i] for i in range(len(timing) - 1)]
+        # pull out timing for the inquiry stimuli
+        stim_time = timing[-1]
+        if jitter:
+            _inq_timing = jittered_timing(stim_time, jitter, stim_length)
+            inq_timing = init_timing + _inq_timing
+        else:
+            inq_timing = init_timing + [stim_time] * stim_length
+        times.append(inq_timing)
         colors.append([color[i] for i in range(len(color) - 1)] +
                       [color[-1]] * stim_length)
 
     return InquirySchedule(samples, times, colors)
+
+
+def jittered_timing(time: float, jitter: float, stim_count: int) -> List[float]:
+    """Jittered timing.
+
+    Using a base time and a jitter, generate a list (with length stim_count) of timing that is uniformly distributed.
+    """
+    assert time > jitter, (
+        f'Jitter timing [{jitter}] must be less than stimuli timing =[{time}] in the inquiry.')
+    return np.random.uniform(low=time - jitter, high=time + jitter, size=(stim_count,)).tolist()
 
 
 def distributed_target_positions(stim_number: int, stim_length: int, nontarget_inquiries: int) -> list:

--- a/bcipy/helpers/tests/test_copy_phrase_wrapper.py
+++ b/bcipy/helpers/tests/test_copy_phrase_wrapper.py
@@ -77,7 +77,7 @@ class TestCopyPhraseWrapper(unittest.TestCase):
             device_name=self.device_spec.name,
             evidence_names=[EvidenceType.LM, EvidenceType.ERP],
             device_channels=self.device_spec.channels,
-            stimuli_timing=[0.5, 0.25],
+            stim_timing=[0.5, 0.25],
         )
 
         triggers = [
@@ -182,7 +182,7 @@ class TestCopyPhraseWrapper(unittest.TestCase):
             device_name=self.device_spec.name,
             evidence_names=[EvidenceType.LM, EvidenceType.ERP],
             device_channels=self.device_spec.channels,
-            stimuli_timing=[0.5, 0.25],
+            stim_timing=[0.5, 0.25],
             notch_filter_frequency=4.0,
             filter_low=1.0,
             filter_high=4.0,

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -429,6 +429,14 @@
     "recommended_values": "",
     "type": "float"
   },
+  "stim_jitter": {
+    "value": "0.0",
+    "section": "bci_config",
+    "readableName": "Stimulus Presentation Jitter (sec)",
+    "helpTip": "Specifies the time (sec) to jitter presentation rates. Default: 0.0",
+    "recommended_values": "",
+    "type": "float"
+  },
   "stim_pos_x": {
     "value": "0",
     "section": "bci_config",

--- a/bcipy/task/control/criteria.py
+++ b/bcipy/task/control/criteria.py
@@ -6,7 +6,6 @@ from copy import copy
 log = logging.getLogger(__name__)
 
 
-# Criteria
 class DecisionCriteria:
     """Abstract class for Criteria which can be applied to evaluate a inquiry
     """

--- a/bcipy/task/paradigm/rsvp/calibration/calibration.py
+++ b/bcipy/task/paradigm/rsvp/calibration/calibration.py
@@ -66,6 +66,7 @@ class RSVPCalibrationTask(Task):
         self.timing = [parameters['time_prompt'],
                        parameters['time_fixation'],
                        parameters['time_flash']]
+        self.jitter = parameters['stim_jitter']
 
         self.color = [parameters['target_color'],
                       parameters['fixation_color'],
@@ -95,6 +96,7 @@ class RSVPCalibrationTask(Task):
                                              target_positions=self.target_positions,
                                              nontarget_inquiries=self.nontarget_inquiries,
                                              timing=self.timing,
+                                             jitter=self.jitter,
                                              is_txt=self.rsvp.is_txt_stim,
                                              color=self.color)
 

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -87,7 +87,7 @@ class RSVPCopyPhraseTask(Task):
         'preview_inquiry_key_input', 'preview_inquiry_length',
         'preview_inquiry_progress_method', 'session_file_name',
         'show_feedback', 'show_preview_inquiry', 'spelled_letters_count',
-        'static_trigger_offset', 'stim_color', 'stim_font', 'stim_height',
+        'static_trigger_offset', 'stim_color', 'stim_font', 'stim_height', 'stim_jitter',
         'stim_length', 'stim_number', 'stim_order', 'stim_pos_x', 'stim_pos_y',
         'stim_space_char', 'target_color', 'task_buffer_length', 'task_color',
         'task_font', 'task_height', 'task_text', 'info_pos_x', 'info_pos_y',
@@ -230,7 +230,7 @@ class RSVPCopyPhraseTask(Task):
             is_txt_stim=self.parameters['is_txt_stim'],
             device_name=self.daq.device_info.name,
             device_channels=self.daq.device_info.channels,
-            stimuli_timing=[
+            stim_timing=[
                 self.parameters['time_fixation'], self.parameters['time_flash']
             ],
             decision_threshold=self.parameters['decision_threshold'],
@@ -241,6 +241,7 @@ class RSVPCopyPhraseTask(Task):
             filter_order=self.parameters['filter_order'],
             notch_filter_frequency=self.parameters['notch_filter_frequency'],
             stim_length=self.parameters['stim_length'],
+            stim_jitter=self.parameters['stim_jitter'],
             stim_order=StimuliOrder(self.parameters['stim_order']))
 
     def user_wants_to_continue(self) -> bool:
@@ -867,10 +868,10 @@ def _init_copy_phrase_display(parameters, win, static_clock, experiment_clock, s
 def _init_copy_phrase_wrapper(min_num_inq, max_num_inq, signal_model, fs, k,
                               alp, evidence_names, task_list, lmodel,
                               is_txt_stim, device_name, device_channels,
-                              stimuli_timing, decision_threshold,
+                              stim_timing, decision_threshold,
                               backspace_prob, backspace_always_shown,
                               filter_high, filter_low, filter_order,
-                              notch_filter_frequency, stim_length, stim_order):
+                              notch_filter_frequency, stim_length, stim_jitter, stim_order):
     return CopyPhraseWrapper(min_num_inq,
                              max_num_inq,
                              signal_model=signal_model,
@@ -883,7 +884,7 @@ def _init_copy_phrase_wrapper(min_num_inq, max_num_inq, signal_model, fs, k,
                              is_txt_stim=is_txt_stim,
                              device_name=device_name,
                              device_channels=device_channels,
-                             stimuli_timing=stimuli_timing,
+                             stim_timing=stim_timing,
                              decision_threshold=decision_threshold,
                              backspace_prob=backspace_prob,
                              backspace_always_shown=backspace_always_shown,
@@ -892,4 +893,5 @@ def _init_copy_phrase_wrapper(min_num_inq, max_num_inq, signal_model, fs, k,
                              filter_order=filter_order,
                              notch_filter_frequency=notch_filter_frequency,
                              stim_length=stim_length,
+                             stim_jitter=stim_jitter,
                              stim_order=stim_order)

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -70,6 +70,7 @@ class TestCopyPhrase(unittest.TestCase):
             'stim_height': 0.6,
             'stim_length': 10,
             'stim_number': 100,
+            'stim_jitter': 0.0,
             'stim_order': 'random',
             'stim_pos_x': 0.0,
             'stim_pos_y': 0.0,


### PR DESCRIPTION
# Overview

Add a stimuli jitter parameter that will allow users to -/+ flash_time in seconds. 

## Ticket

[Ticket](https://www.pivotaltracker.com/story/show/182646315) 

## Contributions

- Added jitter parameter that is leveraged at all stimuli generation points
- Cleanup docstings and test_stimuli.py 
- Added validation to `calibration_inquiry_generator`


## Test

- `make test-all`
- IP calibration and copy phrase testing

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here. updated docstrings and added type annotations where possible.

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? yes!
