### PR TITLE
MNE unit conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
+# 2.0.0-rc.3
+
+## Contributions
+
+- Updated GUIs
+    - Paramater GUI `save as` functionality #255
+    - Paramater GUI user editable parameters defined in `bcipy/parameters.json` #256
+    - GUI history using a `.bcipy_cache` file #257
+- Bug Fixes
+    - Missing inits and lock some dependencies #258
+- MNE updates
+    - convert to mne can now handle conversion to Volts from microvolts, and no channel map #259
+
+
 # 2.0.1-rc.2
+
+## Contributions
 
 Small patch release to fix a missing import in helpers/parameters.py
 

--- a/bcipy/helpers/convert.py
+++ b/bcipy/helpers/convert.py
@@ -486,21 +486,53 @@ def tar_name_checker(tar_file_name: str) -> str:
 
 def convert_to_mne(
         raw_data: RawData,
-        channel_map: List[int],
+        channel_map: List[int] = None,
+        channel_types: Optional[List[str]] = None,
         transform: Optional[Composition] = None,
-        montage: str = 'standard_1020') -> RawArray:
+        montage: str = 'standard_1020',
+        volts: bool = True) -> RawArray:
     """Convert to MNE.
 
-    Returns BciPy RawData as an MNE RawArray. This assumes all data channels are eeg and channel names
-    are reflective of standard 1020 locations.
-    See https://mne.tools/dev/generated/mne.channels.make_standard_montage.html
+    Returns BciPy RawData as an MNE RawArray. This assumes all channel names
+    are reflective of provided montage locations.
+
+    Parameters
+    ----------
+        raw_data - BciPy RawData object
+        channel_map - optional list of channels to include in the MNE RawArray [1, 0, 1, 0, 1, 0, 1, 0].
+            1 indicates the channel should be included, 0 indicates it should be excluded.
+            Must be the same length as the number of channels in the raw_data.
+        channel_types - list of channel types to include in the MNE RawArray.
+            If None, all channels will be assumed to be eeg.
+            See: https://mne.tools/stable/overview/implementation.html#supported-channel-types
+        transform - optional transform to apply to the data
+        montage - name of the channel location montage to use.
+            See https://mne.tools/dev/generated/mne.channels.make_standard_montage.html
+        volts - if True, assume data is already in volts. If false, assume data is in microvolts and convert to volts.
+            MNE expects data to be in volts.
+            See: https://mne.tools/dev/overview/implementation.html#internal-representation-units
     """
+    # if no channel map provided, assume all channels are included
+    if not channel_map:
+        channel_map = [1] * len(raw_data.channels)
+
     data, channels, fs = raw_data.by_channel_map(channel_map, transform)
-    channel_types = ['eeg' for _ in channels]
+
+    # if no channel types provided, assume all channels are eeg
+    if not channel_types:
+        channel_types = ['eeg'] * len(channels)
+
+    # check that number of channel types matches number of channels in the case custom channel types are provided
+    assert len(channel_types) == len(channels), \
+        f'Number of channel types ({len(channel_types)}) must match number of channels ({len(channels)})'
 
     info = mne.create_info(channels, fs, channel_types)
     mne_data = RawArray(data, info)
     ten_twenty_montage = mne.channels.make_standard_montage(montage)
     mne_data.set_montage(ten_twenty_montage)
+
+    # convert to volts if necessary (the default for many systems is microvolts)
+    if not volts:
+        mne_data = mne_data.apply_function(lambda x: x * 1e-6)
 
     return mne_data


### PR DESCRIPTION
# Overview

Added unit conversion functionality for mne data. 

## Ticket

https://www.pivotaltracker.com/story/show/182310991

## Contributions

- `helpers/convert`: update convert_to_mne to accept volts as an argument. If False, it assumes mV and will apply a transformation to the data to ensure all MNE assumptions are met. 

## Test

- `pytest`
- `flake8 lint`

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Updated docstrings and inline documentation. 

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? TODO
