### PR TITLE
Server metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Acquisition
     - Set channel spec information in devices.json. Removed aliases. #266 Updated default analysis channels for Wearable Sensing devices #279
     - Refactor to allow multiple devices to be configured for multimodal acquisition. #277
+    - Refinements to LSL server to use the device ChannelSpec information for generating metadata. #282
 - Matrix
     - Matrix calibration refinements #262
     - Matrix Copy Phrase Task #261

--- a/bcipy/acquisition/datastream/lsl_server.py
+++ b/bcipy/acquisition/datastream/lsl_server.py
@@ -63,18 +63,14 @@ class LslDataServer(StoppableThread):
                           f'{device_spec.content_type.lower()}_{uuid.uuid1()}')
 
         if include_meta:
-            # TODO: different types of metadata depending on the content type
-            unit = 'unknown'
-            channel_type = 'unknown'
-            if self.device_spec.content_type == 'EEG':
-                unit = 'microvolts'
-                channel_type = 'EEG'
             meta_channels = info.desc().append_child('channels')
             for channel in device_spec.channel_specs:
-                meta_channels.append_child('channel') \
-                    .append_child_value('label', channel.name) \
-                    .append_child_value('unit', channel.units or unit) \
-                    .append_child_value('type', channel.type or channel_type)
+                channel_node = meta_channels.append_child('channel')
+                channel_node.append_child_value('label', channel.name)
+                if channel.units:
+                    channel_node.append_child_value('unit', channel.units)
+                if channel.type:
+                    channel_node.append_child_value('type', channel.type)
 
         self.outlet = StreamOutlet(info)
 

--- a/bcipy/acquisition/protocols/lsl/lsl_client.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_client.py
@@ -2,7 +2,7 @@
 import logging
 from typing import List
 
-from pylsl import StreamInfo, StreamInlet, local_clock, resolve_stream
+from pylsl import StreamInfo, StreamInlet, local_clock, resolve_stream, resolve_byprop
 
 from bcipy.acquisition.devices import DEFAULT_DEVICE_TYPE, DeviceSpec, IRREGULAR_RATE
 from bcipy.acquisition.exceptions import InvalidClockError
@@ -300,7 +300,7 @@ def discover_device_spec(content_type: str) -> DeviceSpec:
     """Finds the first LSL stream with the given content type and creates a
     device spec from the stream's metadata."""
     log.info(f"Waiting for {content_type} data to be streamed over LSL.")
-    streams = resolve_stream('type', content_type)
+    streams = resolve_byprop('type', content_type, timeout=5.0)
     if not streams:
         raise Exception(
             f'LSL Stream not found for content type {content_type}')


### PR DESCRIPTION
# Overview

Refinements to LSL server to use the device ChannelSpec information for generating metadata.

## Ticket

https://www.pivotaltracker.com/story/show/179542651

## Contributions

- Updated lsl_server
- Updated code for discovering devices to provide a timeout if the device is not available.

## Test

- Started a demo Eyetracker server; used pylsl to inspect the stream metadata to confirm that it had the correct shape and values.