### PR TITLE
Fix Windows Builds (pin pygame version)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ transformers==4.15.0
 torch==1.10.1
 construct==2.8.14
 mne==1.0.2
+pygame==2.1.2
 pyglet<=1.5.27,>=1.4
 PsychoPy==2021.2.3
 openpyxl==2.6.3


### PR DESCRIPTION
# Overview

Pin pygame version to prevent build failure on Windows. 

## Ticket

https://www.pivotaltracker.com/story/show/184488213

## Contributions

- pin pygame to 2.1.2 (a requirement of PsychoPy- we use pyglet as the window backend)

## Test

- `make test-all`

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.

## Changelog

- Is the CHANGELOG.md updated with your detailed changes?
