### PR TITLE
Acquisition chunk size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Our last release candidate before the official 2.0 release!
     - Set channel spec information in devices.json. Removed aliases. #266 Updated default analysis channels for Wearable Sensing devices #279
     - Refactor to allow multiple devices to be configured for multimodal acquisition. #277
     - Refinements to LSL server to use the device ChannelSpec information for generating metadata. #282
+    - Updated data consumers to explicitly set a chunk size. Refinements to LSL server to simulate different chunk sizes. #292
 - Matrix
     - Matrix calibration refinements #262
     - Matrix Copy Phrase Task #261

--- a/bcipy/acquisition/protocols/lsl/lsl_client.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_client.py
@@ -74,7 +74,9 @@ class LslAcquisitionClient:
                 f'LSL Stream not found for content type {content_type}')
         stream_info = streams[0]
 
-        self.inlet = StreamInlet(stream_info, max_buflen=self.max_buffer_len)
+        self.inlet = StreamInlet(stream_info,
+                                 max_buflen=self.max_buffer_len,
+                                 max_chunklen=1)
 
         if self.device_spec:
             check_device(self.device_spec, self.inlet.info())
@@ -98,6 +100,7 @@ class LslAcquisitionClient:
         """Timestamp returned by the first sample. If the data is being
         recorded this value reflects the timestamp of the first recorded sample"""
         if self.recorder:
+            # TODO: wait until there is a value
             return self.recorder.first_sample_time
         return self._first_sample_time
 

--- a/bcipy/acquisition/protocols/lsl/lsl_client.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_client.py
@@ -100,7 +100,6 @@ class LslAcquisitionClient:
         """Timestamp returned by the first sample. If the data is being
         recorded this value reflects the timestamp of the first recorded sample"""
         if self.recorder:
-            # TODO: wait until there is a value
             return self.recorder.first_sample_time
         return self._first_sample_time
 

--- a/bcipy/acquisition/protocols/lsl/lsl_recorder.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_recorder.py
@@ -193,7 +193,7 @@ class LslRecordingThread(StoppableThread):
         until the `stop()` method is called.
         """
         # Note that self.stream_info does not have the channel names.
-        inlet = StreamInlet(self.stream_info)
+        inlet = StreamInlet(self.stream_info, max_chunklen=1)
         full_metadata = inlet.info()
 
         log.info("Acquiring data from data stream:")


### PR DESCRIPTION
# Overview

Modified data consumers to specify the acquisition chunk size to override default value set by the device driver. This prevents data loss during recording and allows us to make realtime data queries to devices that set a chunk size in their lsl stream_outlet.

## Ticket

https://www.pivotaltracker.com/story/show/185934928

## Contributions

- Updated lsl_recorder and lsl_client to set a max_chunklen. According to the [LSL Documentation](https://labstreaminglayer.readthedocs.io/projects/liblsl/ref/inlet.html), when a max_chunklen is not set it defaults to the value provided by the stream_outlet. This was not a problem with the DSI driver since it did not set a chunk size. However, there is one set in the [TobiiPro Driver](https://github.com/CAMBI-tech/App-TobiiPro/blob/bb186c59cc4bea1618c9076904f0eba01530575c/mainwindow.cpp#L180).
- Added functionality to the lsl_server module to simulate serving data with a set chunk size.

## Test

- I simulated a chunk_size of 1200 while serving mock eye tracker data and ran a Calibration task. Analysis on the recorded raw_data was consistent with our latest experiment data in that there were around 15 seconds of data missing at the end.
- I also streamed the data in a visualizer and was able to observe lags in the data stream with 20 seconds between new data, consistent with the configured chunk_size (20 seconds * 60 samples per second).
- After setting the max_chunklen, I ran the same mock server with the chunk size set to 1200 and ran another Calibration task. I analyzed the data and confirmed that all of the data needed for offline_analysis was recorded.
