### PR TITLE
add Tobii / PsychoPy display convert methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,9 @@
     - Missing inits and lock some dependencies #258 Fix Windows Builds (pin pygame version) #265 Fix Mac Os Builds (pin pyo version) #432
     - Update cross_validation.py #271
 - Documentation
-    - Update README.md with correct installation instructions for development requirements #263
-    - Update README.md with new language model installation instructions #268
+    - Update README.md with correct installation instructions for development requirements #263 and new language model installation instructions #268
+- Misc Features!
+    - Add `tobii_to_norm` and `norm_to_tobii` methods to `helpers/convert.py` #278
 
 # 2.0.1-rc.2
 

--- a/bcipy/helpers/convert.py
+++ b/bcipy/helpers/convert.py
@@ -536,3 +536,50 @@ def convert_to_mne(
         mne_data = mne_data.apply_function(lambda x: x * 1e-6)
 
     return mne_data
+
+
+def tobii_to_norm(tobii_units: Tuple[float, float]) -> Tuple[float, float]:
+    """Tobii to PsychoPy's 'norm' units.
+
+    https://developer.tobiipro.com/commonconcepts/coordinatesystems.html
+    https://www.psychopy.org/general/units.html
+
+    Tobii uses an Active Display Coordinate System.
+        The point (0, 0) denotes the upper left corner and (1, 1) the lower right corner of it.
+
+    PsychoPy uses several coordinate systems, the normalized window unit is assumed here.
+        The point (0, 0) denotes the center of the screen and (-1, -1) the upper left corner
+        and (1, 1) the lower right corner.
+
+    """
+    # check that Tobii units are within the expected range
+    assert 0 <= tobii_units[0] <= 1, "Tobii x coordinate must be between 0 and 1"
+    assert 0 <= tobii_units[1] <= 1, "Tobii y coordinate must be between 0 and 1"
+
+    # convert Tobii units to Psychopy units
+    norm_x = (tobii_units[0] - 0.5) * 2
+    norm_y = (tobii_units[1] - 0.5) * 2 * -1
+    return (norm_x, norm_y)
+
+
+def norm_to_tobii(norm_units: Tuple[float, float]) -> Tuple[float, float]:
+    """PsychoPy's 'norm' units to Tobii.
+
+    https://developer.tobiipro.com/commonconcepts/coordinatesystems.html
+    https://www.psychopy.org/general/units.html
+
+    Tobii uses an Active Display Coordinate System.
+        The point (0, 0) denotes the upper left corner and (1, 1) the lower right corner of it.
+
+    PsychoPy uses several coordinate systems, the normalized window unit is assumed here.
+        The point (0, 0) denotes the center of the screen and (-1, -1) the upper left corner
+        and (1, 1) the lower right corner.
+    """
+    # check that the coordinates are within the bounds of the screen
+    assert norm_units[0] >= -1 and norm_units[0] <= 1, "X coordinate must be between -1 and 1"
+    assert norm_units[1] >= -1 and norm_units[1] <= 1, "Y coordinate must be between -1 and 1"
+
+    # convert PsychoPy norm units to Tobii units
+    tobii_x = (norm_units[0] / 2) + 0.5
+    tobii_y = ((norm_units[1] * -1) / 2) + 0.5
+    return (tobii_x, tobii_y)

--- a/bcipy/helpers/tests/test_convert.py
+++ b/bcipy/helpers/tests/test_convert.py
@@ -20,6 +20,8 @@ from bcipy.helpers.convert import (
     convert_to_mne,
     decompress,
     pyedf_convert,
+    tobii_to_norm,
+    norm_to_tobii,
 )
 from bcipy.helpers.parameters import Parameters
 from bcipy.helpers.raw_data import sample_data, write, RawData
@@ -624,6 +626,64 @@ class TestCompressionSupport(unittest.TestCase):
         compress(self.tar_file_name, [self.test_file_name])
         tar_list = archive_list(self.tar_file_full_name)
         self.assertTrue(tar_list[0] == self.test_file_name)
+
+
+class TestConvertTobii(unittest.TestCase):
+
+    def test_tobii_to_norm(self):
+        """Test the tobii_to_norm function"""
+        tobii_data = (0.5, 0.5)  # center of screen in tobii coordinates
+        excepted_norm_data = (0, 0)  # center of screen in norm coordinates
+        norm_data = tobii_to_norm(tobii_data)
+        self.assertEqual(norm_data, excepted_norm_data)
+
+        tobii_data = (0, 0)  # top left of screen in tobii coordinates
+        excepted_norm_data = (-1, 1)  # top left of screen in norm coordinates
+        norm_data = tobii_to_norm(tobii_data)
+        self.assertEqual(norm_data, excepted_norm_data)
+
+        tobii_data = (1, 1)  # bottom right of screen in tobii coordinates
+        excepted_norm_data = (1, -1)  # bottom right of screen in norm coordinates
+        norm_data = tobii_to_norm(tobii_data)
+        self.assertEqual(norm_data, excepted_norm_data)
+
+    def test_tobii_to_norm_raises_error_with_invalid_units(self):
+        """Test the tobii_to_norm function raises an error with invalid units"""
+        tobii_data = (-1, 1)  # invalid tobii coordinates
+        with self.assertRaises(AssertionError):
+            tobii_to_norm(tobii_data)
+
+        tobii_data = (1, 11)  # invalid tobii coordinates
+
+        with self.assertRaises(AssertionError):
+            tobii_to_norm(tobii_data)
+
+    def test_norm_to_tobii(self):
+        """Test the norm_to_tobii function"""
+        norm_data = (0, 0)  # center of screen in norm coordinates
+        excepted_tobii_data = (0.5, 0.5)  # center of screen in tobii coordinates
+        tobii_data = norm_to_tobii(norm_data)
+        self.assertEqual(tobii_data, excepted_tobii_data)
+
+        norm_data = (-1, 1)  # top left of screen in norm coordinates
+        excepted_tobii_data = (0, 0)  # top left of screen in tobii coordinates
+        tobii_data = norm_to_tobii(norm_data)
+        self.assertEqual(tobii_data, excepted_tobii_data)
+
+        norm_data = (1, -1)  # bottom right of screen in norm coordinates
+        excepted_tobii_data = (1, 1)  # bottom right of screen in tobii coordinates
+        tobii_data = norm_to_tobii(norm_data)
+        self.assertEqual(tobii_data, excepted_tobii_data)
+
+    def test_norm_to_tobii_raises_error_with_invalid_units(self):
+        """Test the norm_to_tobii function raises an error with invalid units"""
+        norm_data = (-1.1, 1)
+        with self.assertRaises(AssertionError):
+            norm_to_tobii(norm_data)
+
+        norm_data = (1, 1.1)
+        with self.assertRaises(AssertionError):
+            norm_to_tobii(norm_data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Overview

Added two conversion methods to `helpers/convert.py` to support going in between Tobii and PsychoPy norm units.

## Ticket

- https://www.pivotaltracker.com/story/show/184861219

## Contributions

- `convert.py`: added `tobii_to_norm` and `norm_to_tobii` methods

## Test

- `make test-all`

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? TODO
