### PR TITLE
Add jitter to matrix and time tests

### DIFF
--- a/bcipy/display/paradigm/rsvp/display.py
+++ b/bcipy/display/paradigm/rsvp/display.py
@@ -73,7 +73,7 @@ class RSVPDisplay(Display):
         self.logger = logging.getLogger(__name__)
 
         # Stimuli parameters, these are set on display in order to allow
-        #  easy updating after defintion
+        #  easy updating after definition
         self.stimuli_inquiry = stimuli.stim_inquiry
         self.stimuli_colors = stimuli.stim_colors
         self.stimuli_timing = stimuli.stim_timing

--- a/bcipy/task/paradigm/matrix/calibration.py
+++ b/bcipy/task/paradigm/matrix/calibration.py
@@ -61,6 +61,7 @@ class MatrixCalibrationTask(Task):
 
         self.stim_number = parameters['stim_number']
         self.stim_length = parameters['stim_length']
+        self.jitter = parameters['stim_jitter']
         self.stim_order = StimuliOrder(parameters['stim_order'])
         self.target_positions = TargetPositions(parameters['target_positions'])
         self.nontarget_inquiries = parameters['nontarget_inquiries']
@@ -100,6 +101,7 @@ class MatrixCalibrationTask(Task):
             stim_number=self.stim_number,
             stim_length=self.stim_length,
             stim_order=self.stim_order,
+            jitter=self.jitter,
             target_positions=self.target_positions,
             nontarget_inquiries=self.nontarget_inquiries,
             timing=self.timing,

--- a/bcipy/task/paradigm/matrix/timing_verification.py
+++ b/bcipy/task/paradigm/matrix/timing_verification.py
@@ -3,7 +3,7 @@ from typing import List
 from bcipy.task.paradigm.matrix.calibration import (
     MatrixCalibrationTask, InquirySchedule, DEFAULT_TEXT_FIXATION, Display,
     init_calibration_display_task)
-from bcipy.helpers.stimuli import PhotoDiodeStimuli
+from bcipy.helpers.stimuli import PhotoDiodeStimuli, jittered_timing
 
 
 class MatrixTimingVerificationCalibration(MatrixCalibrationTask):
@@ -37,6 +37,7 @@ class MatrixTimingVerificationCalibration(MatrixCalibrationTask):
         samples, times, colors = [], [], []
         [time_target, time_fixation, time_stim] = self.timing
         stimuli = cycle(PhotoDiodeStimuli.list())
+        stim_timing = jittered_timing(time_stim, self.jitter, self.stim_length)
 
         # advance iterator to start on the solid stim.
         next(stimuli)
@@ -45,7 +46,7 @@ class MatrixTimingVerificationCalibration(MatrixCalibrationTask):
         inq_stim = [PhotoDiodeStimuli.SOLID.value, DEFAULT_TEXT_FIXATION
                     ] + [next(stimuli) for _ in range(self.stim_length)]
         inq_times = [time_target, time_fixation
-                     ] + [time_stim] * self.stim_length
+                     ] + stim_timing
         inq_colors = [self.color[0]] * (self.stim_length + 2)
 
         for _ in range(self.stim_number):

--- a/bcipy/task/paradigm/rsvp/calibration/timing_verification.py
+++ b/bcipy/task/paradigm/rsvp/calibration/timing_verification.py
@@ -1,7 +1,7 @@
 from itertools import cycle
 from bcipy.task import Task
 from bcipy.task.paradigm.rsvp.calibration.calibration import RSVPCalibrationTask
-from bcipy.helpers.stimuli import PhotoDiodeStimuli, get_fixation
+from bcipy.helpers.stimuli import PhotoDiodeStimuli, get_fixation, jittered_timing
 
 
 class RSVPTimingVerificationCalibration(Task):
@@ -44,13 +44,14 @@ class RSVPTimingVerificationCalibration(Task):
         letters = cycle(self.stimuli)
         time_prompt, time_fixation, time_stim = self._task.timing
         color_target, color_fixation, color_stim = self._task.color
+        inq_len = self._task.stim_length
 
+        stim_timing = jittered_timing(time_stim, self._task.jitter, inq_len)
         target = next(letters)
         fixation = get_fixation(is_txt=True)
 
-        inq_len = self._task.stim_length
         inq_stim = [target, fixation, *[next(letters) for _ in range(inq_len)]]
-        inq_times = [time_prompt, time_fixation, *[time_stim for _ in range(inq_len)]]
+        inq_times = [time_prompt, time_fixation] + stim_timing
         inq_colors = [color_target, color_fixation, *[color_stim for _ in range(inq_len)]]
 
         for _ in range(self._task.stim_number):


### PR DESCRIPTION
# Overview

Add stim_jitter parameter to Matrix. Add jitter to time test verifications to help in testing different stimuli configurations.

## Ticket

https://www.pivotaltracker.com/story/show/183548761

## Contributions

- `matrix/calibration.py`: add reference to stim_jitter, apply to generate stimuli method
- `timing_verification.py`: added jittered timing to both RSVP and Matrix time tests

## Test

- `make test-all`
- `bcipy --task "Matrix Time Test Calibration" -nv`
- `bcipy --task "RSVP Time Test Calibration" -nv`

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here. N/a

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? TODO
