### PR TITLE
Patch rc3

### DIFF
--- a/.bcipy/experiment/experiments.json
+++ b/.bcipy/experiment/experiments.json
@@ -1,6 +1,0 @@
-{
-  "default": {
-    "fields": [],
-    "summary": "Default experiment to test various BciPy features without registering a full experiment."
-  }
-}

--- a/.bcipy/field/fields.json
+++ b/.bcipy/field/fields.json
@@ -1,6 +1,0 @@
-{
-  "age": {
-    "help_text": "Age (in years) of user.",
-    "type": "int"
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ dist/
 bcipy/parameters/parameters_*
 bcipy_cache
 
+bcipy/language/lms/lm_dec19_char_large_12gram.*
 bcipy/language/lms/out_*
 bcipy/language/out/

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,5 @@ dist/
 bcipy/parameters/parameters_*
 bcipy_cache
 
-bcipy/language/lms/lm_dec19_char_large_12gram.*
 bcipy/language/lms/out_*
 bcipy/language/out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.0.1-rc.3
+
+## Contributions
+
+- Bug Fixes
+    - Fix for missing inits and static assets #284 catch sessions with no data #284 move experiment and field assets to parameters location #284
+
 # 2.0.0-rc.3
 
 ## Contributions

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,7 @@
+include bcipy/parameters/*.json
+include bcipy/parameters/experiment/*.json
+include bcipy/parameters/field/*.json
+include bcipy/language/lms/*
+include bcipy/language/sets/*
+include bcipy/static/images/*/*
+include bcipy/static/sounds/*/*

--- a/bcipy/config.py
+++ b/bcipy/config.py
@@ -14,8 +14,8 @@ FIELD_FILENAME = 'fields.json'
 EXPERIMENT_DATA_FILENAME = 'experiment_data.json'
 BCIPY_ROOT = Path(__file__).resolve().parent
 ROOT = BCIPY_ROOT.parent
-DEFAULT_EXPERIMENT_PATH = f'{ROOT}/.bcipy/experiment'
-DEFAULT_FIELD_PATH = f'{ROOT}/.bcipy/field'
+DEFAULT_EXPERIMENT_PATH = f'{BCIPY_ROOT}/parameters/experiment'
+DEFAULT_FIELD_PATH = f'{BCIPY_ROOT}/parameters/field'
 
 DEFAULT_PARAMETER_FILENAME = 'parameters.json'
 DEFAULT_PARAMETERS_PATH = f'{BCIPY_ROOT}/parameters/{DEFAULT_PARAMETER_FILENAME}'
@@ -28,7 +28,7 @@ STATIC_PATH = f'{BCIPY_ROOT}/static'
 STATIC_IMAGES_PATH = f'{STATIC_PATH}/images'
 STATIC_AUDIO_PATH = f'{STATIC_PATH}/sounds'
 BCIPY_LOGO_PATH = f'{STATIC_IMAGES_PATH}/gui/cambi.png'
-PREFERENCES_PATH = f'{ROOT}/.bcipy/bcipy_cache'
+PREFERENCES_PATH = f'{ROOT}/bcipy_cache'
 LM_PATH = f'{BCIPY_ROOT}/language/lms'
 
 # core data configuration

--- a/bcipy/helpers/system_utils.py
+++ b/bcipy/helpers/system_utils.py
@@ -210,7 +210,9 @@ def configure_logger(
         '[%(threadName)-9s][%(asctime)s][%(name)s][%(levelname)s]: %(message)s'))
     root_logger.addHandler(handler)
 
-    print(f'Printing all BciPy logs to: {logfile}')
+    # print to console the absolute path of the log file to aid in debugging
+    path_to_logs = os.path.abspath(logfile)
+    print(f'Printing all BciPy logs to: {path_to_logs}')
 
     if version:
         logging.info(f'Start of Session for BciPy Version: ({version})')

--- a/bcipy/main.py
+++ b/bcipy/main.py
@@ -99,7 +99,12 @@ def bci_main(
 
     if execute_task(task, parameters, save_folder, alert, fake):
         if visualize:
-            visualize_session_data(save_folder, parameters)
+
+            # Visualize session data and fail silently if it errors
+            try:
+                visualize_session_data(save_folder, parameters)
+            except Exception as e:
+                log.info(f'Error visualizing session data: {e}')
         return True
 
     return False

--- a/bcipy/parameters/experiment/experiments.json
+++ b/bcipy/parameters/experiment/experiments.json
@@ -1,0 +1,6 @@
+{
+  "default": {
+    "fields": [],
+    "summary": "Default experiment to test various BciPy features without registering a full experiment."
+  }
+}

--- a/bcipy/parameters/field/fields.json
+++ b/bcipy/parameters/field/fields.json
@@ -1,0 +1,6 @@
+{
+  "age": {
+    "help_text": "Age (in years) of user.",
+    "type": "int"
+  }
+}

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -617,10 +617,10 @@
     "type": "int"
   },
   "lang_model_type": {
-    "value": "MIXTURE",
+    "value": "UNIFORM",
     "section": "lang_model_config",
     "readableName": "Language Model Type",
-    "helpTip": "Specifies which language model to use. Default: MIXTURE",
+    "helpTip": "Specifies which language model to use. Default: UNIFORM",
     "recommended_values": [
       "UNIFORM",
       "CAUSAL",

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,21 @@
+"""Setup for bcipy package.
+
+Installation:
+    To install locally, run:
+        pip install -e .
+    To install as a package, run:
+        python setup.py install
+    To create a distribution, run:
+        python setup.py sdist bdist_wheel
+
+Release:
+    *credentials required*
+    PyPi: https://pypi.org/project/bcipy/
+    GitHub: https://github.com/CAMBI-tech/BciPy
+    To upload to PyPi and create git tags, run:
+        python setup.py upload
+"""
+
 import os
 import sys
 import platform
@@ -13,7 +31,7 @@ EMAIL = 'cambi_support@googlegroups.com'
 AUTHOR = 'CAMBI'
 REQUIRES_PYTHON = '>3.7,<3.10'
 
-VERSION = '2.0.0rc3'
+VERSION = '2.0.1rc3'
 
 REQUIRED = []
 
@@ -23,11 +41,6 @@ if platform.system() == 'Windows' or platform.system() == 'Darwin':
         REQUIRED += f.read().splitlines()
 with open('requirements.txt', 'r', encoding='utf-8') as f:
     REQUIRED += f.read().splitlines()
-
-# The rest you shouldn't have to touch too much :)
-# ------------------------------------------------
-# Except, perhaps the License and Trove Classifiers!
-# If you do change the License, remember to change the Trove Classifier for that!
 
 here = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
# Overview

Updated install to allow bcipy app functions to work outside of local development. Currently, many submodules do work as expected and can be used in other packages as a requirement. However, due to missing assets and inits others will fail to work. This PR addresses these small changes and adds greater clarity when using it as a standalone package outside of root. 

