### PR TITLE
Filter updates and small fixes to offline analysis

### DIFF
--- a/bcipy/helpers/raw_data.py
+++ b/bcipy/helpers/raw_data.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 
 from bcipy.config import DEFAULT_ENCODING
+from bcipy.helpers.exceptions import BciPyCoreException
 from bcipy.signal.generator.generator import gen_random_data
 from bcipy.signal.process import Composition
 
@@ -310,12 +311,15 @@ def load(filename: str) -> RawData:
     """
     # Loading all data from a csv is faster using pandas than using the
     # RawDataReader.
-    with open(filename, mode='r', encoding=DEFAULT_ENCODING) as file_obj:
-        daq_type, sample_rate = read_metadata(file_obj)
-        dataframe = pd.read_csv(file_obj)
-        data = RawData(daq_type, sample_rate, list(dataframe.columns))
-        data.rows = dataframe.values.tolist()
-        return data
+    try:
+        with open(filename, mode='r', encoding=DEFAULT_ENCODING) as file_obj:
+            daq_type, sample_rate = read_metadata(file_obj)
+            dataframe = pd.read_csv(file_obj)
+            data = RawData(daq_type, sample_rate, list(dataframe.columns))
+            data.rows = dataframe.values.tolist()
+            return data
+    except FileNotFoundError:
+        raise BciPyCoreException(f"\nError loading BciPy RawData. Valid data not found at: {filename}")
 
 
 def read_metadata(file_obj: TextIO) -> Tuple[str, float]:

--- a/bcipy/helpers/tests/test_raw_data.py
+++ b/bcipy/helpers/tests/test_raw_data.py
@@ -10,6 +10,7 @@ import pandas as pd
 
 from mockito import any, mock, when, verify, unstub
 
+from bcipy.helpers.exceptions import BciPyCoreException
 from bcipy.helpers.raw_data import (RawData, RawDataReader, RawDataWriter,
                                     load, sample_data, settings, write)
 
@@ -95,6 +96,12 @@ class TestRawData(unittest.TestCase):
         self.assertEqual(loaded_data.rows[0], self.row1)
         self.assertEqual(loaded_data.rows[1], self.row2)
         self.assertEqual(loaded_data.rows[2], self.row3)
+
+    def test_load_with_invalid_filepath(self):
+        """Test that an exception is raised when an invalid file is loaded."""
+        with self.assertRaises(BciPyCoreException):
+            path = "invalid/path/to/file.csv"
+            load(path)
 
     def test_deserialization(self):
         """Test that the load function can be accessed through a class

--- a/bcipy/signal/process/filter.py
+++ b/bcipy/signal/process/filter.py
@@ -1,7 +1,7 @@
 from typing import Optional, Tuple
 
 import numpy as np
-from scipy.signal import butter, filtfilt, iirnotch, sosfilt
+from scipy.signal import butter, filtfilt, iirnotch, sosfiltfilt
 
 
 class Notch:
@@ -24,7 +24,7 @@ class Bandpass:
         self.sos = butter(order, [lo, hi], analog=False, btype="band", output="sos")
 
     def __call__(self, data: np.ndarray, fs: Optional[int] = None) -> Tuple[np.ndarray, int]:
-        return sosfilt(self.sos, data), fs
+        return sosfiltfilt(self.sos, data), fs
 
 
 def filter_inquiries(inquiries, transform, sample_rate) -> Tuple[np.ndarray, float]:


### PR DESCRIPTION
# Overview

Update the BciPy default filter to sosfiltfilt, which will perform better than sosfilt. Update integration tests to use valid device name (DSI-24). Update load method to catch file not found error stacktrace and alert user. 

## Ticket

[Link a pivotal ticket here
](https://www.pivotaltracker.com/story/show/183840733)

## Contributions

- `signal/process/filter.py`: update to use `sosfiltfilt` https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.sosfiltfilt.html
- `helpers/raw_data.py`: update load to catch FileNotFoundError and return BciPyCoreException describing the issue
- `signal/test/model/input` update the raw_data.csv file header with a registered device name

## Test

- `Make test-all`
- Run signal model integration tests
- Run offline analysis on collected data: It improved AUC slightly in my testing and changed the direction of ERP near the end of the response. 

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? M/A

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? TODO
