### PR TITLE
#179846837 ; user editable parameters

### DIFF
--- a/bcipy/gui/main.py
+++ b/bcipy/gui/main.py
@@ -213,6 +213,7 @@ class FormInput(QWidget):
         options - optional list of recommended values used by some controls.
         help_size - font size for the help text.
         help_color - color of the help text.
+        should_display - if False, the input is always hidden.
     """
 
     def __init__(self,
@@ -221,18 +222,23 @@ class FormInput(QWidget):
                  help_tip: str = None,
                  options: List[str] = None,
                  help_size: int = 12,
-                 help_color: str = 'darkgray'):
+                 help_color: str = 'darkgray',
+                 should_display: bool = True):
         super(FormInput, self).__init__()
 
         self.label = label
         self.help_tip = help_tip
         self.options = options
+        self.should_display = should_display
 
         self.label_widget = self.init_label()
         self.help_tip_widget = self.init_help(help_size, help_color)
         self.control = self.init_control(value)
         self.control.installEventFilter(self)
         self.init_layout()
+
+        if not should_display:
+            self.hide()
 
     def eventFilter(self, source, event):
         """Event filter that suppresses the scroll wheel event."""
@@ -294,9 +300,10 @@ class FormInput(QWidget):
 
     def show(self):
         """Show this widget, and all child widgets."""
-        for widget in self.widgets():
-            if widget:
-                widget.setVisible(True)
+        if self.should_display:
+            for widget in self.widgets():
+                if widget:
+                    widget.setVisible(True)
 
     def hide(self):
         """Hide this widget, and all child widgets."""

--- a/bcipy/gui/parameters/params_form.py
+++ b/bcipy/gui/parameters/params_form.py
@@ -149,6 +149,7 @@ def clear_layout(layout):
     while layout.count():
         child = layout.takeAt(0)
         if child.widget() is not None:
+            child.widget().setVisible(False)
             child.widget().deleteLater()
         elif child.layout() is not None:
             clear_layout(child.layout())

--- a/bcipy/gui/parameters/params_form.py
+++ b/bcipy/gui/parameters/params_form.py
@@ -56,8 +56,10 @@ class ParamsForm(QWidget):
     def add_controls(self):
         """Add controls to layout"""
         if self.controls:
-            for _param_name, form_input in self.controls.items():
-                self.layout.addWidget(form_input)
+            for param_name, form_input in self.controls.items():
+                # Only items with a named section are user-editable.
+                if (self.params[param_name]['section']):
+                    self.layout.addWidget(form_input)
 
     def create_controls(self, params: Parameters) -> Dict[str, FormInput]:
         """Create controls (inputs, labels, etc) for each item in the

--- a/bcipy/gui/parameters/params_form.py
+++ b/bcipy/gui/parameters/params_form.py
@@ -56,10 +56,8 @@ class ParamsForm(QWidget):
     def add_controls(self):
         """Add controls to layout"""
         if self.controls:
-            for param_name, form_input in self.controls.items():
-                # Only items with a named section are user-editable.
-                if (self.params[param_name]['section']):
-                    self.layout.addWidget(form_input)
+            for form_input in self.controls.values():
+                self.layout.addWidget(form_input)
 
     def create_controls(self, params: Parameters) -> Dict[str, FormInput]:
         """Create controls (inputs, labels, etc) for each item in the
@@ -98,7 +96,8 @@ class ParamsForm(QWidget):
                           help_tip=param['helpTip'],
                           options=param['recommended_values'],
                           help_size=self.help_size,
-                          help_color=self.help_color)
+                          help_color=self.help_color,
+                          should_display=bool(param['section']))
 
     def search(self, text: str) -> None:
         """Search for an input. Hides inputs which do not match.


### PR DESCRIPTION
# Overview

Params GUI change so that only parameters with a value in the 'section' attribute are user-editable.

## Ticket

https://www.pivotaltracker.com/story/show/179846837

## Contributions

- Updated params_form to only allow user to edit parameters with a section.

## Test

- Tested editing a copy of parameters.json where the section was set to blank for a number of fields. Confirmed that those fields did not appear in the GUI, but were retained when the file was saved or saved as another file.
- Confirmed that editing a normal, unmodified parameters file was unchanged and that the user could view and edit all parameters.