### PR TITLE
Device channel specs

### DIFF
--- a/bcipy/acquisition/datastream/lsl_server.py
+++ b/bcipy/acquisition/datastream/lsl_server.py
@@ -26,7 +26,7 @@ class LslDataServer(StoppableThread):
     using pylsl. See https://github.com/sccn/labstreaminglayer/wiki.
 
     In parameters.json, if the fake_data parameter is set to true and the
-    device is set to LSL, this server will be used to mock data. Alternatively,
+    device is set to DSI-24, this server will be used to mock data. Alternatively,
     fake_data can be set to false and this module can be run standalone in its
     own python instance.
 
@@ -181,7 +181,7 @@ def main():
                         help="file containing data to be streamed; "
                         "if missing, random data will be served.")
     parser.add_argument('-m', '--markers', action="store_true", default=False)
-    parser.add_argument('-n', '--name', default='LSL', help='Name of the device spec to mock.')
+    parser.add_argument('-n', '--name', default='DSI-24', help='Name of the device spec to mock.')
     args = parser.parse_args()
 
     if args.filename:

--- a/bcipy/acquisition/demo/demo_lsl_acq_client.py
+++ b/bcipy/acquisition/demo/demo_lsl_acq_client.py
@@ -12,7 +12,7 @@ def main():
     The client can be stopped with a Keyboard Interrupt (Ctl-C)."""
 
     # Start the server with the command:
-    # python bcipy/acquisition/datastream/lsl_server.py --name LSL
+    # python bcipy/acquisition/datastream/lsl_server.py --name 'DSI-24'
 
     client = LslAcquisitionClient(max_buffer_len=1, save_directory='.')
 

--- a/bcipy/acquisition/demo/demo_lsl_server.py
+++ b/bcipy/acquisition/demo/demo_lsl_server.py
@@ -16,7 +16,7 @@ def main():
 
     parser.add_argument('-n',
                         '--name',
-                        default='LSL',
+                        default='DSI-24',
                         help='Name of the device spec to mock.')
     args = parser.parse_args()
     device_spec = preconfigured_device(args.name)

--- a/bcipy/acquisition/tests/protocols/lsl/test_lsl_client.py
+++ b/bcipy/acquisition/tests/protocols/lsl/test_lsl_client.py
@@ -13,7 +13,7 @@ from bcipy.acquisition.devices import (IRREGULAR_RATE, DeviceSpec,
 from bcipy.acquisition.protocols.lsl.lsl_client import LslAcquisitionClient
 from bcipy.helpers.clock import Clock
 
-DEVICE_NAME = 'DSI'
+DEVICE_NAME = 'DSI-24'
 DEVICE = preconfigured_device(DEVICE_NAME)
 
 
@@ -51,7 +51,7 @@ class TestDataAcquisitionClient(unittest.TestCase):
     def test_specified_device_wrong_channels(self):
         """Should throw an exception if channels don't match metadata."""
         client = LslAcquisitionClient(max_buffer_len=1,
-                                      device_spec=preconfigured_device('LSL'))
+                                      device_spec=preconfigured_device('DSI-VR300'))
 
         with self.assertRaises(Exception):
             client.start_acquisition()

--- a/bcipy/acquisition/tests/protocols/lsl/test_lsl_recorder.py
+++ b/bcipy/acquisition/tests/protocols/lsl/test_lsl_recorder.py
@@ -12,7 +12,7 @@ from bcipy.acquisition.devices import preconfigured_device
 from bcipy.acquisition.protocols.lsl.lsl_recorder import LslRecorder
 from bcipy.helpers.raw_data import TIMESTAMP_COLUMN, load
 
-DEVICE_NAME = 'DSI'
+DEVICE_NAME = 'DSI-24'
 DEVICE = preconfigured_device(DEVICE_NAME)
 
 

--- a/bcipy/acquisition/tests/test_devices.py
+++ b/bcipy/acquisition/tests/test_devices.py
@@ -22,10 +22,9 @@ class TestDeviceSpecs(unittest.TestCase):
         backwards compatibility."""
         supported = devices.preconfigured_devices()
         self.assertTrue(len(supported.keys()) > 0)
-        self.assertTrue('LSL' in supported.keys())
-        self.assertTrue('DSI' in supported.keys())
+        self.assertTrue('DSI-24' in supported.keys())
 
-        dsi = supported['DSI']
+        dsi = supported['DSI-24']
         self.assertEqual('EEG', dsi.content_type)
 
     def test_load_from_config(self):
@@ -120,8 +119,8 @@ class TestDeviceSpecs(unittest.TestCase):
 
     def test_search_by_name(self):
         """Should be able to find a supported device by name."""
-        dsi_device = devices.preconfigured_device('DSI')
-        self.assertEqual('DSI', dsi_device.name)
+        dsi_device = devices.preconfigured_device('DSI-24')
+        self.assertEqual('DSI-24', dsi_device.name)
 
     def test_device_spec_defaults(self):
         """DeviceSpec should require minimal information with default values."""

--- a/bcipy/gui/viewer/demo/viewer_demo.py
+++ b/bcipy/gui/viewer/demo/viewer_demo.py
@@ -13,7 +13,7 @@ def main():
     from bcipy.acquisition.devices import preconfigured_device
     from bcipy.gui.viewer import data_viewer
 
-    device_spec = preconfigured_device('LSL')
+    device_spec = preconfigured_device('DSI-VR300')
     server = LslDataServer(device_spec=device_spec)
 
     try:

--- a/bcipy/helpers/copy_phrase_wrapper.py
+++ b/bcipy/helpers/copy_phrase_wrapper.py
@@ -84,7 +84,7 @@ class CopyPhraseWrapper:
                  task_list: List[Tuple[str, str]] = [('I_LOVE_COOKIES',
                                                       'I_LOVE_')],
                  is_txt_stim: bool = True,
-                 device_name: str = 'LSL',
+                 device_name: str = 'DSI-24',
                  device_channels: List[str] = None,
                  decision_threshold: float = 0.8,
                  backspace_prob: float = 0.05,

--- a/bcipy/helpers/tests/test_acquisition.py
+++ b/bcipy/helpers/tests/test_acquisition.py
@@ -31,7 +31,7 @@ class TestAcquisition(unittest.TestCase):
 
     def test_default_values(self):
         """Test default values."""
-        self.parameters['acq_device'] = 'DSI'
+        self.parameters['acq_device'] = 'DSI-24'
 
         client, server = init_eeg_acquisition(self.parameters,
                                               self.save,

--- a/bcipy/parameters/devices.json
+++ b/bcipy/parameters/devices.json
@@ -2,8 +2,32 @@
     {
         "name": "DSI-24",
         "content_type": "EEG",
-        "channels": [ "P3", "C3", "F3", "Fz", "F4", "C4", "P4", "Cz", "Pz", "Fp1", "Fp2", "T3",
-            "T5", "O1", "O2", "X3", "X2", "F7", "F8", "X1", "A2", "T6", "T4", "TRG" ],
+        "channels": [
+            { "name": "P3", "label": "P3", "units": "microvolts", "type": "EEG" },
+            { "name": "C3", "label": "C3", "units": "microvolts", "type": "EEG" },
+            { "name": "F3", "label": "F3", "units": "microvolts", "type": "EEG" },
+            { "name": "Fz", "label": "Fz", "units": "microvolts", "type": "EEG" },
+            { "name": "F4", "label": "F4", "units": "microvolts", "type": "EEG" },
+            { "name": "C4", "label": "C4", "units": "microvolts", "type": "EEG" },
+            { "name": "P4", "label": "P4", "units": "microvolts", "type": "EEG" },
+            { "name": "Cz", "label": "Cz", "units": "microvolts", "type": "EEG" },
+            { "name": "Pz", "label": "Pz", "units": "microvolts", "type": "EEG" },
+            { "name": "Fp1", "label": "Fp1", "units": "microvolts", "type": "EEG" },
+            { "name": "Fp2", "label": "Fp2", "units": "microvolts", "type": "EEG" },
+            { "name": "T3", "label": "T3", "units": "microvolts", "type": "EEG" },
+            { "name": "T5", "label": "T5", "units": "microvolts", "type": "EEG" },
+            { "name": "O1", "label": "O1", "units": "microvolts", "type": "EEG" },
+            { "name": "O2", "label": "O2", "units": "microvolts", "type": "EEG" },
+            { "name": "X3", "label": "X3", "units": "microvolts", "type": "EEG" },
+            { "name": "X2", "label": "X2", "units": "microvolts", "type": "EEG" },
+            { "name": "F7", "label": "F7", "units": "microvolts", "type": "EEG" },
+            { "name": "F8", "label": "F8", "units": "microvolts", "type": "EEG" },
+            { "name": "X1", "label": "X1", "units": "microvolts", "type": "EEG" },
+            { "name": "A2", "label": "A2", "units": "microvolts", "type": "EEG" },
+            { "name": "T6", "label": "T6", "units": "microvolts", "type": "EEG" },
+            { "name": "T4", "label": "T4", "units": "microvolts", "type": "EEG" },
+            { "name": "TRG", "label": "TRG", "units": "microvolts", "type": "EEG "}
+        ],
         "sample_rate": 300.0,
         "description": "Wearable Sensing DSI-24",
         "excluded_from_analysis": ["TRG", "X1", "X2", "X3", "A2"]
@@ -11,7 +35,16 @@
     {
         "name": "DSI-VR300",
         "content_type": "EEG",
-        "channels": [ "P4", "Fz", "Pz", "F7", "PO8", "PO7", "Oz", "TRG" ],
+        "channels": [
+            { "name": "P4", "label": "P4", "units": "microvolts", "type": "EEG" },
+            { "name": "Fz", "label": "Fz", "units": "microvolts", "type": "EEG" },
+            { "name": "Pz", "label": "Pz", "units": "microvolts", "type": "EEG" },
+            { "name": "F7", "label": "F7", "units": "microvolts", "type": "EEG" },
+            { "name": "PO8", "label": "PO8", "units": "microvolts", "type": "EEG" },
+            { "name": "PO7", "label": "PO7", "units": "microvolts", "type": "EEG" },
+            { "name": "Oz", "label": "Oz", "units": "microvolts", "type": "EEG" },
+            { "name": "TRG", "label": "TRG", "units": "microvolts", "type": "EEG" }
+        ],
         "sample_rate": 300.0,
         "description": "Wearable Sensing DSI-VR300",
         "excluded_from_analysis": ["TRG"]
@@ -19,27 +52,26 @@
     {
         "name": "g.USBamp-1",
         "content_type": "EEG",
-        "channels": [ "Ch1", "Ch2", "Ch3", "Ch4", "Ch5", "Ch6",  "Ch7", "Ch8",
-            "Ch9", "Ch10", "Ch11", "Ch12", "Ch13", "Ch14", "Ch15", "Ch16" ],
+        "channels": [
+            { "name": "Ch1", "label": "Ch1", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch2", "label": "Ch2", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch3", "label": "Ch3", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch4", "label": "Ch4", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch5", "label": "Ch5", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch6", "label": "Ch6", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch7", "label": "Ch7", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch8", "label": "Ch8", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch9", "label": "Ch9", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch10", "label": "Ch10", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch11", "label": "Ch11", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch12", "label": "Ch12", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch13", "label": "Ch13", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch14", "label": "Ch14", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch15", "label": "Ch15", "units": "microvolts", "type": "EEG" },
+            { "name": "Ch16", "label": "Ch16", "units": "microvolts", "type": "EEG" }
+        ],
         "sample_rate": 256.0,
         "description": "GTec g.USBamp"
-    },
-    {
-        "name": "DSI",
-        "content_type": "EEG",
-        "channels": [ "P3", "C3", "F3", "Fz", "F4", "C4", "P4", "Cz", "Pz", "Fp1", "Fp2", "T3",
-            "T5", "O1", "O2", "X3", "X2", "F7", "F8", "X1", "A2", "T6", "T4", "TRG" ],
-        "sample_rate": 300.0,
-        "description": "Alias to DSI-24 for backwards compatibility and demos.",
-        "excluded_from_analysis": ["TRG", "X1", "X2", "X3", "A2"]
-    },
-    {
-        "name": "LSL",
-        "content_type": "EEG",
-        "channels": [ "ch1", "ch2", "ch3", "ch4", "ch5", "ch6",  "ch7", "ch8",
-            "ch9", "ch10", "ch11", "ch12", "ch13", "ch14", "ch15", "ch16" ],
-        "sample_rate": 256.0,
-        "description": "Alias to GTec g.USBamp for backwards compatibility and demos."
     },
     {
         "name": "Tobii Nano",
@@ -47,13 +79,5 @@
         "channels": ["device_ts", "system_ts", "left_x", "left_y", "left_pupil", "right_x" , "right_y", "right_pupil" ],
         "sample_rate": 60.0,
         "description": "Tobii Nano. For use with the Tobii Pro SDK."
-    },
-    {
-        "name": "DSI_VR300",
-        "content_type": "EEG",
-        "channels": [ "P4", "Fz", "Pz", "F7", "PO8", "PO7", "Oz", "TRG" ],
-        "sample_rate": 300.0,
-        "description": "Alias to DSI-VR300 for backwards compatibility.",
-        "excluded_from_analysis": ["TRG"]
     }
 ]

--- a/bcipy/parameters/devices.json
+++ b/bcipy/parameters/devices.json
@@ -76,7 +76,16 @@
     {
         "name": "Tobii Nano",
         "content_type": "Eyetracker",
-        "channels": ["device_ts", "system_ts", "left_x", "left_y", "left_pupil", "right_x" , "right_y", "right_pupil" ],
+        "channels": [
+            { "name": "device_ts", "label": "device_ts" },
+            { "name": "system_ts", "label": "system_ts" },
+            { "name": "left_x", "label": "left_x", "units": "screencoords", "type": "ScreenX" },
+            { "name": "left_y", "label": "left_y", "units": "screencoords", "type": "ScreenY" },
+            { "name": "left_pupil", "label": "left_pupil", "type": "pupilsize" },
+            { "name": "right_x", "label": "right_x", "units": "screencoords", "type": "ScreenX" },
+            { "name": "right_y", "label": "right_y", "units": "screencoords", "type": "ScreenY" },
+            { "name": "right_pupil", "label": "right_pupil", "type": "pupilsize" }
+        ],
         "sample_rate": 60.0,
         "description": "Tobii Nano. For use with the Tobii Pro SDK."
     }


### PR DESCRIPTION
# Overview

Set channel spec information in devices.json. Removed aliases.

## Ticket

https://www.pivotaltracker.com/story/show/182849439

## Contributions

- Updated devices.json to include channel spec information.
- Removed devices that were aliases.
- Updated code that was using the alias devices.

## Test

- Ran unit tests and demos.
- Ran an RSVP Calibration using streamed data.
