### PR TITLE
Convert: add BDF support and fix static offset bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,16 @@
     - Logging improvements #244
 - Device configuratio moved to bcipy/parameters #242
 - New MNE based plotting for EEG data #220
+- New file export features for BciPy data, including .bdf format and prefiltering #246
 - New Supported Devices: Tobii-Nano #234
-- Bug fixes #218, #225, #228, #235, #240
+- Bug fixes #218, #225, #228, #235, #240, #246
 
 ### Added
 
 - `display/paradigm/vep`: added create_vep_codes for generating random flicker patterns, VEPBox to encapsulate each flickering box stimuli, and a working VEPDisplay for later task development. #237
 - `helpers/visualization.py`: added methods for visualized MNE Epochs and better visualizing EEG data in BciPy. #220 `visualize_joint_average` and `visualize_evokeds`.
 - `helpers/stimuli.py`: added a method for converting MNE RawArray to Epochs. #220 Added stimuli flash time jitter to calibration and inq_generation methods #233 Added ssvep_to_code method #232
-- `helpers/convert.py`: added a convert to mne method that returns an MNE RawArray. Assumes standard_1020 eeg montage by default.#220
+- `helpers/convert.py`: added a convert to mne method that returns an MNE RawArray. Assumes standard_1020 eeg montage by default.#220 Refactored the convert to edf method. Add convert to bdf method for better export resolution. Ensured the static offset output in the parameters file is accounted for. Add a pre-filter option. Fix annotations. #246
 - Better handling of the `fake_data` parameter to avoid erroneous recordings. Added a confirmation dialog when the `fake_data` parameter is set to `True` to alert users that they are in a system test mode. #219
 - `task/data.py`: session data contains more contextual data for interpreting the results, including the `symbol_set` and the `decision_threshold` used.
 - `parameters/parameters.json`: Added `summarize_session` parameter is used to output richer session summaries after a Copy Phrase task. Added the `signal_model_path` parameter. When set this can be used for loading the pre-trained signal model during typing sessions.

--- a/bcipy/helpers/convert.py
+++ b/bcipy/helpers/convert.py
@@ -1,5 +1,4 @@
 """Functionality for converting the bcipy raw data output to other formats"""
-
 import logging
 import os
 import tarfile
@@ -8,13 +7,13 @@ from typing import Dict, List, Tuple, Optional
 
 import numpy as np
 
-from pyedflib import FILETYPE_EDFPLUS, EdfWriter
+from pyedflib import FILETYPE_EDFPLUS, EdfWriter, FILETYPE_BDFPLUS
 from tqdm import tqdm
 
 from bcipy.config import RAW_DATA_FILENAME, TRIGGER_FILENAME, DEFAULT_PARAMETER_FILENAME
 from bcipy.helpers.load import load_json_parameters, load_raw_data
 from bcipy.helpers.raw_data import RawData
-from bcipy.signal.process import Composition
+from bcipy.signal.process import Composition, get_default_transform
 from bcipy.helpers.triggers import trigger_decoder, trigger_durations
 
 import mne
@@ -28,65 +27,182 @@ FILE_LENGTH_LIMIT = 150
 
 def convert_to_edf(data_dir: str,
                    edf_path: str = None,
-                   overwrite=False,
-                   write_targetness=False,
-                   use_event_durations=False) -> Path:
-    """ Converts BciPy raw_data to the EDF+ filetype using pyEDFlib.
+                   overwrite: bool = False,
+                   write_targetness: bool = False,
+                   use_event_durations: bool = False,
+                   remove_pre_fixation: bool = False,
+                   pre_filter: bool = False) -> Path:
+    """ Converts BciPy data to the EDF+ filetype using pyEDFlib.
 
-    See https://www.edfplus.info/ for the official EDF+ spec for more detailed
-        information.
-    See https://www.teuniz.net/edflib_python/index.html for a free EDF viewer.
+    See https://www.edfplus.info/ for more detailed information about the edf specification.
+    See https://www.teuniz.net/edfbrowser/ for a free EDF/BDF viewer.
 
     Parameters
     ----------
-    data_dir - directory which contains the data to be converted. This
-        location must also contain a parameters.json configuration file.
-    edf_path - optional path to write converted data; defaults to writing
-        a file named raw.edf in the data_dir.
-    overwrite - If True, the destination file (if it exists) will be overwritten.
-        If False (default), an error will be raised if the file exists.
-    write_targetness - If True, and targetness information is available, write
-        that instead of the stimuli markers. False by default.
+    data_dir - directory which contains the data to be converted. This location must contain:
+        1. a parameter file.
+        2. a raw_data.csv file.
+        3. a trigger.txt file.
+    edf_path - optional; path to write converted data; defaults to writing a file named raw_data.edf in the data_dir.
+        Must end in .edf.
+    overwrite - If True, the destination file (if it exists) will be overwritten. If False (default), an error will
+        be raised if the file exists.
+    write_targetness - If True, and targetness information is available, write that instead of the stimuli markers.
+        False by default.
     use_event_durations - optional; if True assigns a duration to each event.
+    remove_pre_fixation - optional; if True removes the non-inquiry based markers from the trigger data.
+    pre_filter - optional; if True, apply the default filter to the data using to loaded parameters file.
 
     Returns
     -------
         Path to new edf file
     """
     if not edf_path:
-        edf_path = Path(data_dir, f'{RAW_DATA_FILENAME}.edf')
+        edf_path = str(Path(data_dir, f'{RAW_DATA_FILENAME}.edf').resolve())
+    if not edf_path.endswith('.edf'):
+        raise ValueError(f'edf_path=[{edf_path}] must end in .edf')
+
+    data, channels, fs, events, annotation_channels = pyedf_convert(
+        data_dir,
+        write_targetness=write_targetness,
+        use_event_durations=use_event_durations,
+        remove_pre_fixation=remove_pre_fixation,
+        pre_filter=pre_filter)
+
+    return write_edf(edf_path, data, channels, fs, events, overwrite, annotation_channels)
+
+
+def convert_to_bdf(data_dir: str,
+                   bdf_path: str = None,
+                   overwrite: bool = False,
+                   write_targetness: bool = False,
+                   use_event_durations: bool = False,
+                   remove_pre_fixation: bool = False,
+                   pre_filter: bool = False) -> Path:
+    """ Converts BciPy data to the BDF+ filetype using pyEDFlib.
+
+    See https://www.biosemi.com/faq/file_format.html for more detailed information about the BDF specification.
+    See https://www.teuniz.net/edfbrowser/ for a free EDF/BDF viewer.
+
+    Parameters
+    ----------
+    data_dir - directory which contains the data to be converted. This location must contain:
+        1. a parameter file.
+        2. a raw_data.csv file.
+        3. a trigger.txt file.
+    edf_path - optional; path to write converted data; defaults to writing a file named raw_data.edf in the data_dir.
+        Must end in .edf.
+    overwrite - If True, the destination file (if it exists) will be overwritten. If False (default), an error will
+        be raised if the file exists.
+    write_targetness - If True, and targetness information is available, write that instead of the stimuli markers.
+        False by default.
+    use_event_durations - optional; if True assigns a duration to each event.
+    remove_pre_fixation - optional; if True removes the non-inquiry based markers from the trigger data.
+    pre_filter - optional; if True, apply the default filter to the data using to loaded parameters file.
+
+    Returns
+    -------
+        Path to new bdf file
+    """
+    if not bdf_path:
+        bdf_path = str(Path(data_dir, f'{RAW_DATA_FILENAME}.bdf').resolve())
+    if not bdf_path.endswith('.bdf'):
+        raise ValueError(f'bdf_path=[{bdf_path}] must end in .bdf')
+
+    data, channels, fs, events, annotation_channels = pyedf_convert(
+        data_dir,
+        write_targetness=write_targetness,
+        use_event_durations=use_event_durations,
+        remove_pre_fixation=remove_pre_fixation,
+        pre_filter=pre_filter)
+
+    return write_bdf(bdf_path, data, channels, fs, events, overwrite, annotation_channels)
+
+
+def pyedf_convert(data_dir: str,
+                  write_targetness=False,
+                  use_event_durations=False,
+                  remove_pre_fixation=False,
+                  pre_filter=False) -> Tuple[RawData, List[str], int, List[Tuple[str, int, int]], int]:
+    """ Converts BciPy data to formats that can be used by pyEDFlib.
+
+    Parameters
+    ----------
+
+    data_dir - directory which contains the data to be converted. This location must contain:
+        1. a parameter file.
+        2. a raw_data.csv file.
+        3. a trigger.txt file.
+    write_targetness - If True, and targetness information is available, write that instead of the stimuli markers.
+        False by default.
+    use_event_durations - optional; if True assigns a duration to each event.
+    remove_pre_fixation - optional; if True removes the non-inquiry based markers from the trigger data.
+    pre_filter - optional; if True, apply the default filter to the data using to loaded parameters file.
+
+    Returns
+    -------
+        data - raw data
+        channels - list of channel names
+        fs - sampling rate
+        events - list of events
+        annotation_channels - number of annotation channels
+    """
 
     params = load_json_parameters(Path(data_dir, DEFAULT_PARAMETER_FILENAME),
                                   value_cast=True)
     data = load_raw_data(Path(data_dir, f'{RAW_DATA_FILENAME}.csv'))
-    raw_data, _ = data.by_channel()
+    fs = data.sample_rate
+    if pre_filter:
+        default_transform = get_default_transform(
+            sample_rate_hz=data.sample_rate,
+            notch_freq_hz=params.get("notch_filter_frequency"),
+            bandpass_low=params.get("filter_low"),
+            bandpass_high=params.get("filter_high"),
+            bandpass_order=params.get("filter_order"),
+            downsample_factor=params.get("down_sampling_rate"),
+        )
+        raw_data, fs = data.by_channel(transform=default_transform)
+    else:
+        raw_data, _ = data.by_channel()
     durations = trigger_durations(params) if use_event_durations else {}
+    static_offset = params['static_trigger_offset']
+    logger.info(f'Static offset: {static_offset}')
 
     trigger_type, trigger_timing, trigger_label = trigger_decoder(
-        str(Path(data_dir, TRIGGER_FILENAME)), remove_pre_fixation=False)
+        str(Path(data_dir, TRIGGER_FILENAME)),
+        remove_pre_fixation=remove_pre_fixation,
+        offset=static_offset)
 
-    # validate annotation parameters given data length and trigger count
-    validate_annotations(len(raw_data[0]) / data.sample_rate, len(trigger_type))
+    # validate annotation parameters given data length and trigger count, up the annotation limit byt increasing
+    # annotation_channels if needed
+    annotation_channels = validate_annotations(len(raw_data[0]) / data.sample_rate, len(trigger_type))
 
     triggers = compile_triggers(
         trigger_label, trigger_type, trigger_timing, write_targetness)
 
-    events = edf_annotations(triggers, durations)
+    events = compile_annotations(triggers, durations)
 
-    return write_edf(edf_path, raw_data, data.channels, data.sample_rate, events, overwrite)
+    return raw_data, data.channels, fs, events, annotation_channels
 
 
-def validate_annotations(record_time: float, trigger_count: int) -> None:
+def validate_annotations(record_time: float, trigger_count: int) -> bool:
     """Validate Annotations.
 
     Using the pyedflib library, it is recommended the number of triggers (or annotations) not exceed the recording
-        time in seconds. This may not result in an unsuccessful export.
+        time in seconds. This may result in an unsuccessful export. The best workaround is to increase the number of
+        annotation channels. This function will return the number of annotation channels needed to export the triggers
+        successfully. The maximum number of annotation channels is 64 and it is not advised to use more than required
+        due to fize size restrictions.
+
+    See https://github.com/holgern/pyedflib/issues/34 for more information.
     """
     if trigger_count > record_time:
         logger.warning(
-            f'\n*Warning* The number of triggers [{trigger_count}] exceeds recording time [{record_time}]. '
-            'Not all triggers may be written. '
-            'Validate export carefully.')
+            f'\n*Warning* The number of triggers [{trigger_count}] exceeds recording time [{record_time}]. ')
+        annotation_channels = round(trigger_count / record_time) + 1
+        logger.warning(f'\nIncreasing annotation channels to {annotation_channels} to compensate.')
+        return annotation_channels
+    return 1
 
 
 def compile_triggers(labels: List[str], targetness: List[str], timing: List[float],
@@ -113,7 +229,8 @@ def write_edf(output_path: str,
               ch_names: List[str],
               sample_rate: float,
               events: List[Tuple[float, float, str]],
-              overwrite=False) -> Path:
+              overwrite: bool = False,
+              annotation_channels: int = 1) -> Path:
     """
     Converts BciPy raw_data to the EDF+ filetype using pyEDFlib.
 
@@ -129,6 +246,7 @@ def write_edf(output_path: str,
     events - List[Tuple(onset_in_seconds: float, duration_in_seconds: float, description: str)]
     overwrite - If True, the destination file (if it exists) will be overwritten.
         If False (default), an error will be raised if the file exists.
+    annotation_channels - number of annotation channels to use
 
     Returns
     -------
@@ -167,23 +285,103 @@ def write_edf(output_path: str,
             channel_info.append(ch_dict)
             data_list.append(raw_data[i])
 
+        if events:
+            writer.set_number_of_annotation_signals(annotation_channels)
+            for onset, duration, label in events:
+                writer.writeAnnotation(onset, duration, label)
+
         writer.setSignalHeaders(channel_info)
         writer.writeSamples(data_list)
 
-        if events:
-            for onset, duration, label in events:
-                writer.writeAnnotation(onset, duration, label)
     except Exception as error:
-        logging.getLogger(__name__).info(error)
-        return None
+        logger.info(error)
+        raise error
     finally:
         writer.close()
     return output_path
 
 
-def edf_annotations(triggers: List[Tuple[str, str, float]],
-                    durations: Dict[str, float] = {}
-                    ) -> List[Tuple[float, float, str]]:
+def write_bdf(output_path: str,
+              raw_data: np.array,
+              ch_names: List[str],
+              sample_rate: float,
+              events: List[Tuple[float, float, str]],
+              overwrite: bool = False,
+              annotation_channels: int = 1) -> Path:
+    """
+    Converts BciPy raw_data to the BDF+ filetype using pyEDFlib.
+
+    Adapted from: https://github.com/holgern/pyedflib
+
+    Parameters
+    ----------
+    output_path - optional path to write converted data; defaults to writing
+        a file named raw.bdf in the raw_data_dir.
+    raw_data - raw data with a row for each channel
+    ch_names - names of the channels
+    sample_rate - sample frequency
+    events - List[Tuple(onset_in_seconds: float, duration_in_seconds: float, description: str)]
+    overwrite - If True, the destination file (if it exists) will be overwritten.
+        If False (default), an error will be raised if the file exists.
+    annotation_channels - number of annotation channels to use for writing triggers
+
+    Returns
+    -------
+        Path to new bdf file
+    """
+    if not overwrite and os.path.exists(output_path):
+        raise OSError('BDF file already exists.')
+
+    # set conversion parameters. The digital min/max are specific to BDF and much higher than EDF.
+    digital_min, digital_max = [-8388607, 8388607]
+    physical_min, physical_max = [raw_data.min(), raw_data.max()]
+
+    n_channels = len(raw_data)
+
+    try:
+        # even though we are writing a BDF file, we need to use the EDF writer and set the file type to BDF
+        writer = EdfWriter(str(output_path),
+                           n_channels=n_channels,
+                           file_type=FILETYPE_BDFPLUS)
+
+        channel_info = []
+        data_list = []
+
+        for i in range(n_channels):
+            ch_dict = {
+                'label': ch_names[i],
+                'dimension': 'uV',
+                'sample_frequency': sample_rate,
+                'physical_min': physical_min,
+                'physical_max': physical_max,
+                'digital_min': digital_min,
+                'digital_max': digital_max,
+                'transducer': '',
+                'prefilter': ''
+            }
+
+            channel_info.append(ch_dict)
+            data_list.append(raw_data[i])
+
+        if events:
+            writer.set_number_of_annotation_signals(annotation_channels)
+            for onset, duration, label in events:
+                writer.writeAnnotation(onset, duration, label)
+
+        writer.setSignalHeaders(channel_info)
+        writer.writeSamples(data_list)
+
+    except Exception as error:
+        logger.info(error)
+        raise error
+    finally:
+        writer.close()
+    return output_path
+
+
+def compile_annotations(triggers: List[Tuple[str, str, float]],
+                        durations: Dict[str, float] = {}
+                        ) -> List[Tuple[float, float, str]]:
     """Convert bcipy triggers to the format expected by pyedflib for writing annotations.
 
     Parameters

--- a/bcipy/helpers/convert.py
+++ b/bcipy/helpers/convert.py
@@ -90,7 +90,7 @@ def convert_to_bdf(data_dir: str,
                    pre_filter: bool = False) -> Path:
     """ Converts BciPy data to the BDF+ filetype using pyEDFlib.
 
-    See https://www.biosemi.com/faq/file_format.html for more detailed information about the BDF specification.
+    See https://www.biosemi.com/faq/file_format.htm for more detailed information about the BDF specification.
     See https://www.teuniz.net/edfbrowser/ for a free EDF/BDF viewer.
 
     Parameters

--- a/bcipy/helpers/demo/demo_convert.py
+++ b/bcipy/helpers/demo/demo_convert.py
@@ -2,9 +2,10 @@
 
 To use at bcipy root,
 
-    `python bcipy/helpers/demo/demo_convert.py -p "path://to/bcipy/data/folder"`
+    `python bcipy/helpers/demo/demo_convert.py -d "path://to/bcipy/data/folder"`
 """
-from bcipy.helpers.convert import convert_to_edf
+from bcipy.helpers.convert import convert_to_edf, convert_to_bdf
+from bcipy.helpers.load import load_experimental_data
 from bcipy.helpers.visualization import plot_edf
 
 
@@ -13,17 +14,38 @@ if __name__ == '__main__':
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-p',
-        '--path',
+        '-d',
+        '--directory',
         help='Path to the directory with raw_data to be converted',
-        required=True)
+        required=False)
+    parser.add_argument(
+        '-p',
+        '--plot',
+        help='whether to plot the resulting edf file',
+        required=False
+    )
     args = parser.parse_args()
 
-    path = args.path
+    path = args.directory
+    if not path:
+        path = load_experimental_data()
+
     edf_path = convert_to_edf(
         path,
-        use_event_durations=True,
-        write_targetness=False,
-        overwrite=True)
-    plot_edf(edf_path)  # comment if not in an iPython notebook to plot using MNE
+        use_event_durations=False,
+        write_targetness=True,
+        overwrite=True,
+        pre_filter=True)
+
+    bdf_path = convert_to_bdf(
+        path,
+        use_event_durations=False,
+        write_targetness=True,
+        overwrite=True,
+        pre_filter=True)
+
+    if args.plot:
+        plot_edf(edf_path)  # comment if not in an iPython notebook to plot using MNE
+
     print(f"\nWrote edf file to {edf_path}")
+    print(f"\nWrote bdf file to {bdf_path}")

--- a/bcipy/helpers/tests/test_convert.py
+++ b/bcipy/helpers/tests/test_convert.py
@@ -2,6 +2,7 @@
 import os
 import shutil
 import tempfile
+from typing import Tuple
 import unittest
 import warnings
 
@@ -11,41 +12,73 @@ from mockito import mock, when, unstub, verify, verifyNoMoreInteractions, any as
 
 from bcipy.config import DEFAULT_ENCODING, RAW_DATA_FILENAME, TRIGGER_FILENAME, DEFAULT_PARAMETER_FILENAME
 from bcipy.helpers import convert
-from bcipy.helpers.convert import convert_to_edf, convert_to_bdf, compress, decompress, archive_list
+from bcipy.helpers.convert import (
+    archive_list,
+    compress,
+    convert_to_bdf,
+    convert_to_edf,
+    decompress,
+    pyedf_convert,
+)
 from bcipy.helpers.parameters import Parameters
-from bcipy.helpers.raw_data import sample_data, write
+from bcipy.helpers.raw_data import sample_data, write, RawData
 from bcipy.helpers.triggers import MOCK_TRIGGER_DATA
 
 from mne.io import read_raw_edf, read_raw_bdf
 
 
+def create_bcipy_session_artifacts(
+        write_dir: str,
+        channels: int = 3,
+        sample_rate: int = 300,
+        samples: int = 5000,
+        filter_settings: dict = {
+            'filter_low': 0.5,
+            'filter_high': 30,
+            'filter_order': 5,
+            'notch_filter_frequency': 60,
+            'down_sampling_rate': 3,
+            'static_trigger_offset': 0.0
+        },
+) -> Tuple[str, RawData, Parameters]:
+    """Write BciPy session artifacts to a temporary directory.
+
+    This includes a raw data file, trigger file, and a parameters file.
+    """
+    trg_data = MOCK_TRIGGER_DATA
+    channels = [f'ch{i}' for i in range(channels)]
+    data = sample_data(ch_names=channels, sample_rate=sample_rate, rows=samples)
+    with open(Path(write_dir, TRIGGER_FILENAME), 'w', encoding=DEFAULT_ENCODING) as trg_file:
+        trg_file.write(trg_data)
+
+    write(data, Path(write_dir, f'{RAW_DATA_FILENAME}.csv'))
+
+    params = Parameters.from_cast_values(raw_data_name=f'{RAW_DATA_FILENAME}.csv',
+                                         trigger_file_name=TRIGGER_FILENAME,
+                                         preview_inquiry_length=0.5,
+                                         time_fixation=0.5,
+                                         time_prompt=0.5,
+                                         time_flash=0.5,
+                                         # define filter settings
+                                         static_trigger_offset=filter_settings['static_trigger_offset'],
+                                         down_sampling_rate=filter_settings['down_sampling_rate'],
+                                         notch_filter_frequency=filter_settings['notch_filter_frequency'],
+                                         filter_high=filter_settings['filter_high'],
+                                         filter_low=filter_settings['filter_low'],
+                                         filter_order=filter_settings['filter_order'])
+    params.save(write_dir, DEFAULT_PARAMETER_FILENAME)
+    return trg_data, data, params
+
+
 class TestEDFConvert(unittest.TestCase):
     """Tests for EDF data format conversions."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Initialize data once"""
-        cls.trg_data = MOCK_TRIGGER_DATA
-        cls.channels = ['ch1', 'ch2', 'ch3']
-        cls.sample_data = sample_data(rows=3000, ch_names=cls.channels)
-
     def setUp(self):
-        """Override; set up the needed path for load functions."""
-
         self.temp_dir = tempfile.mkdtemp()
-
-        with open(Path(self.temp_dir, TRIGGER_FILENAME), 'w', encoding=DEFAULT_ENCODING) as trg_file:
-            trg_file.write(self.__class__.trg_data)
-
-        write(self.__class__.sample_data, Path(self.temp_dir, f'{RAW_DATA_FILENAME}.csv'))
-
-        params = Parameters.from_cast_values(raw_data_name=f'{RAW_DATA_FILENAME}.csv',
-                                             trigger_file_name=TRIGGER_FILENAME,
-                                             static_trigger_offset=0)
-        params.save(self.temp_dir, DEFAULT_PARAMETER_FILENAME)
+        _, data, _ = create_bcipy_session_artifacts(self.temp_dir)
+        self.channels = data.channels
 
     def tearDown(self):
-        """Override"""
         shutil.rmtree(self.temp_dir)
         verifyNoMoreInteractions()
         unstub()
@@ -83,6 +116,12 @@ class TestEDFConvert(unittest.TestCase):
                               edf_path=str(Path(self.temp_dir, 'mydata.edf').resolve()))
 
         self.assertEqual(Path(path).name, 'mydata.edf')
+
+    def test_convert_to_edf_raises_value_error_with_invalid_edfpath(self):
+        """Test that an value error is raised when the edf path is invalid"""
+        edf_path = 'invalid.pdf'
+        with self.assertRaises(ValueError):
+            convert_to_edf(self.temp_dir, edf_path=edf_path)
 
     def test_convert_to_edf_with_write_targetness(self):
         """Test creating the EDF using targetness for event annotations"""
@@ -163,27 +202,12 @@ class TestEDFConvert(unittest.TestCase):
 class TestBDFConvert(unittest.TestCase):
     """Tests for BDF data format conversions."""
 
-    @classmethod
-    def setUpClass(cls):
-        """Initialize data once"""
-        cls.trg_data = MOCK_TRIGGER_DATA
-        cls.channels = ['ch1', 'ch2', 'ch3']
-        cls.sample_data = sample_data(rows=3000, ch_names=cls.channels)
-
     def setUp(self):
         """Override; set up the needed path for load functions."""
 
         self.temp_dir = tempfile.mkdtemp()
-
-        with open(Path(self.temp_dir, TRIGGER_FILENAME), 'w', encoding=DEFAULT_ENCODING) as trg_file:
-            trg_file.write(self.__class__.trg_data)
-
-        write(self.__class__.sample_data, Path(self.temp_dir, f'{RAW_DATA_FILENAME}.csv'))
-
-        params = Parameters.from_cast_values(raw_data_name=f'{RAW_DATA_FILENAME}.csv',
-                                             trigger_file_name=TRIGGER_FILENAME,
-                                             static_trigger_offset=0)
-        params.save(self.temp_dir, DEFAULT_PARAMETER_FILENAME)
+        _, data, _ = create_bcipy_session_artifacts(self.temp_dir)
+        self.channels = data.channels
 
     def tearDown(self):
         """Override"""
@@ -198,12 +222,12 @@ class TestBDFConvert(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
-            edf = read_raw_bdf(path, preload=True)
+            bdf = read_raw_bdf(path, preload=True)
 
-        self.assertTrue(len(edf.get_data()) > 0)
+        self.assertTrue(len(bdf.get_data()) > 0)
 
         for ch_name in self.channels:
-            self.assertTrue(ch_name in edf.ch_names)
+            self.assertTrue(ch_name in bdf.ch_names)
 
     def test_convert_to_bdf_overwrite_false(self):
         """Test overwriting fails if not configured"""
@@ -224,6 +248,12 @@ class TestBDFConvert(unittest.TestCase):
                               bdf_path=str(Path(self.temp_dir, 'mydata.bdf').resolve()))
 
         self.assertEqual(Path(path).name, 'mydata.bdf')
+
+    def test_convert_to_bdf_raises_value_error_with_invalid_edfpath(self):
+        """Test that a value error is raised with the bdf path is invalid"""
+        bdf_path = 'invalid.pdf'
+        with self.assertRaises(ValueError):
+            convert_to_bdf(self.temp_dir, bdf_path=bdf_path)
 
     def test_convert_to_bdf_with_write_targetness(self):
         """Test creating the EDF using targetness for event annotations"""
@@ -301,13 +331,136 @@ class TestBDFConvert(unittest.TestCase):
         self.assertEqual(path, return_path)
 
 
+class TestPyedfconvert(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.mkdtemp()
+        self.sample_rate = 300
+        self.filter_settings = {
+            'filter_low': 0.5,
+            'filter_high': 30,
+            'filter_order': 5,
+            'notch_filter_frequency': 60,
+            'down_sampling_rate': 3,
+            'static_trigger_offset': 0.0
+        }
+        create_bcipy_session_artifacts(
+            self.temp_dir,
+            sample_rate=self.sample_rate,
+            filter_settings=self.filter_settings,
+            samples=10000)  # sample number determines the annotation count, set it high here!
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.temp_dir)
+        verifyNoMoreInteractions()
+        unstub()
+
+    def test_pyedf_convert_defaults(self):
+        """Test the pyedf_convert function"""
+        data, channels, fs, events, annotation_channels = pyedf_convert(
+            self.temp_dir)
+
+        self.assertTrue(len(data) > 0)
+        self.assertTrue(len(channels) > 0)
+        self.assertEqual(fs, self.sample_rate)
+        self.assertTrue(len(events) > 2)
+        # see the validate_annotations function for details on how this is calculated
+        self.assertEqual(annotation_channels, 1)
+
+    def test_pyedf_convert_with_pre_filter(self):
+        """Test the pyedf_convert function with pre-filtering"""
+        data, channels, fs, events, annotation_channels = pyedf_convert(
+            self.temp_dir, pre_filter=True)
+
+        self.assertTrue(len(data) > 0)
+        self.assertTrue(len(channels) > 0)
+        self.assertEqual(fs, self.sample_rate / self.filter_settings['down_sampling_rate'])
+        self.assertTrue(len(events) > 2)
+        # see the validate_annotations function for details on how this is calculated
+        #  with less samples, the number of annotation channels increases
+        self.assertEqual(annotation_channels, 2)
+
+    def test_pyedf_convert_with_write_targetness(self):
+        """Test the pyedf_convert function with targetness for event annotations"""
+        data, channels, fs, events, annotation_channels = pyedf_convert(
+            self.temp_dir, write_targetness=True)
+
+        self.assertTrue(len(data) > 0)
+        self.assertTrue(len(channels) > 0)
+        self.assertEqual(fs, self.sample_rate)
+        self.assertTrue(len(events) > 2)
+        # see the validate_annotations function for details on how this is calculated
+        self.assertEqual(annotation_channels, 1)
+        for event in events:
+            _, _, label = event
+            # in this casae label and targetness should not be the same
+            self.assertTrue(label in ['target', 'nontarget'])
+
+    def test_pyedf_convert_without_write_targetness(self):
+        """Test the pyedf_convert function with labels as event annotations"""
+        data, channels, fs, events, annotation_channels = pyedf_convert(
+            self.temp_dir, write_targetness=False)
+
+        self.assertTrue(len(data) > 0)
+        self.assertTrue(len(channels) > 0)
+        self.assertEqual(fs, self.sample_rate)
+        self.assertTrue(len(events) > 2)
+        # see the validate_annotations function for details on how this is calculated
+        self.assertEqual(annotation_channels, 1)
+        for event in events:
+            _, _, label = event
+            self.assertTrue(label not in ['target', 'nontarget'])
+
+    def test_pyedf_convert_with_use_event_durations(self):
+        """Test the pyedf_convert function with event durations"""
+        data, channels, fs, events, annotation_channels = pyedf_convert(
+            self.temp_dir, use_event_durations=True)
+
+        self.assertTrue(len(data) > 0)
+        self.assertTrue(len(channels) > 0)
+        self.assertEqual(fs, self.sample_rate)
+        self.assertTrue(len(events) > 2)
+        # see the validate_annotations function for details on how this is calculated
+        self.assertEqual(annotation_channels, 1)
+        for _, duration, _ in events:
+            self.assertTrue(duration > 0)
+
+    def test_pyedf_convert_without_use_event_durations(self):
+        """Test the pyedf_convert function without event durations"""
+        data, channels, fs, events, annotation_channels = pyedf_convert(
+            self.temp_dir, use_event_durations=False)
+
+        self.assertTrue(len(data) > 0)
+        self.assertTrue(len(channels) > 0)
+        self.assertEqual(fs, self.sample_rate)
+        self.assertTrue(len(events) > 2)
+        # see the validate_annotations function for details on how this is calculated
+        self.assertEqual(annotation_channels, 1)
+        for _, duration, _ in events:
+            self.assertEqual(duration, 0)
+
+    def test_pyedf_convert_with_remove_pre_fixation(self):
+        """Test the pyedf_convert function with pre-fixation removal"""
+        data, channels, fs, events, annotation_channels = pyedf_convert(
+            self.temp_dir, remove_pre_fixation=True)
+
+        self.assertTrue(len(data) > 0)
+        self.assertTrue(len(channels) > 0)
+        self.assertEqual(fs, self.sample_rate)
+        self.assertTrue(len(events) > 2)
+        # see the validate_annotations function for details on how this is calculated
+        self.assertEqual(annotation_channels, 1)
+        for event in events:
+            self.assertNotIn('fixation', event)
+            self.assertNotIn('prompt', event)
+
+
 class TestCompressionSupport(unittest.TestCase):
 
     def setUp(self):
         self.dir_name = 'test/'
         self.tar_file_name = 'test_file'
         self.tar_file_full_name = f'{self.tar_file_name}.tar.gz'
-        # Write a test file
         self.test_file_name = 'test.text'
         with open(self.test_file_name, 'w', encoding=DEFAULT_ENCODING) as fp:
             pass

--- a/bcipy/helpers/tests/test_convert.py
+++ b/bcipy/helpers/tests/test_convert.py
@@ -168,16 +168,19 @@ class TestEDFConvert(unittest.TestCase):
             channels,
             fs,
             events,
-            annotation_channels
+            annotation_channels,
+            'filter_settings'
         ))
-        when(convert).write_edf(
+        when(convert).write_pyedf(
             any_value(str),
             data,
             channels,
             fs,
             events,
+            any_value(int),
             any_value(bool),
-            annotation_channels).thenReturn(return_path)
+            annotation_channels,
+            any_value(str)).thenReturn(return_path)
         path = convert_to_edf(self.temp_dir,
                               pre_filter=True)
 
@@ -188,14 +191,16 @@ class TestEDFConvert(unittest.TestCase):
             remove_pre_fixation=any_value(bool),
             pre_filter=True,
         )
-        verify(convert, times=1).write_edf(
+        verify(convert, times=1).write_pyedf(
             any_value(str),
             data,
             channels,
             fs,
             events,
+            any_value(int),
             any_value(bool),
-            annotation_channels)
+            annotation_channels,
+            any_value(str))
         self.assertEqual(path, return_path)
 
 
@@ -300,16 +305,19 @@ class TestBDFConvert(unittest.TestCase):
             channels,
             fs,
             events,
-            annotation_channels
+            annotation_channels,
+            'filter_settings'
         ))
-        when(convert).write_bdf(
+        when(convert).write_pyedf(
             any_value(str),
             data,
             channels,
             fs,
             events,
+            any_value(int),
             any_value(bool),
-            annotation_channels).thenReturn(return_path)
+            annotation_channels,
+            any_value(str)).thenReturn(return_path)
         path = convert_to_bdf(self.temp_dir,
                               pre_filter=True)
 
@@ -320,14 +328,16 @@ class TestBDFConvert(unittest.TestCase):
             remove_pre_fixation=any_value(bool),
             pre_filter=True,
         )
-        verify(convert, times=1).write_bdf(
+        verify(convert, times=1).write_pyedf(
             any_value(str),
             data,
             channels,
             fs,
             events,
+            any_value(int),
             any_value(bool),
-            annotation_channels)
+            annotation_channels,
+            any_value(str))
         self.assertEqual(path, return_path)
 
 
@@ -357,7 +367,7 @@ class TestPyedfconvert(unittest.TestCase):
 
     def test_pyedf_convert_defaults(self):
         """Test the pyedf_convert function"""
-        data, channels, fs, events, annotation_channels = pyedf_convert(
+        data, channels, fs, events, annotation_channels, pre_filter = pyedf_convert(
             self.temp_dir)
 
         self.assertTrue(len(data) > 0)
@@ -366,10 +376,11 @@ class TestPyedfconvert(unittest.TestCase):
         self.assertTrue(len(events) > 2)
         # see the validate_annotations function for details on how this is calculated
         self.assertEqual(annotation_channels, 1)
+        self.assertFalse(pre_filter)
 
     def test_pyedf_convert_with_pre_filter(self):
         """Test the pyedf_convert function with pre-filtering"""
-        data, channels, fs, events, annotation_channels = pyedf_convert(
+        data, channels, fs, events, annotation_channels, pre_filter = pyedf_convert(
             self.temp_dir, pre_filter=True)
 
         self.assertTrue(len(data) > 0)
@@ -379,10 +390,11 @@ class TestPyedfconvert(unittest.TestCase):
         # see the validate_annotations function for details on how this is calculated
         #  with less samples, the number of annotation channels increases
         self.assertEqual(annotation_channels, 2)
+        self.assertIsInstance(pre_filter, str)
 
     def test_pyedf_convert_with_write_targetness(self):
         """Test the pyedf_convert function with targetness for event annotations"""
-        data, channels, fs, events, annotation_channels = pyedf_convert(
+        data, channels, fs, events, annotation_channels, _ = pyedf_convert(
             self.temp_dir, write_targetness=True)
 
         self.assertTrue(len(data) > 0)
@@ -398,7 +410,7 @@ class TestPyedfconvert(unittest.TestCase):
 
     def test_pyedf_convert_without_write_targetness(self):
         """Test the pyedf_convert function with labels as event annotations"""
-        data, channels, fs, events, annotation_channels = pyedf_convert(
+        data, channels, fs, events, annotation_channels, _ = pyedf_convert(
             self.temp_dir, write_targetness=False)
 
         self.assertTrue(len(data) > 0)
@@ -413,7 +425,7 @@ class TestPyedfconvert(unittest.TestCase):
 
     def test_pyedf_convert_with_use_event_durations(self):
         """Test the pyedf_convert function with event durations"""
-        data, channels, fs, events, annotation_channels = pyedf_convert(
+        data, channels, fs, events, annotation_channels, _ = pyedf_convert(
             self.temp_dir, use_event_durations=True)
 
         self.assertTrue(len(data) > 0)
@@ -427,7 +439,7 @@ class TestPyedfconvert(unittest.TestCase):
 
     def test_pyedf_convert_without_use_event_durations(self):
         """Test the pyedf_convert function without event durations"""
-        data, channels, fs, events, annotation_channels = pyedf_convert(
+        data, channels, fs, events, annotation_channels, _ = pyedf_convert(
             self.temp_dir, use_event_durations=False)
 
         self.assertTrue(len(data) > 0)
@@ -441,7 +453,7 @@ class TestPyedfconvert(unittest.TestCase):
 
     def test_pyedf_convert_with_remove_pre_fixation(self):
         """Test the pyedf_convert function with pre-fixation removal"""
-        data, channels, fs, events, annotation_channels = pyedf_convert(
+        data, channels, fs, events, annotation_channels, _ = pyedf_convert(
             self.temp_dir, remove_pre_fixation=True)
 
         self.assertTrue(len(data) > 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,6 @@ pandas==1.1.3
 psutil==5.7.2
 Pillow==9.0.1
 py-cpuinfo==7.0.0
-pyedflib==0.1.28
+pyedflib==0.1.30
 PyQt5==5.15.1
 tqdm==4.62.2


### PR DESCRIPTION
# Overview

Refactored the convert to edf method. Add convert to bdf method for better export resolution. Ensured the static offset output in the parameters file is accounted for. Add a pre-filter option that will apply the default transform using the filter parameters in the parameters.json stored in the session directory. Ensured the correct annotation channels are used. Upgraded pyedflib to latest version. 

## Ticket

https://www.pivotaltracker.com/story/show/182395017

## Contributions

- `convert.py`: Refactored the convert to edf method into reusable parts (`pdf_convert`). Add convert to bdf method for better export resolution. Ensured the static offset output in the parameters file is accounted for. Update documentation. Calculate the correct annotation channels needed instead of only alerting. 
- `demo_convert.py`: Added a plot option for file viewing, using -d for the directory arg instead. Added the export to bdf option. 
- `test_convert.py`: refactored setup needed in the `create_bcipy_session_artifacts`. Add tests for added methods. 


## Test

- `make test-all`
- Used `demo_convert.py` and shared the data with @danielpklee for review. I shared a .edf and .bdf file. 

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? Yes
