### PR TITLE
Matrix Copy Phrase Task

### DIFF
--- a/bcipy/display/demo/matrix/demo_calibration_matrix.py
+++ b/bcipy/display/demo/matrix/demo_calibration_matrix.py
@@ -1,3 +1,5 @@
+"""Demo Matrix Display functionality related to Calibration task logic."""
+# pylint: disable=invalid-name
 from psychopy import core
 from bcipy.display import InformationProperties, TaskDisplayProperties, StimuliProperties
 from bcipy.display.paradigm.matrix import MatrixDisplay
@@ -11,58 +13,62 @@ info = InformationProperties(
     info_font=['Arial'],
     info_text=['Matrix Calibration Demo'],
 )
-task_display = TaskDisplayProperties(
-    task_color=['White'],
-    task_pos=(-.8, .85),
-    task_font='Arial',
-    task_height=.1,
-    task_text='1/100'
-)
-stim_properties = StimuliProperties(
-    stim_font='Arial',
-    stim_pos=(-0.6, 0.4),
-    stim_height=0.1,
-    stim_inquiry=['A'],
-    stim_colors=[],
-    stim_timing=[0.1],
-    is_txt_stim=True,
-    prompt_time=1.0
-)
+task_display = TaskDisplayProperties(task_color=['White'],
+                                     task_pos=(-.8, .85),
+                                     task_font='Arial',
+                                     task_height=.1,
+                                     task_text='1/100')
+stim_properties = StimuliProperties(stim_font='Arial',
+                                    stim_pos=(-0.6, 0.4),
+                                    stim_height=0.1,
+                                    is_txt_stim=True)
 
 # Initialize Stimulus
 window_parameters = {
     'full_screen': False,
     'window_height': 500,
     'window_width': 500,
-    'stim_screen': 1,
+    'stim_screen': 0,
     'background_color': 'black'
 }
-static_clock = core.StaticPeriod()
+
 experiment_clock = core.Clock()
 win = init_display_window(window_parameters)
 win.recordFrameIntervals = False
 
-matrix_display = MatrixDisplay(
-    win,
-    static_clock,
-    experiment_clock,
-    stim_properties,
-    task_display,
-    info)
+matrix_display = MatrixDisplay(win, experiment_clock, stim_properties,
+                               task_display, info)
 
+time_target = 1
+time_fixation = 2
+time_flash = 0.25
+timing = [time_target] + [time_fixation] + [time_flash] * 5
+task_buffer = 2
 
-matrix_display.schedule_to(stimuli=['A', 'B', 'C'], timing=[0.5, 0.5, 0.5], colors=[])
+matrix_display.schedule_to(stimuli=['A', '+', 'F', '<', 'A', 'B', 'C'],
+                           timing=timing,
+                           colors=[])
 matrix_display.update_task_state(text='1/100', color_list=['White'])
 matrix_display.do_inquiry()
+core.wait(task_buffer)
 
-matrix_display.schedule_to(stimuli=['X', 'F', '<', 'A', 'B', 'C'], timing=[1, 1, 1, 1, 1, 1], colors=[])
+matrix_display.schedule_to(stimuli=['B', '+', 'F', '<', 'A', 'B', 'C'],
+                           timing=timing,
+                           colors=[])
 matrix_display.update_task_state(text='2/100', color_list=['White'])
 matrix_display.do_inquiry()
+core.wait(task_buffer)
 
-matrix_display.schedule_to(stimuli=['X', 'F', '<', 'A', 'B', 'C'], timing=[1, 1, 1, 1, 1, 1], colors=[])
+matrix_display.schedule_to(stimuli=['C', '+', 'F', '<', 'A', 'B', 'C'],
+                           timing=timing,
+                           colors=[])
 matrix_display.update_task_state(text='3/100', color_list=['White'])
 matrix_display.do_inquiry()
+core.wait(task_buffer)
 
-matrix_display.schedule_to(stimuli=['X', 'F', '<', 'A', 'B', 'C'], timing=[1, 1, 1, 1, 1, 1], colors=[])
+matrix_display.schedule_to(stimuli=['<', '+', 'F', '<', 'A', 'B', 'C'],
+                           timing=timing,
+                           colors=[])
 matrix_display.update_task_state(text='4/100', color_list=['White'])
 matrix_display.do_inquiry()
+core.wait(task_buffer)

--- a/bcipy/display/demo/matrix/demo_calibration_matrix.py
+++ b/bcipy/display/demo/matrix/demo_calibration_matrix.py
@@ -26,7 +26,7 @@ stim_properties = StimuliProperties(
     stim_colors=[],
     stim_timing=[0.1],
     is_txt_stim=True,
-    prompt_time=2.0
+    prompt_time=1.0
 )
 
 # Initialize Stimulus

--- a/bcipy/display/demo/matrix/demo_calibration_matrix.py
+++ b/bcipy/display/demo/matrix/demo_calibration_matrix.py
@@ -25,7 +25,8 @@ stim_properties = StimuliProperties(
     stim_inquiry=['A'],
     stim_colors=[],
     stim_timing=[0.1],
-    is_txt_stim=True
+    is_txt_stim=True,
+    prompt_time=2.0
 )
 
 # Initialize Stimulus

--- a/bcipy/display/demo/matrix/demo_calibration_matrix.py
+++ b/bcipy/display/demo/matrix/demo_calibration_matrix.py
@@ -7,13 +7,13 @@ from bcipy.display.paradigm.matrix import MatrixDisplay
 from bcipy.display import init_display_window
 
 info = InformationProperties(
-    info_color=['White'],
+    info_color=['white'],
     info_pos=[(-.5, -.75)],
     info_height=[0.1],
     info_font=['Arial'],
     info_text=['Matrix Calibration Demo'],
 )
-task_display = TaskDisplayProperties(task_color=['White'],
+task_display = TaskDisplayProperties(task_color=['white'],
                                      task_pos=(-.8, .85),
                                      task_font='Arial',
                                      task_height=.1,
@@ -39,36 +39,37 @@ win.recordFrameIntervals = False
 matrix_display = MatrixDisplay(win, experiment_clock, stim_properties,
                                task_display, info)
 
-time_target = 1
+time_target = 2
 time_fixation = 2
 time_flash = 0.25
 timing = [time_target] + [time_fixation] + [time_flash] * 5
+colors = ['green', 'red'] + ['white'] * 5
 task_buffer = 2
 
 matrix_display.schedule_to(stimuli=['A', '+', 'F', '<', 'A', 'B', 'C'],
                            timing=timing,
-                           colors=[])
-matrix_display.update_task_state(text='1/100', color_list=['White'])
+                           colors=colors)
+matrix_display.update_task_state(text='1/100', color_list=['white'])
 matrix_display.do_inquiry()
 core.wait(task_buffer)
 
 matrix_display.schedule_to(stimuli=['B', '+', 'F', '<', 'A', 'B', 'C'],
                            timing=timing,
-                           colors=[])
-matrix_display.update_task_state(text='2/100', color_list=['White'])
+                           colors=colors)
+matrix_display.update_task_state(text='2/100', color_list=['white'])
 matrix_display.do_inquiry()
 core.wait(task_buffer)
 
 matrix_display.schedule_to(stimuli=['C', '+', 'F', '<', 'A', 'B', 'C'],
                            timing=timing,
-                           colors=[])
-matrix_display.update_task_state(text='3/100', color_list=['White'])
+                           colors=colors)
+matrix_display.update_task_state(text='3/100', color_list=['white'])
 matrix_display.do_inquiry()
 core.wait(task_buffer)
 
 matrix_display.schedule_to(stimuli=['<', '+', 'F', '<', 'A', 'B', 'C'],
                            timing=timing,
-                           colors=[])
-matrix_display.update_task_state(text='4/100', color_list=['White'])
+                           colors=colors)
+matrix_display.update_task_state(text='4/100', color_list=['white'])
 matrix_display.do_inquiry()
 core.wait(task_buffer)

--- a/bcipy/display/demo/matrix/demo_calibration_matrix.py
+++ b/bcipy/display/demo/matrix/demo_calibration_matrix.py
@@ -43,7 +43,7 @@ time_target = 2
 time_fixation = 2
 time_flash = 0.25
 timing = [time_target] + [time_fixation] + [time_flash] * 5
-colors = ['green', 'red'] + ['white'] * 5
+colors = ['green', 'lightgray'] + ['white'] * 5
 task_buffer = 2
 
 matrix_display.schedule_to(stimuli=['A', '+', 'F', '<', 'A', 'B', 'C'],

--- a/bcipy/display/demo/matrix/demo_copyphrase_matrix.py
+++ b/bcipy/display/demo/matrix/demo_copyphrase_matrix.py
@@ -35,33 +35,34 @@ window_parameters = {
     'full_screen': False,
     'window_height': 500,
     'window_width': 500,
-    'stim_screen': 1,
+    'stim_screen': 0,
     'background_color': 'black'
 }
 
 # Create the stimuli to be presented, in real-time these stimuli will likely be given by a model or randomized
 
-ele_sti = [['+', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', '<', '-'],
-           ['+', 'F', 'G', 'E', '-', 'S', 'Q', 'W', 'E', '<', 'A'],
-           ['+', 'F', 'G', 'E', '-', 'S', 'Q', 'W', 'R', '<', 'A'],
-           ['+', 'F', 'G', 'E', '-', 'S', 'Q', 'W', 'E', '<', 'A']]
+ele_sti = [['+', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', '<', '_'],
+           ['+', 'F', 'G', 'E', '_', 'S', 'Q', 'W', 'E', '<', 'A'],
+           ['+', 'F', 'G', 'E', '_', 'S', 'Q', 'W', 'R', '<', 'A'],
+           ['+', 'F', 'G', 'E', '_', 'S', 'Q', 'W', 'E', '<', 'A']]
 color_sti = [[
     'red', 'white', 'white', 'white', 'white', 'white', 'white', 'white',
     'white', 'white', 'white'
 ]] * 4
 
-timing_sti = [[0.5] + [0.25] * 10] * 4
+timing_sti = [[2] + [0.25] * 10] * 4
 
 task_text = ['COPY_PHA', 'COPY_PH']
 task_color = [['white'] * 5 + ['green'] * 2 + ['red'],
               ['white'] * 5 + ['green'] * 2]
 
 # Initialize decision
-ele_list_dec = [['[<]'], ['[R]']]
+decisions = ['<', 'R']
 
 # Initialize Window
 experiment_clock = core.Clock()
 win = init_display_window(window_parameters)
+
 # This is useful during time critical portions of the code, turn off otherwise
 win.recordFrameIntervals = False
 
@@ -69,8 +70,12 @@ frameRate = win.getActualFrameRate()
 
 print(frameRate)
 
-display = MatrixDisplay(win, experiment_clock, stim_properties, task_display,
-                        info, should_prompt_target=False)
+display = MatrixDisplay(win,
+                        experiment_clock,
+                        stim_properties,
+                        task_display,
+                        info,
+                        should_prompt_target=False)
 
 counter = 0
 
@@ -86,16 +91,15 @@ for idx_o in range(len(task_text)):
         display.schedule_to(stimuli=ele_sti[counter],
                             timing=timing_sti[counter],
                             colors=color_sti[counter])
-
         core.wait(inter_stim_buffer)
         inquiry_timing = display.do_inquiry()
-
         core.wait(inter_stim_buffer)
         counter += 1
 
-    # # Get stimuli parameters
-    # display.stim_inquiry = ele_list_dec[idx_o]
-    # display.color_list_sti = ['green']
-    # display.time_list_sti = [2]
+    display.update_task_state(text=f"Selected: {decisions[idx_o]}",
+                              color_list=['green'])
+    display.draw_static()
+    win.flip()
+    core.wait(2.0)
 
 win.close()

--- a/bcipy/display/demo/matrix/demo_copyphrase_matrix.py
+++ b/bcipy/display/demo/matrix/demo_copyphrase_matrix.py
@@ -1,0 +1,101 @@
+"""Demo using the Matrix display with Copy Phrase. This logic is integrated as
+a task, but this module demonstates how to customize or as a proof of concept
+prior to integration.
+"""
+
+from psychopy import core
+
+from bcipy.display import (init_display_window, InformationProperties,
+                           StimuliProperties, TaskDisplayProperties)
+from bcipy.display.paradigm.matrix.display import MatrixDisplay
+
+info = InformationProperties(
+    info_color=['White'],
+    info_pos=[(-.5, -.75)],
+    info_height=[0.1],
+    info_font=['Arial'],
+    info_text=['Matrix Copy Phrase Demo'],
+)
+task_height = 0.1
+task_display = TaskDisplayProperties(task_color=['White'],
+                                     task_pos=(0, 1 - (2 * task_height)),
+                                     task_font='Arial',
+                                     task_height=.1,
+                                     task_text='COPY_PHRASE')
+
+inter_stim_buffer = .5
+
+stim_properties = StimuliProperties(stim_font='Arial',
+                                    stim_pos=(-0.6, 0.4),
+                                    stim_height=0.1,
+                                    is_txt_stim=True)
+
+# Initialize Stimulus
+window_parameters = {
+    'full_screen': False,
+    'window_height': 500,
+    'window_width': 500,
+    'stim_screen': 1,
+    'background_color': 'black'
+}
+
+# Create the stimuli to be presented, in real-time these stimuli will likely be given by a model or randomized
+
+ele_sti = [['+', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', '<', '-'],
+           ['+', 'F', 'G', 'E', '-', 'S', 'Q', 'W', 'E', '<', 'A'],
+           ['+', 'F', 'G', 'E', '-', 'S', 'Q', 'W', 'R', '<', 'A'],
+           ['+', 'F', 'G', 'E', '-', 'S', 'Q', 'W', 'E', '<', 'A']]
+color_sti = [[
+    'red', 'white', 'white', 'white', 'white', 'white', 'white', 'white',
+    'white', 'white', 'white'
+]] * 4
+
+timing_sti = [[0.5] + [0.25] * 10] * 4
+
+task_text = ['COPY_PHA', 'COPY_PH']
+task_color = [['white'] * 5 + ['green'] * 2 + ['red'],
+              ['white'] * 5 + ['green'] * 2]
+
+# Initialize decision
+ele_list_dec = [['[<]'], ['[R]']]
+
+# Initialize Window
+experiment_clock = core.Clock()
+win = init_display_window(window_parameters)
+# This is useful during time critical portions of the code, turn off otherwise
+win.recordFrameIntervals = False
+
+frameRate = win.getActualFrameRate()
+
+print(frameRate)
+
+display = MatrixDisplay(win, experiment_clock, stim_properties, task_display,
+                        info, should_prompt_target=False)
+
+counter = 0
+
+for idx_o in range(len(task_text)):
+
+    display.update_task_state(text=task_text[idx_o],
+                              color_list=task_color[idx_o])
+    display.draw_static()
+    win.flip()
+
+    for idx in range(int(len(ele_sti) / 2)):
+        # Schedule a inquiry
+        display.schedule_to(stimuli=ele_sti[counter],
+                            timing=timing_sti[counter],
+                            colors=color_sti[counter])
+
+        core.wait(inter_stim_buffer)
+        inquiry_timing = display.do_inquiry()
+
+        core.wait(inter_stim_buffer)
+        counter += 1
+
+    # # Get stimuli parameters
+    # display.stim_inquiry = ele_list_dec[idx_o]
+    # display.color_list_sti = ['green']
+    # display.time_list_sti = [2]
+
+win.close()

--- a/bcipy/display/main.py
+++ b/bcipy/display/main.py
@@ -145,7 +145,7 @@ class StimuliProperties:
         stim_colors(List[str]): Ordered list of colors to apply to stimuli
         stim_timing(List[float]): Ordered list of timing to apply to an inquiry using the stimuli
         is_txt_stim(bool): Whether or not this is a text based stimuli (False implies image based)
-        prompt_time(float): Time to display target prompt for at the beggining of inquiry
+        prompt_time(float): Time to display target prompt for at the beginning of inquiry
         """
         self.stim_font = stim_font
         self.stim_pos = stim_pos

--- a/bcipy/display/main.py
+++ b/bcipy/display/main.py
@@ -131,10 +131,10 @@ class StimuliProperties:
             stim_font: str,
             stim_pos: Tuple[float, float],
             stim_height: float,
-            stim_inquiry: List[str],
-            stim_colors: List[str],
-            stim_timing: List[float],
-            is_txt_stim: bool,
+            stim_inquiry: List[str] = None,
+            stim_colors: List[str] = None,
+            stim_timing: List[float] = None,
+            is_txt_stim: bool = True,
             prompt_time: float = None):
         """Initialize Stimuli Parameters.
 
@@ -150,9 +150,9 @@ class StimuliProperties:
         self.stim_font = stim_font
         self.stim_pos = stim_pos
         self.stim_height = stim_height
-        self.stim_inquiry = stim_inquiry
-        self.stim_colors = stim_colors
-        self.stim_timing = stim_timing
+        self.stim_inquiry = stim_inquiry or []
+        self.stim_colors = stim_colors or []
+        self.stim_timing = stim_timing or []
         self.is_txt_stim = is_txt_stim
         self.stim_length = len(self.stim_inquiry)
         self.sti = None

--- a/bcipy/display/paradigm/matrix/display.py
+++ b/bcipy/display/paradigm/matrix/display.py
@@ -257,7 +257,8 @@ class MatrixDisplay(Display):
         # Flashing the grid at full opacity is considered fixation.
         self.window.callOnFlip(self.add_timing, fixation.symbol)
         self.draw(grid_opacity=self.full_grid_opacity,
-                  grid_color=fixation.color,
+                  grid_color=(fixation.color if self.should_prompt_target else
+                              self.grid_color),
                   duration=fixation.duration / 2)
         self.draw(grid_opacity=self.start_opacity,
                   duration=fixation.duration / 2)

--- a/bcipy/display/paradigm/matrix/display.py
+++ b/bcipy/display/paradigm/matrix/display.py
@@ -184,6 +184,7 @@ class MatrixDisplay(Display):
 
     def draw_grid(self,
                   opacity: float = 1,
+                  color: Optional[str] = 'white',
                   highlight: Optional[str] = None,
                   highlight_color: Optional[str] = None):
         """Draw the grid.
@@ -191,6 +192,7 @@ class MatrixDisplay(Display):
         Parameters
         ----------
             opacity - opacity for each item in the matrix
+            color - optional color for each item in the matrix
             highlight - optional stim label for the item to be highlighted
                 (rendered using the highlight_opacity).
             highlight_color - optional color to use for rendering the
@@ -200,7 +202,7 @@ class MatrixDisplay(Display):
             stim.setOpacity(self.highlight_opacity if highlight ==
                             symbol else opacity)
             stim.setColor(highlight_color if highlight_color and
-                          highlight == symbol else self.grid_color)
+                          highlight == symbol else color)
             stim.draw()
 
     def prompt_target(self, target: SymbolDuration) -> float:
@@ -220,7 +222,8 @@ class MatrixDisplay(Display):
 
     def draw(self,
              grid_opacity: float,
-             duration: float = None,
+             grid_color: Optional[str] = None,
+             duration: Optional[float] = None,
              highlight: Optional[str] = None,
              highlight_color: Optional[str] = None):
         """Draw all screen elements and flip the window.
@@ -228,12 +231,14 @@ class MatrixDisplay(Display):
         Parameters
         ----------
             grid_opacity - opacity value to use on all grid symbols
+            grid_color - optional color to use for all grid symbols
             duration - optional seconds to wait after flipping the window.
             highlight - optional symbol to highlight in the grid.
             highlight_color - optional color to use for rendering the
               highlighted stim.
         """
         self.draw_grid(opacity=grid_opacity,
+                       color=grid_color or self.grid_color,
                        highlight=highlight,
                        highlight_color=highlight_color)
         self.draw_static()
@@ -252,6 +257,7 @@ class MatrixDisplay(Display):
         # Flashing the grid at full opacity is considered fixation.
         self.window.callOnFlip(self.add_timing, fixation.symbol)
         self.draw(grid_opacity=self.full_grid_opacity,
+                  grid_color=fixation.color,
                   duration=fixation.duration / 2)
         self.draw(grid_opacity=self.start_opacity,
                   duration=fixation.duration / 2)

--- a/bcipy/display/paradigm/matrix/display.py
+++ b/bcipy/display/paradigm/matrix/display.py
@@ -14,6 +14,7 @@ class SymbolDuration(NamedTuple):
     """Represents a symbol and its associated duration to display"""
     symbol: str
     duration: float
+    color: str = 'white'
 
 
 class MatrixDisplay(Display):
@@ -68,6 +69,7 @@ class MatrixDisplay(Display):
 
         self.stimuli_inquiry = []
         self.stimuli_timing = []
+        self.stimuli_colors = []
         self.stimuli_font = stimuli.stim_font
 
         assert stimuli.is_txt_stim, "Matrix display is a text only display"
@@ -80,6 +82,7 @@ class MatrixDisplay(Display):
         self.position_increment = self.grid_stimuli_height + .05
         self.max_grid_width = 0.7
 
+        self.grid_color = 'white'
         self.start_opacity = 0.15
         self.highlight_opacity = 0.95
         self.full_grid_opacity = 0.95
@@ -106,16 +109,22 @@ class MatrixDisplay(Display):
                 timing(list[float]): list of timings of stimuli
                 colors(list[string]): list of colors
         """
-        assert len(stimuli) == len(timing), "each stimuli must have a timing value"
+        assert len(stimuli) == len(
+            timing), "each stimuli must have a timing value"
         self.stimuli_inquiry = stimuli
         self.stimuli_timing = timing
+        if colors:
+            assert len(stimuli) == len(colors), "each stimuli must have a color"
+            self.stimuli_colors = colors
+        else:
+            self.stimuli_colors = [self.grid_color] * len(stimuli)
 
     def symbol_durations(self) -> List[SymbolDuration]:
         """Symbols associated with their duration for the currently configured
         stimuli_inquiry."""
         return [
             SymbolDuration(*sti)
-            for sti in zip(self.stimuli_inquiry, self.stimuli_timing)
+            for sti in zip(self.stimuli_inquiry, self.stimuli_timing, self.stimuli_colors)
         ]
 
     def add_timing(self, stimuli: str):
@@ -157,6 +166,7 @@ class MatrixDisplay(Display):
         for sym in self.symbol_set:
             grid[sym] = visual.TextStim(win=self.window,
                                         text=sym,
+                                        color=self.grid_color,
                                         opacity=self.start_opacity,
                                         pos=pos,
                                         height=self.grid_stimuli_height)
@@ -172,7 +182,10 @@ class MatrixDisplay(Display):
             x_coordinate = self.position[0]
         return (x_coordinate, y_coordinate)
 
-    def draw_grid(self, opacity: float = 1, highlight: Optional[str] = None):
+    def draw_grid(self,
+                  opacity: float = 1,
+                  highlight: Optional[str] = None,
+                  highlight_color: Optional[str] = None):
         """Draw the grid.
 
         Parameters
@@ -180,10 +193,14 @@ class MatrixDisplay(Display):
             opacity - opacity for each item in the matrix
             highlight - optional stim label for the item to be highlighted
                 (rendered using the highlight_opacity).
+            highlight_color - optional color to use for rendering the
+              highlighted stim.
         """
         for symbol, stim in self.stim_registry.items():
             stim.setOpacity(self.highlight_opacity if highlight ==
                             symbol else opacity)
+            stim.setColor(highlight_color if highlight_color and
+                          highlight == symbol else self.grid_color)
             stim.draw()
 
     def prompt_target(self, target: SymbolDuration) -> float:
@@ -196,31 +213,29 @@ class MatrixDisplay(Display):
         """
         # register any timing and marker callbacks
         self.window.callOnFlip(self.add_timing, target.symbol)
-
-        target_stim = visual.TextStim(win=self.window,
-                                      font=self.stimuli_font,
-                                      text=f'Target: {target.symbol}',
-                                      height=.25,
-                                      color='Green',
-                                      wrapWidth=2)
-        target_stim.draw()
-        self.draw_static()
-        self.window.flip()
-        core.wait(target.duration)
+        self.draw(grid_opacity=self.start_opacity,
+                  duration=target.duration,
+                  highlight=target.symbol,
+                  highlight_color=target.color)
 
     def draw(self,
              grid_opacity: float,
              duration: float = None,
-             highlight: Optional[str] = None):
+             highlight: Optional[str] = None,
+             highlight_color: Optional[str] = None):
         """Draw all screen elements and flip the window.
 
         Parameters
         ----------
             grid_opacity - opacity value to use on all grid symbols
-            duration - optioanl seconds to wait after flipping the window.
+            duration - optional seconds to wait after flipping the window.
             highlight - optional symbol to highlight in the grid.
+            highlight_color - optional color to use for rendering the
+              highlighted stim.
         """
-        self.draw_grid(opacity=grid_opacity, highlight=highlight)
+        self.draw_grid(opacity=grid_opacity,
+                       highlight=highlight,
+                       highlight_color=highlight_color)
         self.draw_static()
         self.window.flip()
         if duration:
@@ -245,7 +260,8 @@ class MatrixDisplay(Display):
             self.window.callOnFlip(self.add_timing, stim.symbol)
             self.draw(grid_opacity=self.start_opacity,
                       duration=stim.duration,
-                      highlight=stim.symbol)
+                      highlight=stim.symbol,
+                      highlight_color=stim.color)
         self.draw(self.start_opacity)
 
     def wait_screen(self, message: str, message_color: str) -> None:

--- a/bcipy/display/paradigm/matrix/display.py
+++ b/bcipy/display/paradigm/matrix/display.py
@@ -187,8 +187,8 @@ class MatrixDisplay(Display):
             stim.draw()
 
     def prompt_target(self, target: SymbolDuration) -> float:
-        """Present the target for the configured length of time. Appends the
-        timing information to the configured accumulator.
+        """Present the target for the configured length of time. Records the
+        stimuli timing information.
 
         Parameters
         ----------
@@ -231,7 +231,7 @@ class MatrixDisplay(Display):
         """Animate the given stimuli using single character presentation.
 
         Flashes each stimuli in stimuli_inquiry for their respective flash
-        times. Adds timing information to the configured accumulator.
+        times and records the timing information.
         """
 
         # Flashing the grid at full opacity is considered fixation.

--- a/bcipy/display/paradigm/matrix/display.py
+++ b/bcipy/display/paradigm/matrix/display.py
@@ -20,6 +20,13 @@ class MatrixDisplay(Display):
     """Matrix Display Object for Inquiry Presentation.
 
     Animates display objects in matrix grid common to any Matrix task.
+
+    NOTE: The following are recommended parameter values for matrix experiments:
+
+    time_fixation: 2
+    stim_pos_x: -0.6
+    stim_pos_y: 0.4
+    stim_height: 0.1
     """
 
     def __init__(

--- a/bcipy/display/paradigm/matrix/mode/calibration.py
+++ b/bcipy/display/paradigm/matrix/mode/calibration.py
@@ -1,5 +1,4 @@
 from bcipy.display.paradigm.matrix.display import MatrixDisplay
-from bcipy.helpers.task import SPACE_CHAR
 
 
 class CalibrationDisplay(MatrixDisplay):
@@ -7,24 +6,18 @@ class CalibrationDisplay(MatrixDisplay):
 
     def __init__(self,
                  window,
-                 static_clock,
                  experiment_clock,
                  stimuli,
                  task_display,
                  info,
                  trigger_type='text',
-                 space_char=SPACE_CHAR,
-                 full_screen=False,
                  symbol_set=None):
 
         super(CalibrationDisplay, self).__init__(
             window,
-            static_clock,
-            experiment_clock,
-            stimuli,
-            task_display,
-            info,
+            experiment_clock=experiment_clock,
+            stimuli=stimuli,
+            task_display=task_display,
+            info=info,
             trigger_type=trigger_type,
-            space_char=space_char,
-            full_screen=full_screen,
             symbol_set=symbol_set)

--- a/bcipy/display/tests/paradigm/matrix/test_matrix_display.py
+++ b/bcipy/display/tests/paradigm/matrix/test_matrix_display.py
@@ -110,9 +110,6 @@ class TestMatrixDisplay(unittest.TestCase):
         self.assertEqual(self.matrix.stimuli_colors, self.stimuli.stim_colors)
 
     def test_do_inquiry_if_scp(self):
-        # If SCP is true, matrix should animate.
-        self.matrix.scp = True
-
         when(self.matrix).prompt_target().thenReturn(([], 'A'))
         when(self.matrix).animate_scp().thenReturn([])
         self.matrix.do_inquiry()
@@ -120,13 +117,6 @@ class TestMatrixDisplay(unittest.TestCase):
         verify(self.matrix, times=1)._trigger_pulse()
         verify(self.matrix, times=1).prompt_target()
         verify(self.matrix, times=1).animate_scp()
-
-    def test_do_inquiry_if_not_scp(self):
-        # If SCP is false, an exception should be raised as currently there is no other inquiry option available.
-        self.matrix.scp = False
-
-        with self.assertRaises(BciPyCoreException):
-            self.matrix.do_inquiry()
 
     def test_build_grid(self):
         # mock the text stims and increment_position

--- a/bcipy/display/tests/paradigm/matrix/test_matrix_display.py
+++ b/bcipy/display/tests/paradigm/matrix/test_matrix_display.py
@@ -61,6 +61,7 @@ class TestMatrixDisplay(unittest.TestCase):
         when(psychopy.visual).TextStim(
             win=self.window,
             text=any(),
+            color=any(),
             opacity=any(),
             pos=any(),
             height=any(),
@@ -149,6 +150,7 @@ class TestMatrixDisplay(unittest.TestCase):
             win=self.window,
             height=any(),
             text=any(),
+            color=any(),
             pos=any(),
             opacity=any()
         ).thenReturn(self.text_stim_mock)

--- a/bcipy/display/tests/paradigm/matrix/test_matrix_display.py
+++ b/bcipy/display/tests/paradigm/matrix/test_matrix_display.py
@@ -199,11 +199,14 @@ class TestMatrixDisplay(unittest.TestCase):
         when(self.matrix.window).flip().thenReturn()
         # skip the core wait
         when(psychopy.core).wait(any()).thenReturn()
-        when(self.matrix.trigger_callback).reset().thenReturn()
-        # we expect the timing returned to be a list
-        response = self.matrix.animate_scp(fixation=SymbolDuration('+', 1),
-                                           stimuli=[])
-        self.assertIsInstance(response, list)
+
+        self.matrix.animate_scp(
+            fixation=SymbolDuration('+', 1),
+            stimuli=[SymbolDuration('A', 1),
+                     SymbolDuration('Z', 1)])
+        verify(self.matrix.window, times=1).callOnFlip(any(), '+')
+        verify(self.matrix.window, times=1).callOnFlip(any(), 'A')
+        verify(self.matrix.window, times=1).callOnFlip(any(), 'Z')
 
     def test_draw_static(self):
         # mock the task draw and info text draw methods

--- a/bcipy/helpers/acquisition.py
+++ b/bcipy/helpers/acquisition.py
@@ -107,13 +107,14 @@ def max_inquiry_duration(parameters: dict) -> float:
     fixation_duration = parameters['time_fixation']
     target_duration = parameters['time_prompt']
     prestimulus_duration = parameters['prestim_length']
+    poststim_duration = parameters['prestim_length']
     stim_count = parameters['stim_length']
     stim_duration = parameters['time_flash']
     interval_duration = parameters['task_buffer_length']
     jitter = parameters['stim_jitter']
 
     return prestimulus_duration + jitter + target_duration + fixation_duration + (
-        stim_count * stim_duration) + interval_duration
+        stim_count * stim_duration) + poststim_duration + interval_duration
 
 
 def analysis_channels(channels: List[str], device_name: str) -> list:

--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -29,6 +29,7 @@ log = logging.getLogger(__name__)
 DEFAULT_FIXATION_PATH = 'bcipy/static/images/main/PLUS.png'
 DEFAULT_TEXT_FIXATION = '+'
 
+
 class StimuliOrder(Enum):
     """Stimuli Order.
 

--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -27,7 +27,7 @@ import mne
 
 log = logging.getLogger(__name__)
 DEFAULT_FIXATION_PATH = 'bcipy/static/images/main/PLUS.png'
-
+DEFAULT_TEXT_FIXATION = '+'
 
 class StimuliOrder(Enum):
     """Stimuli Order.
@@ -462,7 +462,7 @@ def calibration_inquiry_generator(
                 timing(list[list[float]]): list of timings
                 color(list(list[str])): list of colors)): scheduled inquiries
     """
-
+    assert len(timing) == 3, "timing must include values for [target, fixation, stimuli]"
     target_indexes = []
     no_target = None
 
@@ -694,7 +694,7 @@ def get_fixation(is_txt: bool) -> str:
     Return the correct stimulus fixation given the type (text or image).
     """
     if is_txt:
-        return '+'
+        return DEFAULT_TEXT_FIXATION
     else:
         return DEFAULT_FIXATION_PATH
 

--- a/bcipy/task/paradigm/matrix/calibration.py
+++ b/bcipy/task/paradigm/matrix/calibration.py
@@ -7,7 +7,7 @@ from bcipy.display import InformationProperties, StimuliProperties, TaskDisplayP
 from bcipy.display.paradigm.matrix.mode.calibration import CalibrationDisplay
 from bcipy.helpers.clock import Clock
 from bcipy.helpers.stimuli import (StimuliOrder, TargetPositions, calibration_inquiry_generator,
-                                   get_task_info)
+                                   get_task_info, InquirySchedule)
 from bcipy.helpers.task import (alphabet, get_user_input, pause_calibration,
                                 trial_complete_message)
 from bcipy.helpers.triggers import TriggerHandler, TriggerType, Trigger, FlushFrequency, convert_timing_triggers
@@ -72,7 +72,7 @@ class MatrixCalibrationTask(Task):
         self.is_txt_stim = parameters['is_txt_stim']
         self.enable_breaks = parameters['enable_breaks']
 
-    def generate_stimuli(self):
+    def generate_stimuli(self) -> InquirySchedule:
         """Generates the inquiries to be presented.
         Returns:
         --------
@@ -81,16 +81,15 @@ class MatrixCalibrationTask(Task):
                 timing(list[list[float]]): list of timings
                 color(list(list[str])): list of colors)
         """
-        samples, timing, color = calibration_inquiry_generator(self.alp,
-                                                               stim_number=self.stim_number,
-                                                               stim_length=self.stim_length,
-                                                               stim_order=self.stim_order,
-                                                               target_positions=self.target_positions,
-                                                               nontarget_inquiries=self.nontarget_inquiries,
-                                                               timing=self.timing,
-                                                               color=self.color)
-
-        return (samples, timing, color)
+        return calibration_inquiry_generator(
+            self.alp,
+            stim_number=self.stim_number,
+            stim_length=self.stim_length,
+            stim_order=self.stim_order,
+            target_positions=self.target_positions,
+            nontarget_inquiries=self.nontarget_inquiries,
+            timing=self.timing,
+            color=self.color)
 
     def trigger_type(self, symbol: str, target: str, index: int) -> TriggerType:
         """Trigger Type.
@@ -160,7 +159,7 @@ class MatrixCalibrationTask(Task):
                 core.wait(self.buffer_val)
 
                 # Do the inquiry
-                timing, target = self.matrix.do_inquiry()
+                timing = self.matrix.do_inquiry()
 
                 # Write triggers for the inquiry
                 self.write_trigger_data(timing, (inquiry == 0))

--- a/bcipy/task/paradigm/matrix/calibration.py
+++ b/bcipy/task/paradigm/matrix/calibration.py
@@ -3,10 +3,12 @@ from typing import List, Tuple
 from psychopy import core
 
 from bcipy.config import TRIGGER_FILENAME, WAIT_SCREEN_MESSAGE
-from bcipy.display import InformationProperties, StimuliProperties, TaskDisplayProperties
-from bcipy.display.paradigm.matrix.mode.calibration import CalibrationDisplay
+from bcipy.display import Display, InformationProperties, StimuliProperties, TaskDisplayProperties
+from bcipy.display.paradigm.matrix.display import MatrixDisplay
 from bcipy.helpers.clock import Clock
-from bcipy.helpers.stimuli import (StimuliOrder, TargetPositions, calibration_inquiry_generator,
+from bcipy.helpers.stimuli import (DEFAULT_TEXT_FIXATION, StimuliOrder,
+                                   TargetPositions,
+                                   calibration_inquiry_generator,
                                    get_task_info, InquirySchedule)
 from bcipy.helpers.task import (alphabet, get_user_input, pause_calibration,
                                 trial_complete_message)
@@ -44,11 +46,7 @@ class MatrixCalibrationTask(Task):
         self.static_clock = core.StaticPeriod(screenHz=self.frame_rate)
         self.experiment_clock = Clock()
         self.buffer_val = parameters['task_buffer_length']
-        self.alp = alphabet(parameters)
-
-        self.matrix = init_calibration_display_task(
-            self.parameters, self.window,
-            self.static_clock, self.experiment_clock)
+        self.symbol_set = alphabet(parameters)
 
         self.file_save = file_save
         self.trigger_handler = TriggerHandler(
@@ -65,12 +63,23 @@ class MatrixCalibrationTask(Task):
         self.target_positions = TargetPositions(parameters['target_positions'])
         self.nontarget_inquiries = parameters['nontarget_inquiries']
 
-        self.timing = [parameters['time_flash']]
+        self.timing = [
+            parameters['time_prompt'], parameters['time_fixation'],
+            parameters['time_flash']
+        ]
         self.color = [parameters['stim_color']]
         self.task_info_color = parameters['task_color']
         self.stimuli_height = parameters['stim_height']
         self.is_txt_stim = parameters['is_txt_stim']
         self.enable_breaks = parameters['enable_breaks']
+
+        self.matrix = self.init_display()
+
+    def init_display(self) -> Display:
+        """Initialize the display"""
+        return init_calibration_display_task(self.parameters, self.window,
+                                             self.experiment_clock,
+                                             self.symbol_set)
 
     def generate_stimuli(self) -> InquirySchedule:
         """Generates the inquiries to be presented.
@@ -82,7 +91,7 @@ class MatrixCalibrationTask(Task):
                 color(list(list[str])): list of colors)
         """
         return calibration_inquiry_generator(
-            self.alp,
+            self.symbol_set,
             stim_number=self.stim_number,
             stim_length=self.stim_length,
             stim_order=self.stim_order,
@@ -99,6 +108,8 @@ class MatrixCalibrationTask(Task):
         """
         if index == 0:
             return TriggerType.PROMPT
+        if symbol == DEFAULT_TEXT_FIXATION:
+            return TriggerType.FIXATION
         if target == symbol:
             return TriggerType.TARGET
         return TriggerType.NONTARGET
@@ -128,7 +139,7 @@ class MatrixCalibrationTask(Task):
             (task_text, task_color) = get_task_info(self.stim_number,
                                                     self.task_info_color)
 
-            for inquiry in range(len(task_text)):
+            for inquiry, count_text in enumerate(task_text):
 
                 # check user input to make sure we should be going
                 if not get_user_input(self.matrix, self.wait_screen_message,
@@ -142,7 +153,7 @@ class MatrixCalibrationTask(Task):
 
                 # update task state
                 self.matrix.update_task_state(
-                    text=task_text[inquiry],
+                    text=count_text,
                     color_list=task_color[inquiry])
 
                 # Draw and flip screen
@@ -227,7 +238,7 @@ class MatrixCalibrationTask(Task):
 
 
 def init_calibration_display_task(
-        parameters, window, static_clock, experiment_clock):
+        parameters, window, experiment_clock, symbol_set):
     info = InformationProperties(
         info_color=[parameters['info_color']],
         info_pos=[(parameters['info_pos_x'],
@@ -252,13 +263,11 @@ def init_calibration_display_task(
         task_height=parameters['task_height'],
         task_text=''
     )
-    return CalibrationDisplay(
+    return MatrixDisplay(
         window,
-        static_clock,
         experiment_clock,
         stimuli,
         task_display,
         info,
         trigger_type=parameters['trigger_type'],
-        space_char=parameters['stim_space_char'],
-        full_screen=parameters['full_screen'])
+        symbol_set=symbol_set)

--- a/bcipy/task/paradigm/matrix/calibration.py
+++ b/bcipy/task/paradigm/matrix/calibration.py
@@ -67,7 +67,10 @@ class MatrixCalibrationTask(Task):
             parameters['time_prompt'], parameters['time_fixation'],
             parameters['time_flash']
         ]
-        self.color = [parameters['stim_color']]
+        self.color = [
+            parameters['target_color'], parameters['fixation_color'],
+            parameters['stim_color']
+        ]
         self.task_info_color = parameters['task_color']
         self.stimuli_height = parameters['stim_height']
         self.is_txt_stim = parameters['is_txt_stim']

--- a/bcipy/task/paradigm/matrix/copy_phrase.py
+++ b/bcipy/task/paradigm/matrix/copy_phrase.py
@@ -1,8 +1,7 @@
 """Defines the Copy Phrase Task which uses a Matrix display"""
 
 from bcipy.task.paradigm.rsvp.copy_phrase import RSVPCopyPhraseTask
-from bcipy.display import Display, InformationProperties, TaskDisplayProperties,\
-    StimuliProperties, PreviewInquiryProperties
+from bcipy.display import Display, InformationProperties, TaskDisplayProperties, StimuliProperties
 from bcipy.display.paradigm.matrix import MatrixDisplay
 
 
@@ -39,12 +38,11 @@ class MatrixCopyPhraseTask(RSVPCopyPhraseTask):
 
     def init_display(self) -> Display:
         """Initialize the Matrix display"""
-        return init_display(self.parameters, self.window, self.static_clock,
+        return init_display(self.parameters, self.window,
                             self.experiment_clock, self.spelled_text)
 
 
-def init_display(parameters, win, static_clock, experiment_clock,
-                 starting_spelled_text):
+def init_display(parameters, win, experiment_clock, starting_spelled_text):
     """Constructs a new Matrix display"""
     # preview_inquiry = PreviewInquiryProperties(
     #     preview_only=parameters['preview_only'],
@@ -53,22 +51,24 @@ def init_display(parameters, win, static_clock, experiment_clock,
     #     preview_inquiry_progress_method=parameters[
     #         'preview_inquiry_progress_method'],
     #     preview_inquiry_isi=parameters['preview_inquiry_isi'])
+
+    # Includes configured info as well as the copy phrase.
     info = InformationProperties(
-        info_color=[parameters['info_color']],
-        info_pos=[(parameters['info_pos_x'], parameters['info_pos_y'])],
-        info_height=[parameters['info_height']],
-        info_font=[parameters['font']],
-        info_text=[parameters['info_text']],
+        info_color=[parameters['info_color'], parameters['task_color']],
+        info_pos=[(parameters['info_pos_x'], parameters['info_pos_y']),
+                  (0, 1 - parameters['task_height'])],
+        info_height=[parameters['info_height'], parameters['info_height']],
+        info_font=[parameters['font'], parameters['font']],
+        info_text=[parameters['info_text'], parameters['task_text']],
     )
-    stimuli = StimuliProperties(
-        stim_font=parameters['font'],
-        stim_pos=(parameters['stim_pos_x'], parameters['stim_pos_y']),
-        stim_height=parameters['stim_height'],
-        stim_inquiry=['A'] * parameters['stim_length'],
-        stim_colors=[parameters['stim_color']] * parameters['stim_length'],
-        stim_timing=[10] * parameters['stim_length'],
-        is_txt_stim=parameters['is_txt_stim'],
-        prompt_time=parameters['time_prompt'])
+
+    stimuli = StimuliProperties(stim_font=parameters['font'],
+                                stim_pos=(parameters['stim_pos_x'],
+                                          parameters['stim_pos_y']),
+                                stim_height=parameters['stim_height'],
+                                is_txt_stim=parameters['is_txt_stim'],
+                                prompt_time=parameters['time_prompt'])
+
     padding = abs(len(parameters['task_text']) - len(starting_spelled_text))
     starting_spelled_text += ' ' * padding
     task_display = TaskDisplayProperties(
@@ -80,15 +80,10 @@ def init_display(parameters, win, static_clock, experiment_clock,
 
     return MatrixDisplay(
         win,
-        static_clock,
         experiment_clock,
         stimuli,
         task_display,
         info,
-        #  static_task_text=parameters['task_text'],
-        #  static_task_color=parameters['task_color'],
         trigger_type=parameters['trigger_type'],
-        space_char=parameters['stim_space_char'],
         #  preview_inquiry=preview_inquiry
-        should_prompt_target=False
-    )
+        should_prompt_target=False)

--- a/bcipy/task/paradigm/matrix/copy_phrase.py
+++ b/bcipy/task/paradigm/matrix/copy_phrase.py
@@ -1,0 +1,94 @@
+"""Defines the Copy Phrase Task which uses a Matrix display"""
+
+from bcipy.task.paradigm.rsvp.copy_phrase import RSVPCopyPhraseTask
+from bcipy.display import Display, InformationProperties, TaskDisplayProperties,\
+    StimuliProperties, PreviewInquiryProperties
+from bcipy.display.paradigm.matrix import MatrixDisplay
+
+
+class MatrixCopyPhraseTask(RSVPCopyPhraseTask):
+    """Matrix Copy Phrase Task.
+
+    Initializes and runs all needed code for executing a copy phrase task. A
+        phrase is set in parameters and necessary objects (daq, display) are
+        passed to this function.
+
+    Parameters
+    ----------
+        win : object,
+            display window to present visual stimuli.
+        daq : object,
+            data acquisition object initialized for the desired protocol
+        parameters : dict,
+            configuration details regarding the experiment. See parameters.json
+        file_save : str,
+            path location of where to save data from the session
+        signal_model : loaded pickle file,
+            trained signal model.
+        language_model: object,
+            trained language model.
+        fake : boolean, optional
+            boolean to indicate whether this is a fake session or not.
+    Returns
+    -------
+        file_save : str,
+            path location of where to save data from the session
+    """
+    TASK_NAME = 'Matrix Copy Phrase Task'
+    MODE = 'Matrix'
+
+    def init_display(self) -> Display:
+        """Initialize the Matrix display"""
+        return init_display(self.parameters, self.window, self.static_clock,
+                            self.experiment_clock, self.spelled_text)
+
+
+def init_display(parameters, win, static_clock, experiment_clock,
+                 starting_spelled_text):
+    """Constructs a new Matrix display"""
+    # preview_inquiry = PreviewInquiryProperties(
+    #     preview_only=parameters['preview_only'],
+    #     preview_inquiry_length=parameters['preview_inquiry_length'],
+    #     preview_inquiry_key_input=parameters['preview_inquiry_key_input'],
+    #     preview_inquiry_progress_method=parameters[
+    #         'preview_inquiry_progress_method'],
+    #     preview_inquiry_isi=parameters['preview_inquiry_isi'])
+    info = InformationProperties(
+        info_color=[parameters['info_color']],
+        info_pos=[(parameters['info_pos_x'], parameters['info_pos_y'])],
+        info_height=[parameters['info_height']],
+        info_font=[parameters['font']],
+        info_text=[parameters['info_text']],
+    )
+    stimuli = StimuliProperties(
+        stim_font=parameters['font'],
+        stim_pos=(parameters['stim_pos_x'], parameters['stim_pos_y']),
+        stim_height=parameters['stim_height'],
+        stim_inquiry=['A'] * parameters['stim_length'],
+        stim_colors=[parameters['stim_color']] * parameters['stim_length'],
+        stim_timing=[10] * parameters['stim_length'],
+        is_txt_stim=parameters['is_txt_stim'],
+        prompt_time=parameters['time_prompt'])
+    padding = abs(len(parameters['task_text']) - len(starting_spelled_text))
+    starting_spelled_text += ' ' * padding
+    task_display = TaskDisplayProperties(
+        task_color=[parameters['task_color']],
+        task_pos=(0, 1 - (2 * parameters['task_height'])),
+        task_font=parameters['font'],
+        task_height=parameters['task_height'],
+        task_text=starting_spelled_text)
+
+    return MatrixDisplay(
+        win,
+        static_clock,
+        experiment_clock,
+        stimuli,
+        task_display,
+        info,
+        #  static_task_text=parameters['task_text'],
+        #  static_task_color=parameters['task_color'],
+        trigger_type=parameters['trigger_type'],
+        space_char=parameters['stim_space_char'],
+        #  preview_inquiry=preview_inquiry
+        should_prompt_target=False
+    )

--- a/bcipy/task/paradigm/matrix/timing_verification.py
+++ b/bcipy/task/paradigm/matrix/timing_verification.py
@@ -25,9 +25,11 @@ class MatrixTimingVerificationCalibration(MatrixCalibrationTask):
 
     def init_display(self) -> Display:
         """Initialize the display"""
-        return init_calibration_display_task(
+        display = init_calibration_display_task(
             self.parameters, self.window, self.experiment_clock,
             symbols_with_photodiode_stim(self.symbol_set))
+        display.start_opacity = 0.0
+        return display
 
     def generate_stimuli(self) -> InquirySchedule:
         """Generates the inquiries to be presented.

--- a/bcipy/task/paradigm/matrix/timing_verification.py
+++ b/bcipy/task/paradigm/matrix/timing_verification.py
@@ -1,11 +1,13 @@
 from itertools import cycle
-from bcipy.task import Task
-from bcipy.task.paradigm.matrix.calibration import MatrixCalibrationTask
+from typing import List
+from bcipy.task.paradigm.matrix.calibration import (
+    MatrixCalibrationTask, InquirySchedule, DEFAULT_TEXT_FIXATION, Display,
+    init_calibration_display_task)
 from bcipy.helpers.stimuli import PhotoDiodeStimuli
 
 
-class MatrixTimingVerificationCalibration(Task):
-    """Matrix Calibration Task.
+class MatrixTimingVerificationCalibration(MatrixCalibrationTask):
+    """Matrix Timing Verification Task.
 
     This task is used for verifying display timing by alternating solid and empty boxes. These
         stimuli can be used with a photodiode to ensure accurate presentations.
@@ -21,62 +23,47 @@ class MatrixTimingVerificationCalibration(Task):
     """
     TASK_NAME = 'Matrix Timing Verification Task'
 
-    def __init__(self, win, daq, parameters, file_save):
-        super(MatrixTimingVerificationCalibration, self).__init__()
-        self._task = MatrixCalibrationTask(win, daq, parameters, file_save)
-        self.stimuli = PhotoDiodeStimuli.list()
-        self.create_testing_grid()
-        self._task.matrix.start_opacity = 0
-        self._task.matrix.full_grid_opacity = 0
-        self._task.matrix.grid_stimuli_height = 0.8
-        self._task.generate_stimuli = self.generate_stimuli
+    def init_display(self) -> Display:
+        """Initialize the display"""
+        return init_calibration_display_task(
+            self.parameters, self.window, self.experiment_clock,
+            symbols_with_photodiode_stim(self.symbol_set))
 
-    def create_testing_grid(self):
-        """Create Testing Grid.
-
-        To test timing, we require the photodiode stimuli to flicker at the rate used in the execute method. The middle
-            of the existing grid is replaced with the necessary stimuli.
-        """
-        mid = int(len(self._task.matrix.symbol_set) / 2)
-
-        for i, stim in enumerate(self.stimuli):
-            self._task.matrix.symbol_set[mid + i] = stim
-
-    def generate_stimuli(self):
+    def generate_stimuli(self) -> InquirySchedule:
         """Generates the inquiries to be presented.
-        Returns:
-        --------
-            tuple(
-                samples[list[list[str]]]: list of inquiries
-                timing(list[list[float]]): list of timings
-                color(list(list[str])): list of colors)
         """
         samples, times, colors = [], [], []
-        stimuli = cycle(self.stimuli)
+        [time_target, time_fixation, time_stim] = self.timing
+        stimuli = cycle(PhotoDiodeStimuli.list())
+
+        # advance iterator to start on the solid stim.
+        next(stimuli)
 
         # alternate between solid and empty boxes
-        time_stim = self._task.timing
-        color_stim = self._task.color
+        inq_stim = [PhotoDiodeStimuli.SOLID.value, DEFAULT_TEXT_FIXATION
+                    ] + [next(stimuli) for _ in range(self.stim_length)]
+        inq_times = [time_target, time_fixation
+                     ] + [time_stim] * self.stim_length
+        inq_colors = [self.color[0]] * (self.stim_length + 2)
 
-        inq_len = self._task.stim_length
-        inq_stim = [next(stimuli) for _ in range(inq_len)]
-        inq_times = [time_stim[0] for _ in range(inq_len)]
-        inq_colors = [color_stim[0] for _ in range(inq_len)]
-
-        for _ in range(self._task.stim_number):
+        for _ in range(self.stim_number):
             samples.append(inq_stim)
             times.append(inq_times)
             colors.append(inq_colors)
 
-        return (samples, times, colors)
+        return InquirySchedule(samples, times, colors)
 
-    def execute(self):
-        self.logger.debug(f'Starting {self.name()}!')
-        self._task.execute()
 
-    @classmethod
-    def label(cls):
-        return MatrixTimingVerificationCalibration.TASK_NAME
+def symbols_with_photodiode_stim(symbols: List[str]) -> List[str]:
+    """Stim symbols with the central letters swapped out for Photodiode stim.
+    """
+    mid = int(len(symbols) / 2)
 
-    def name(self):
-        return MatrixTimingVerificationCalibration.TASK_NAME
+    def sym_at_index(sym, index) -> str:
+        if index == mid:
+            return PhotoDiodeStimuli.SOLID.value
+        if index == mid + 1:
+            return PhotoDiodeStimuli.EMPTY.value
+        return sym
+
+    return [sym_at_index(sym, i) for i, sym in enumerate(symbols)]

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -7,6 +7,7 @@ from bcipy.config import (
     SESSION_DATA_FILENAME, TRIGGER_FILENAME, WAIT_SCREEN_MESSAGE, SESSION_SUMMARY_FILENAME)
 from bcipy.display import (InformationProperties, PreviewInquiryProperties,
                            StimuliProperties, TaskDisplayProperties)
+from bcipy.display import Display
 from bcipy.display.paradigm.rsvp.mode.copy_phrase import CopyPhraseDisplay
 from bcipy.feedback.visual.visual_feedback import VisualFeedback
 from bcipy.helpers.clock import Clock
@@ -76,6 +77,8 @@ class RSVPCopyPhraseTask(Task):
     """
 
     TASK_NAME = 'RSVP Copy Phrase Task'
+    MODE='RSVP'
+
     PARAMETERS_USED = [
         'time_fixation', 'time_flash', 'time_prompt', 'trial_length',
         'font', 'fixation_color', 'trigger_type',
@@ -150,12 +153,7 @@ class RSVPCopyPhraseTask(Task):
             }
         )
 
-        self.rsvp = _init_copy_phrase_display(
-            self.parameters,
-            self.window,
-            self.static_clock,
-            self.experiment_clock,
-            self.spelled_text)
+        self.rsvp = self.init_display()
 
     def setup(self) -> None:
         """Initialize/reset parameters used in the execute run loop."""
@@ -167,13 +165,20 @@ class RSVPCopyPhraseTask(Task):
         self.session = Session(
             save_location=self.file_save,
             task='Copy Phrase',
-            mode='RSVP',
+            mode=self.MODE,
             symbol_set=self.alp,
             decision_threshold=self.parameters['decision_threshold'])
         self.write_session_data()
 
         self.init_copy_phrase_task()
         self.current_inquiry = self.next_inquiry()
+
+    def init_display(self) -> Display:
+        """Initialize the display"""
+        return _init_copy_phrase_display(self.parameters, self.window,
+                                         self.static_clock,
+                                         self.experiment_clock,
+                                         self.spelled_text)
 
     def validate_parameters(self) -> None:
         """Validate.

--- a/bcipy/task/start_task.py
+++ b/bcipy/task/start_task.py
@@ -5,6 +5,7 @@ from bcipy.task.paradigm.rsvp.calibration.timing_verification import RSVPTimingV
 
 from bcipy.task.paradigm.matrix.calibration import MatrixCalibrationTask
 from bcipy.task.paradigm.matrix.timing_verification import MatrixTimingVerificationCalibration
+from bcipy.task.paradigm.matrix.copy_phrase import MatrixCopyPhraseTask
 
 from bcipy.task import Task
 from bcipy.task.exceptions import TaskRegistryException
@@ -50,6 +51,11 @@ def make_task(display_window, daq, task, parameters, file_save,
 
     if task is TaskType.MATRIX_TIMING_VERIFICATION_CALIBRATION:
         return MatrixTimingVerificationCalibration(display_window, daq, parameters, file_save)
+
+    if task is TaskType.MATRIX_COPY_PHRASE:
+        return MatrixCopyPhraseTask(
+            display_window, daq, parameters, file_save, signal_model,
+            language_model, fake=fake)
     raise TaskRegistryException(
         'The provided experiment type is not registered.')
 

--- a/bcipy/task/task_registry.py
+++ b/bcipy/task/task_registry.py
@@ -37,6 +37,7 @@ class TaskType(Enum):
     RSVP_TIMING_VERIFICATION_CALIBRATION = 'RSVP Time Test Calibration'
     MATRIX_CALIBRATION = 'Matrix Calibration'
     MATRIX_TIMING_VERIFICATION_CALIBRATION = 'Matrix Time Test Calibration'
+    MATRIX_COPY_PHRASE = 'Matrix Copy Phrase'
 
     def __new__(cls, *args, **kwds):
         """Autoincrements the value of each item added to the enum."""

--- a/scripts/python/offset_analysis.py
+++ b/scripts/python/offset_analysis.py
@@ -1,0 +1,228 @@
+"""GUI tool to visualize offset analysis when analyzing system latency."""
+from pathlib import Path
+from textwrap import wrap
+from typing import List
+
+import matplotlib.pyplot as plt
+import numpy as np
+from scipy.stats import describe, normaltest
+
+from bcipy.gui.file_dialog import ask_directory
+from bcipy.helpers.raw_data import RawData, load
+
+ALLOWABLE_TOLERANCE = 0.01
+RSVP = False
+
+
+def clock_seconds(sample_rate: float, sample: int) -> float:
+    """Convert the given raw_data sample number to acquisition clock
+    seconds."""
+    assert sample > 0
+    return sample / sample_rate
+
+
+def calculate_latency(raw_data: RawData,
+                      triggers: List[tuple],
+                      title: str = "",
+                      recommend_static: bool = False,
+                      plot: bool = False):
+    """Plot raw_data triggers, including the TRG_device_stream data
+    (channel streamed from the device; usually populated from a trigger box),
+    as well as TRG data populated from the LSL Marker Stream. Also plots data
+    from the triggers.txt file if available.
+
+    Parameters:
+    -----------
+        raw_data - complete list of samples read in from the raw_data.csv file.
+        triggers - list of (trg, trg_type, stamp) values from the triggers.txt
+            file. Stamps have been converted to the acquisition clock using
+            the offset recorded in the triggers.txt.
+    """
+
+    fig = plt.figure()
+    ax = fig.add_subplot(1, 1, 1)
+    plt.xlabel('acquisition clock (secs)')
+    plt.ylabel('TRG value')
+    if title:
+        plt.title("\n".join(wrap(title, 50)))
+
+    # Plot TRG column; this is a continuous line with >0 indicating light.
+    trg_box_channel = raw_data.dataframe['TRG']
+    trg_box_y = []
+    trg_ymax = 1.5
+    trg_box_x = []
+
+    # setup some analysis variable
+    diode_enc = False
+    starts = []
+    lengths = []
+    length = 0
+
+    for i, val in enumerate(trg_box_channel):
+        timestamp = clock_seconds(raw_data.sample_rate, i + 1)
+        value = int(float(val))
+        trg_box_x.append(timestamp)
+        trg_box_y.append(value)
+
+        if value > 0 and not diode_enc:
+            diode_enc = True
+            starts.append(timestamp)
+
+        if value > 0 and diode_enc:
+            length += 0
+
+        if value < 1 and diode_enc:
+            diode_enc = False
+            lengths.append(length)
+            length = 0
+        # else:
+        #     print('Fail')
+
+    ax.plot(trg_box_x, trg_box_y, label='TRG (trigger box)')
+
+    # Plot triggers.txt data if present; vertical line for each value.
+    if triggers:
+        trigger_diodes_timestamps = [
+            stamp for (_name, _trgtype, stamp) in triggers if _name == '\u25A0'
+        ]
+        plt.vlines(trigger_diodes_timestamps,
+                   ymin=-1.0,
+                   ymax=trg_ymax,
+                   label='triggers.txt (adjusted)',
+                   linewidth=0.5,
+                   color='cyan')
+
+    errors = []
+    diffs = []
+    x = 0
+    if (len(starts) > len(trigger_diodes_timestamps)):
+        len_diff = len(starts) - len(trigger_diodes_timestamps)
+        starts = starts[len_diff:]
+
+    for trigger_stamp, diode_stamp in zip(trigger_diodes_timestamps, starts):
+        diff = trigger_stamp - diode_stamp
+
+        # rsvp bug with fixation
+        if RSVP:
+            if x > 0:
+                if abs(diff) > ALLOWABLE_TOLERANCE:
+                    errors.append(
+                        f'trigger={trigger_stamp} diode={diode_stamp} diff={diff}'
+                    )
+                diffs.append(diff)
+            if x == 4:
+                x = 0
+            else:
+                x += 1
+        else:
+            if abs(diff) > ALLOWABLE_TOLERANCE:
+                errors.append(
+                    f'trigger={trigger_stamp} diode={diode_stamp} diff={diff}')
+            diffs.append(diff)
+
+    if recommend_static:
+        # test for normality
+        _, p_value = normaltest(diffs)
+        print(f'{describe(diffs)}')
+
+        # if it's not normal, take the median
+        if p_value < 0.05:
+            print('Non-normal distribution')
+        recommended_static = abs(np.median(diffs))
+        print(
+            f'System recommended static offset median=[{recommended_static}]')
+        recommended_static = abs(np.mean(diffs))
+        print(f'System recommended static offset mean=[{recommended_static}]')
+
+    else:
+        if errors:
+            num_errors = len(errors)
+            print(
+                f'RESULTS: Allowable tolerance between triggers and photodiode exceeded. {errors}'
+                f'Number of violations: {num_errors}')
+        else:
+            print(
+                f'RESULTS: Triggers and photodiode timestamps within limit of [{ALLOWABLE_TOLERANCE}s]!'
+            )
+
+    # Add labels for TRGs
+    first_trg = trigger_diodes_timestamps[0]
+
+    # Set initial zoom to +-5 seconds around the calibration_trigger
+    if first_trg:
+        ax.set_xlim(left=first_trg - 5, right=first_trg + 5)
+
+    ax.grid(axis='x', linestyle='--', color="0.5", linewidth=0.4)
+    plt.legend(loc='lower left', fontsize='small')
+    # display the plot
+    if plot:
+        plt.show()
+
+
+def read_triggers(triggers_file: str, static_offset: float):
+    """Read in the triggers.txt file. Convert the timestamps to be in
+    aqcuisition clock units using the offset listed in the file (last entry).
+    Returns:
+    --------
+        list of (symbol, targetness, stamp) tuples."""
+
+    with open(triggers_file, encoding='utf-8') as trgfile:
+        records = [line.split(' ') for line in trgfile.readlines()]
+        (_cname, _ctype, cstamp) = records[0]
+        records.pop(0)
+        # (_acq_name, _acq_type, acq_stamp) = records[-1]
+        offset = float(cstamp) + static_offset
+
+        corrected = []
+        for i, (name, trg_type, stamp) in enumerate(records):
+            if i < len(records) - 1:
+                # omit offset record for plotting
+                corrected.append((name, trg_type, float(stamp) + offset))
+        return corrected
+
+
+def main(data_dir: str, recommend: bool = False, static_offset: float = 0.105):
+    """Run the viewer gui
+
+    Parameters:
+    -----------
+        data_dir - path to the data directory, containing raw_data.csv and triggers.txt
+        recommend - whether to recommend a static offset. If True, plots are not displayed.
+        static_offset - fixed offset applied to triggers for plotting and analysis.
+    """
+    if recommend:
+        static_offset = 0.0
+    raw_data = load(Path(data_dir, 'raw_data.csv'))
+    triggers = read_triggers(Path(data_dir, 'triggers.txt'), static_offset)
+
+    calculate_latency(raw_data,
+                      triggers,
+                      title=Path(data_dir).name,
+                      recommend_static=recommend,
+                      plot=not recommend)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description=
+        "Graphs trigger data from a bcipy session to visualize system latency")
+    parser.add_argument('-p',
+                        '--path',
+                        help='path to the data directory',
+                        default=None)
+    parser.add_argument('-r',
+                        '--recommend',
+                        help='flag used for recommending a static offset. If set, plots are not displayed',
+                        action='store_true')
+    parser.add_argument('--offset',
+                        help='static offset applied to triggers for plotting and analysis',
+                        default=0.105)
+
+    args = parser.parse_args()
+    path = args.path
+    if not path:
+        path = ask_directory()
+
+    main(path, bool(args.recommend), float(args.offset))


### PR DESCRIPTION
# Overview

Added a Matrix Copy Phrase Task.

## Ticket

https://www.pivotaltracker.com/story/show/180699453

## Contributions

- Refactored Copy Phrase Task:
     - Use display methods rather than directly writing to properties.
     - Pass paradigm to session data.
- Created new Matrix Copy Phrase Task, which subclasses RSVP Copy Phrase.
- Matrix Display Refactors:
    - Removed unused variables.
    - Eliminated redundant creation of TextStim elements which affects screen draw time.
    - Use configured parameters for pause length, rather than hardcoded values.
    - Added configuration to distinguish between inquiries that display the target and those that don't.
    - Simplified trigger handling.
    - Converted fixation display to be rendered as the entire matrix with all elements highlighted.
- Fixed bugs in demo code.
- Fixed display issues with matrix timing task.
- Documented display parameters required for Matrix tasks that differ from RSVP.

## Test

- Ran all unit tests.
- Ran matrix demos.
- Ran Matrix Calibration Task.
- Using the model from the offline analysis, ran the Matrix Copy Phrase task.
- Confirmed the session data was generated correctly.
- Confirmed the appropriate trigger data was generated.
- Ran the Matrix Timing Task.

https://user-images.githubusercontent.com/2153447/211689840-4c4a4d5e-4c62-4255-9bf6-b9a3c26537ba.mov


