### PR TITLE
upgrade psychopy 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r dev_requirements.txt
+        pip install WxPython==4.1.1
         pip install -e .
     - name: Lint with flake8
       run: |
@@ -104,6 +105,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r dev_requirements.txt
+        pip install WxPython==4.1.1
         pip install -e .
     - name: Lint with flake8
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ transformers==4.15.0
 torch==1.10.1
 construct==2.8.14
 mne==1.0.2
+wxPython==4.1.1
 PsychoPy==2022.2.4
 openpyxl==2.6.3
 pyglet==1.5.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,8 @@ transformers==4.15.0
 torch==1.10.1
 construct==2.8.14
 mne==1.0.2
-wxPython==4.1.1
-PsychoPy==2022.2.4
+PsychoPy==2022.1.4
 openpyxl==2.6.3
-pyglet==1.5.23
 numpy==1.20.3
 sounddevice==0.4.1
 SoundFile==0.10.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ transformers==4.15.0
 torch==1.10.1
 construct==2.8.14
 mne==1.0.2
-PsychoPy==2020.2.10
+PsychoPy==2022.2.4
 openpyxl==2.6.3
 pyglet==1.5.23
 numpy==1.20.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ transformers==4.15.0
 torch==1.10.1
 construct==2.8.14
 mne==1.0.2
-PsychoPy==2022.1.4
+PsychoPy==2021.2.3
 openpyxl==2.6.3
 numpy==1.20.3
 sounddevice==0.4.1

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ EMAIL = 'cambi_support@googlegroups.com'
 AUTHOR = 'CAMBI'
 REQUIRES_PYTHON = '>3.6,<3.9'
 
-VERSION = '2.0.0rc1'
+VERSION = '2.0.0rc2'
 
 
 # What packages are required for this module to be executed?


### PR DESCRIPTION
# Overview

Upgraded PsychoPy to the latest and ensured all builds passed. The most recent release would have required us to deprecate python 3.7. 

## Ticket

https://www.pivotaltracker.com/story/show/182808689

## Contributions

- `requirements.txt`: upgrade PsychoPy, remove pyglet (each os wants a different version 🤦🏼‍♂️)
- `setup.py`: bumped the rc
- `.github/workflows/main.yml`: force macOS and windows to use WxPython 4.1.1 or it errors. Later builds better support this, but we cannot use the very latest Psychopy (2022.2.4)

## Test

- Local builds + ensure the github action workflow passes 

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.

## Changelog

- Is the CHANGELOG.md updated with your detailed changes?
