### PR TITLE
Bug fixes: jitter, offline analysis, task complete alerting 

### DIFF
--- a/bcipy/acquisition/__init__.py
+++ b/bcipy/acquisition/__init__.py
@@ -1,0 +1,8 @@
+from bcipy.acquisition.protocols.lsl.lsl_client import LslAcquisitionClient
+from bcipy.acquisition.datastream.lsl_server import LslDataServer, await_start
+
+__all__ = [
+    'LslAcquisitionClient',
+    'LslDataServer',
+    'await_start'
+]

--- a/bcipy/acquisition/demo/demo_eeg_with_switch.py
+++ b/bcipy/acquisition/demo/demo_eeg_with_switch.py
@@ -3,10 +3,9 @@ import subprocess
 import time
 
 from bcipy.config import BCIPY_ROOT
-from bcipy.acquisition.datastream.lsl_server import await_start, LslDataServer
 from bcipy.acquisition.datastream.mock.switch import switch_device
 from bcipy.acquisition.devices import preconfigured_device
-from bcipy.acquisition.protocols.lsl.lsl_client import LslAcquisitionClient
+from bcipy.acquisition import LslAcquisitionClient, LslDataServer, await_start
 from bcipy.helpers.system_utils import log_to_stdout
 
 

--- a/bcipy/acquisition/demo/demo_eye_tracker_client_and_server.py
+++ b/bcipy/acquisition/demo/demo_eye_tracker_client_and_server.py
@@ -1,8 +1,7 @@
 """Sample script to demonstrate usage of the LSL DataAcquisitionClient."""
 import time
 
-from bcipy.acquisition.protocols.lsl.lsl_client import LslAcquisitionClient
-from bcipy.acquisition.datastream.lsl_server import await_start
+from bcipy.acquisition import LslAcquisitionClient, await_start
 from bcipy.acquisition.datastream.mock.eye_tracker_server import (eye_tracker_device,
                                                                   eye_tracker_server)
 

--- a/bcipy/acquisition/demo/demo_lsl_acq_client.py
+++ b/bcipy/acquisition/demo/demo_lsl_acq_client.py
@@ -2,7 +2,7 @@
 
 import time
 
-from bcipy.acquisition.protocols.lsl.lsl_client import LslAcquisitionClient
+from bcipy.acquisition import LslAcquisitionClient
 
 
 def main():

--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -3,7 +3,7 @@ import sys
 
 from typing import List
 
-from bcipy.config import BCIPY_ROOT, DEFAULT_PARAMETERS_PATH, STATIC_AUDIO_PATH, STATIC_IMAGES_PATH
+from bcipy.config import BCIPY_ROOT, DEFAULT_PARAMETERS_PATH, STATIC_IMAGES_PATH
 from bcipy.gui.main import (
     AlertMessageResponse,
     AlertMessageType,
@@ -15,7 +15,6 @@ from bcipy.gui.main import (
     invalid_length,
 )
 from bcipy.helpers.load import load_json_parameters, load_experiments, copy_parameters, load_users
-from bcipy.helpers.stimuli import play_sound
 from bcipy.task import TaskType
 
 
@@ -402,10 +401,9 @@ class BCInterface(BCIGui):
                 f'bcipy -e "{self.experiment}" '
                 f'-u "{self.user}" -t "{self.task}" -p "{self.parameter_location}"'
             )
-            subprocess.Popen(cmd, shell=True)
-
             if self.alert:
-                play_sound(f"{STATIC_AUDIO_PATH}/{self.parameters['alert_sound_file']}")
+                cmd += ' -a'
+            subprocess.Popen(cmd, shell=True)
 
             if self.autoclose:
                 self.close()

--- a/bcipy/helpers/acquisition.py
+++ b/bcipy/helpers/acquisition.py
@@ -6,9 +6,8 @@ from typing import Dict, List
 
 import numpy as np
 
-from bcipy.acquisition.datastream.lsl_server import await_start, LslDataServer
 from bcipy.acquisition.devices import DeviceSpec, preconfigured_device
-from bcipy.acquisition.protocols.lsl.lsl_client import LslAcquisitionClient
+from bcipy.acquisition import LslAcquisitionClient, await_start, LslDataServer
 from bcipy.helpers.save import save_device_spec
 from bcipy.config import BCIPY_ROOT, RAW_DATA_FILENAME, DEFAULT_DEVICE_SPEC_FILENAME as spec_name
 

--- a/bcipy/helpers/acquisition.py
+++ b/bcipy/helpers/acquisition.py
@@ -83,8 +83,23 @@ def init_lsl_client(parameters: dict, device_spec: DeviceSpec,
 
 def max_inquiry_duration(parameters: dict) -> float:
     """Computes the maximum duration of an inquiry based on the configured
-    parameters. Modes which don't use all of the settings may have shorter
-    durations.
+    parameters. Paradigms which don't use all of the settings may have shorter
+    durations. This can be used to determine the size of the data buffer.
+
+    Parameters
+    ----------
+    - parameters : dict
+        configuration details regarding the task and other relevant information.
+         {
+            "time_fixation": float,
+            "time_prompt": float,
+            "prestim_length": float,
+            "stim_length": float,
+            "stim_jitter": float,
+            "task_buffer_length": float,
+            "time_flash": float,
+
+         }
 
     Returns
     -------
@@ -96,8 +111,9 @@ def max_inquiry_duration(parameters: dict) -> float:
     stim_count = parameters['stim_length']
     stim_duration = parameters['time_flash']
     interval_duration = parameters['task_buffer_length']
+    jitter = parameters['stim_jitter']
 
-    return prestimulus_duration + target_duration + fixation_duration + (
+    return prestimulus_duration + jitter + target_duration + fixation_duration + (
         stim_count * stim_duration) + interval_duration
 
 

--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -635,7 +635,6 @@ def play_sound(sound_file_path: str,
     :param: track_timing: whether or not to track timing of sound playin
     :param: sound_callback: trigger based callback (see MarkerWriter and NullMarkerWriter)
     :param: sound_load_buffer_time: time to wait after loading file before playing
-    :param: sound_post_buffer_time: time to wait after playing sound before returning
     :param: experiment_clock: psychopy clock to get time of sound stimuli
     :param: trigger_name: name of the sound trigger
     :param: timing: list of triggers in the form of trigger name, trigger timing

--- a/bcipy/helpers/tests/test_acquisition.py
+++ b/bcipy/helpers/tests/test_acquisition.py
@@ -71,7 +71,8 @@ class TestAcquisition(unittest.TestCase):
             'stim_length': 10,
             'time_flash': 0.25,
             'task_buffer_length': 0.75,
-            'prestim_length': 0
+            'prestim_length': 0,
+            'stim_jitter': 0
         }
 
         self.assertEqual(4.75, max_inquiry_duration(params))

--- a/bcipy/helpers/tests/test_task.py
+++ b/bcipy/helpers/tests/test_task.py
@@ -7,7 +7,7 @@ from mockito import unstub, mock, when, verify, verifyStubbedInvocationsAreUsed
 import numpy as np
 import psychopy
 
-from bcipy.acquisition.protocols.lsl.lsl_client import LslAcquisitionClient
+from bcipy.acquisition import LslAcquisitionClient
 from bcipy.acquisition.record import Record
 from bcipy.task.exceptions import InsufficientDataException
 

--- a/bcipy/main.py
+++ b/bcipy/main.py
@@ -6,8 +6,7 @@ from typing import Optional
 
 from psychopy import visual
 
-from bcipy.acquisition.client import DataAcquisitionClient
-from bcipy.acquisition.datastream.lsl_server import LslDataServer
+from bcipy.acquisition import LslAcquisitionClient, LslDataServer
 from bcipy.display import init_display_window
 from bcipy.config import DEFAULT_PARAMETERS_PATH, DEFAULT_EXPERIMENT_ID, STATIC_AUDIO_PATH
 from bcipy.helpers.acquisition import init_eeg_acquisition
@@ -159,7 +158,7 @@ def execute_task(
 
 def _clean_up_session(
         display: visual.Window,
-        daq: DataAcquisitionClient,
+        daq: LslAcquisitionClient,
         server: Optional[LslDataServer] = None) -> bool:
     """Clean up session.
 
@@ -167,7 +166,7 @@ def _clean_up_session(
 
     Input:
         display (visual.Window): display window
-        daq (DataAcquisitionClient): data acquisition client
+        daq (LslAcquisitionClient): data acquisition client
         server (LslDataServer): data server
     """
     try:

--- a/bcipy/main.py
+++ b/bcipy/main.py
@@ -2,14 +2,21 @@ import argparse
 import logging
 import multiprocessing
 
+from typing import Optional
+
+from psychopy import visual
+
+from bcipy.acquisition.client import DataAcquisitionClient
+from bcipy.acquisition.datastream.lsl_server import LslDataServer
 from bcipy.display import init_display_window
-from bcipy.config import DEFAULT_PARAMETERS_PATH, DEFAULT_EXPERIMENT_ID
+from bcipy.config import DEFAULT_PARAMETERS_PATH, DEFAULT_EXPERIMENT_ID, STATIC_AUDIO_PATH
 from bcipy.helpers.acquisition import init_eeg_acquisition
 from bcipy.helpers.language_model import init_language_model
 from bcipy.helpers.load import (load_experiments, load_json_parameters,
                                 load_signal_model)
 from bcipy.helpers.save import init_save_data_structure
 from bcipy.helpers.session import collect_experiment_field_data
+from bcipy.helpers.stimuli import play_sound
 from bcipy.helpers.system_utils import configure_logger, get_system_info
 from bcipy.helpers.task import print_message
 from bcipy.helpers.validate import validate_experiment, validate_bcipy_session
@@ -20,7 +27,12 @@ from bcipy.task.start_task import start_task
 log = logging.getLogger(__name__)
 
 
-def bci_main(parameter_location: str, user: str, task: TaskType, experiment: str = DEFAULT_EXPERIMENT_ID) -> bool:
+def bci_main(
+        parameter_location: str,
+        user: str,
+        task: TaskType,
+        experiment: str = DEFAULT_EXPERIMENT_ID,
+        alert: bool = False) -> bool:
     """BCI Main.
 
     The BCI main function will initialize a save folder, construct needed information
@@ -38,8 +50,7 @@ def bci_main(parameter_location: str, user: str, task: TaskType, experiment: str
         user (str): name of the user
         task (TaskType): registered bcipy TaskType
         experiment_id (str): Name of the experiment. Default name is DEFAULT_EXPERIMENT_ID.
-
-
+        alert (bool): whether to alert the user when the task is complete
     """
     validate_experiment(experiment)
     # Load parameters
@@ -78,10 +89,14 @@ def bci_main(parameter_location: str, user: str, task: TaskType, experiment: str
     # Collect experiment field data
     collect_experiment_field_data(experiment, save_folder)
 
-    return execute_task(task, parameters, save_folder)
+    return execute_task(task, parameters, save_folder, alert)
 
 
-def execute_task(task: TaskType, parameters: dict, save_folder: str) -> bool:
+def execute_task(
+        task: TaskType,
+        parameters: dict,
+        save_folder: str,
+        alert: bool) -> bool:
     """Execute Task.
 
     Executes the desired task by setting up the display window and
@@ -89,9 +104,10 @@ def execute_task(task: TaskType, parameters: dict, save_folder: str) -> bool:
         which will initialize experiment.
 
     Input:
-        task(str): registered bcipy TaskType
+        (str): registered bcipy TaskType
         parameters (dict): parameter dictionary
         save_folder (str): path to save folder
+        alert (bool): whether to alert the user when the task is complete
     """
     signal_model = None
     language_model = None
@@ -122,7 +138,7 @@ def execute_task(task: TaskType, parameters: dict, save_folder: str) -> bool:
     # We have to wait until after the prompt to load the signal model before
     # displaying the window, otherwise in fullscreen mode this throws an error
     display = init_display_window(parameters)
-    print_message(display, 'Initializing...')
+    print_message(display, f'Initializing {task}...')
 
     # Start Task
     try:
@@ -134,29 +150,43 @@ def execute_task(task: TaskType, parameters: dict, save_folder: str) -> bool:
     # If exception, close all display and acquisition objects
     except Exception as e:
         log.exception(str(e))
-        _clean_up_session(display, daq, server)
-        raise e
+
+    if alert:
+        play_sound(f"{STATIC_AUDIO_PATH}/{parameters['alert_sound_file']}")
 
     return _clean_up_session(display, daq, server)
 
 
-def _clean_up_session(display, daq, server):
-    """Clean up session."""
+def _clean_up_session(
+        display: visual.Window,
+        daq: DataAcquisitionClient,
+        server: Optional[LslDataServer] = None) -> bool:
+    """Clean up session.
 
-    # Stop Acquisition
-    daq.stop_acquisition()
-    daq.cleanup()
+    Closes the display window and data acquisition objects. Returns True if the session was closed successfully.
 
-    if server:
-        server.stop()
+    Input:
+        display (visual.Window): display window
+        daq (DataAcquisitionClient): data acquisition client
+        server (LslDataServer): data server
+    """
+    try:
+        # Stop Acquisition
+        daq.stop_acquisition()
+        daq.cleanup()
 
-    # Close the display window
-    # NOTE: There is currently a bug in psychopy when attempting to shutdown
-    # windows when using a USB-C monitor. Putting the display close last in
-    # the inquiry allows acquisition to properly shutdown.
-    display.close()
+        if server:
+            server.stop()
 
-    return True
+        # Close the display window
+        # NOTE: There is currently a bug in psychopy when attempting to shutdown
+        # windows when using a USB-C monitor. Putting the display close last in
+        # the inquiry allows acquisition to properly shutdown.
+        display.close()
+        return True
+    except Exception as e:
+        log.exception(str(e))
+        return False
 
 
 def bcipy_main() -> None:
@@ -183,10 +213,16 @@ def bcipy_main() -> None:
         '--experiment',
         default=DEFAULT_EXPERIMENT_ID,
         help=f'Select a valid experiment to run the task for this user. Available options: {experiment_options}')
+    parser.add_argument(
+        '-a',
+        '--alert',
+        default=False,
+        action='store_true',
+        help='Alert the user when the task is complete.')
     args = parser.parse_args()
 
     # Start BCI Main
-    bci_main(args.parameters, str(args.user), TaskType.by_value(str(args.task)), str(args.experiment))
+    bci_main(args.parameters, str(args.user), TaskType.by_value(str(args.task)), str(args.experiment), args.alert)
 
 
 if __name__ == '__main__':

--- a/bcipy/signal/model/offline_analysis.py
+++ b/bcipy/signal/model/offline_analysis.py
@@ -192,7 +192,7 @@ def offline_analysis(
         show=show_figures
     )
     if alert_finished:
-        play_sound(f"{STATIC_AUDIO_PATH}/{self.parameters['alert_sound_file']}")
+        play_sound(f"{STATIC_AUDIO_PATH}/{parameters['alert_sound_file']}")
     return model, figure_handles
 
 

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -12,7 +12,7 @@ from bcipy.config import DEFAULT_ENCODING
 import bcipy.display.paradigm.rsvp.mode.copy_phrase
 from bcipy.helpers.triggers import TriggerHandler
 from bcipy.helpers.exceptions import TaskConfigurationException
-from bcipy.acquisition.protocols.lsl.lsl_client import LslAcquisitionClient
+from bcipy.acquisition import LslAcquisitionClient
 from bcipy.acquisition.devices import DeviceSpec
 from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
 from bcipy.helpers.parameters import Parameters

--- a/bcipy/tests/test_bci_main.py
+++ b/bcipy/tests/test_bci_main.py
@@ -7,7 +7,7 @@ from bcipy.main import (
     _clean_up_session,
     execute_task
 )
-from bcipy.config import DEFAULT_PARAMETERS_PATH, DEFAULT_EXPERIMENT_ID
+from bcipy.config import DEFAULT_PARAMETERS_PATH, DEFAULT_EXPERIMENT_ID, STATIC_AUDIO_PATH
 
 from bcipy.helpers.exceptions import (
     UnregisteredExperimentException,
@@ -27,7 +27,9 @@ class TestBciMain(unittest.TestCase):
         'data_save_loc': data_save_location,
         'log_name': 'test_log',
         'fake_data': False,
-        'signal_model_path': ''
+        'signal_model_path': '',
+        'lm_path': '',
+        'alert_sound_file': 'test.wav',
     }
     system_info = {
         'bcipy_version': 'test_version'
@@ -36,6 +38,7 @@ class TestBciMain(unittest.TestCase):
     task = mock()
     task.label = 'RSVP Calibration'
     experiment = DEFAULT_EXPERIMENT_ID
+    alert = False
 
     def tearDown(self) -> None:
         verifyStubbedInvocationsAreUsed()
@@ -62,7 +65,11 @@ class TestBciMain(unittest.TestCase):
             version=self.system_info['bcipy_version']
         )
         when(main).collect_experiment_field_data(self.experiment, self.save_location)
-        when(main).execute_task(self.task, self.parameters, self.save_location).thenReturn(mock_execute_response)
+        when(main).execute_task(
+            self.task,
+            self.parameters,
+            self.save_location,
+            self.alert).thenReturn(mock_execute_response)
 
         response = bci_main(self.parameter_location, self.user, self.task)
         self.assertEqual(response, mock_execute_response)
@@ -81,7 +88,7 @@ class TestBciMain(unittest.TestCase):
             self.save_location,
             version=self.system_info['bcipy_version'])
         verify(main, times=1).collect_experiment_field_data(self.experiment, self.save_location)
-        verify(main, times=1).execute_task(self.task, self.parameters, self.save_location)
+        verify(main, times=1).execute_task(self.task, self.parameters, self.save_location, self.alert)
 
     def test_bci_main_invalid_experiment(self) -> None:
         experiment = 'does_not_exist'
@@ -153,9 +160,11 @@ class TestExecuteTask(unittest.TestCase):
             'fake_data': True,
             'k_folds': 10,
             'is_txt_stim': True,
-            'signal_model_path': ''
+            'signal_model_path': '',
+            'alert_sound_file': 'test.wav',
         }
         self.save_folder = '/'
+        self.alert = False
         self.task = TaskType(1)
         self.display_mock = mock()
         self.daq = mock()
@@ -186,7 +195,7 @@ class TestExecuteTask(unittest.TestCase):
         )
         when(main)._clean_up_session(self.display_mock, self.daq, self.server)
 
-        execute_task(self.task, self.parameters, self.save_folder)
+        execute_task(self.task, self.parameters, self.save_folder, self.alert)
 
         verify(main, times=1).init_eeg_acquisition(
             self.parameters,
@@ -230,7 +239,7 @@ class TestExecuteTask(unittest.TestCase):
         )
         when(main)._clean_up_session(self.display_mock, self.daq, self.server)
 
-        execute_task(self.task, self.parameters, self.save_folder)
+        execute_task(self.task, self.parameters, self.save_folder, self.alert)
 
         verify(main, times=1).init_eeg_acquisition(
             self.parameters,
@@ -285,7 +294,7 @@ class TestExecuteTask(unittest.TestCase):
         )
         when(main)._clean_up_session(self.display_mock, self.daq, self.server)
 
-        execute_task(self.task, self.parameters, self.save_folder)
+        execute_task(self.task, self.parameters, self.save_folder, self.alert)
 
         verify(main, times=1).init_eeg_acquisition(
             self.parameters,
@@ -307,31 +316,6 @@ class TestExecuteTask(unittest.TestCase):
         verify(main, times=1).load_signal_model(model_class=any(), model_kwargs={
             'k_folds': self.parameters['k_folds']
         }, filename=model_path)
-        verify(main, times=1)._clean_up_session(self.display_mock, self.daq, self.server)
-
-    def test_execute_task_invalid_task(self) -> None:
-        task = 'invalid'
-        response = (self.daq, self.server)
-        when(main).init_eeg_acquisition(
-            self.parameters,
-            self.save_folder,
-            server=self.parameters['fake_data'],
-            export_spec=True
-        ).thenReturn(response)
-        when(main).init_display_window(self.parameters).thenReturn(self.display_mock)
-        when(main).print_message(self.display_mock, any())
-        when(main)._clean_up_session(self.display_mock, self.daq, self.server)
-
-        with self.assertRaises(Exception):
-            execute_task(task, self.parameters, self.save_folder)
-
-        verify(main, times=1).init_eeg_acquisition(
-            self.parameters,
-            self.save_folder,
-            server=self.parameters['fake_data'],
-            export_spec=True)
-        verify(main, times=1).init_display_window(self.parameters)
-        verify(main, times=1).print_message(self.display_mock, any())
         verify(main, times=1)._clean_up_session(self.display_mock, self.daq, self.server)
 
     def test_execute_language_model_enabled(self) -> None:
@@ -370,7 +354,7 @@ class TestExecuteTask(unittest.TestCase):
         )
         when(main)._clean_up_session(self.display_mock, self.daq, self.server)
 
-        execute_task(self.task, self.parameters, self.save_folder)
+        execute_task(self.task, self.parameters, self.save_folder, self.alert)
 
         verify(main, times=1).init_eeg_acquisition(
             self.parameters,
@@ -394,6 +378,52 @@ class TestExecuteTask(unittest.TestCase):
         }, filename='')
         verify(main, times=1).init_language_model(self.parameters)
         verify(main, times=1)._clean_up_session(self.display_mock, self.daq, self.server)
+
+    def test_execute_with_alert_enabled(self):
+        expected_alert_path = f"{STATIC_AUDIO_PATH}/{self.parameters['alert_sound_file']}"
+        response = (self.daq, self.server)
+        when(main).init_eeg_acquisition(
+            self.parameters,
+            self.save_folder,
+            server=self.parameters['fake_data'],
+            export_spec=True
+        ).thenReturn(response)
+        when(main).init_display_window(self.parameters).thenReturn(self.display_mock)
+        when(main).print_message(self.display_mock, any())
+        when(main).start_task(
+            self.display_mock,
+            self.daq,
+            self.task,
+            self.parameters,
+            self.save_folder,
+            language_model=None,
+            signal_model=None,
+            fake=self.parameters['fake_data'],
+        )
+        when(main)._clean_up_session(self.display_mock, self.daq, self.server)
+        when(main).play_sound(expected_alert_path)
+
+        execute_task(self.task, self.parameters, self.save_folder, True)
+
+        verify(main, times=1).init_eeg_acquisition(
+            self.parameters,
+            self.save_folder,
+            server=self.parameters['fake_data'],
+            export_spec=True)
+        verify(main, times=1).init_display_window(self.parameters)
+        verify(main, times=1).print_message(self.display_mock, any())
+        verify(main, times=1).start_task(
+            self.display_mock,
+            self.daq,
+            self.task,
+            self.parameters,
+            self.save_folder,
+            language_model=None,
+            signal_model=None,
+            fake=self.parameters['fake_data'],
+        )
+        verify(main, times=1)._clean_up_session(self.display_mock, self.daq, self.server)
+        verify(main, times=1).play_sound(expected_alert_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Overview

Bug fixes for the release candidate! Copy phrase jitter bug, where the jitter wasn't being factored into the calculation of buffer space needed for  data querying. Unreported offline analysis copy error for the play alert. Move task complete alerting to main and use it in the subprocess command in BCInterface.py.

## Ticket

https://www.pivotaltracker.com/story/show/183214254
https://www.pivotaltracker.com/story/show/183051997


## Contributions

- `offline_analysis.py`: bug fix (`self.parameters` --> `parameter`)
- `BCInterface.py`: remove play_sound and call it using bcipy cmd line util
- `main.py`: add documentation and alerting functionality to let the user know when the task is complete. Add it to the registered cmd line util. Remove raising of exceptions at the end, still logging.

## Test

- `make test-all`
- `bcipy`
- Ran the GUI and ensured tasks could be run and the alert is used at the end! 

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here. Updated where I thought necessary! 

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? None required all within the rc
