### PR TITLE
VEP display

### DIFF
--- a/bcipy/display/components/layout.py
+++ b/bcipy/display/components/layout.py
@@ -1,12 +1,13 @@
 """Defines common functionality for GUI layouts."""
 from enum import Enum
-from typing import Optional, Protocol, Tuple
+from typing import List, Optional, Protocol, Tuple
 
 
 class Container(Protocol):
     """Protocol for an enclosing container with units and size."""
     size: Tuple[float, float]
     units: str
+
 
 # for norm units
 DEFAULT_LEFT = -1.0
@@ -56,11 +57,13 @@ class Layout(Container):
     def check_invariants(self):
         """Check that all invariants hold true."""
         # https://psychopy.org/general/units.html#units
-        assert self.units in ['height', 'norm'], "Units must be 'height' or 'norm'"
+        assert self.units in ['height',
+                              'norm'], "Units must be 'height' or 'norm'"
         if self.units == "norm":
             assert (0.0 <= self.height <= 2.0), "Height must be in norm units."
             assert (0.0 <= self.width <= 2.0), "Width must be in norm units."
-            assert (-1.0 <= self.top <= 1.0), "Top must be a y-value in norm units"
+            assert (-1.0 <= self.top <=
+                    1.0), "Top must be a y-value in norm units"
             assert (-1.0 <= self.left <=
                     1.0), "Left must be an x-value in norm units"
             assert (-1.0 <= self.bottom <=
@@ -68,9 +71,12 @@ class Layout(Container):
             assert (-1.0 <= self.right <=
                     1.0), "Right must be an x-value in norm units"
         if self.units == "height":
-            assert (0.0 <= self.height <= 1.0), "Height must be in height units."
-            assert (-0.5 <= self.top <= 0.5), "Top must be a y-value in height units"
-            assert (-0.5 <= self.bottom <= 0.5), "Bottom must be a y-value in height units"
+            assert (0.0 <= self.height <=
+                    1.0), "Height must be in height units."
+            assert (-0.5 <= self.top <=
+                    0.5), "Top must be a y-value in height units"
+            assert (-0.5 <= self.bottom <=
+                    0.5), "Bottom must be a y-value in height units"
 
         if self.parent:
             assert 0 < self.width <= self.parent.size[
@@ -78,8 +84,12 @@ class Layout(Container):
             assert 0 < self.height <= self.parent.size[
                 1], "Height must be greater than 0 and fit within the parent height."
 
-    def scaled_size(self, height: float, window_size: Optional[Tuple[float, float]] = None) -> Tuple[float, float]:
-        """Returns the value scaled to reflect the aspect ratio of a
+    def scaled_size(
+        self,
+        height: float,
+        window_size: Optional[Tuple[float,
+                                    float]] = None) -> Tuple[float, float]:
+        """Returns the (w,h ) value scaled to reflect the aspect ratio of a
         visual.Window. Used for creating squared stimulus"""
         if self.units == 'height':
             width = height
@@ -281,6 +291,20 @@ def centered(width_pct: float = 1.0, height_pct: float = 1.0) -> Layout:
     container.resize_height(height_pct, alignment=Alignment.CENTERED)
     return container
 
+
+def envelope(layout: Layout, pos: Tuple[float, float],
+             size: Tuple[float, float]) -> List[Tuple[float, float]]:
+    """Compute the vertices for the envelope of a shape centered at pos with
+    the given size."""
+    width, height = size
+    half_w = width / 2
+    half_h = height / 2
+    return [(layout.left_of(pos[0], half_w), layout.above(pos[1], half_h)),
+            (layout.right_of(pos[0], half_w), layout.above(pos[1], half_h)),
+            (layout.right_of(pos[0], half_w), layout.below(pos[1], half_h)),
+            (layout.left_of(pos[0], half_w), layout.below(pos[1], half_h))]
+
+
 def height_units(window_size: Tuple[float, float]):
     """Constructs a layout with height units using the given Window
     dimensions
@@ -292,4 +316,8 @@ def height_units(window_size: Tuple[float, float]):
     """
     win_width, win_height = window_size
     right = (win_width / win_height) / 2
-    return Layout(left=-right, top=0.5, right=right, bottom=-0.5, units='height')
+    return Layout(left=-right,
+                  top=0.5,
+                  right=right,
+                  bottom=-0.5,
+                  units='height')

--- a/bcipy/display/components/layout.py
+++ b/bcipy/display/components/layout.py
@@ -107,7 +107,7 @@ class Layout(Container):
     """
 
     def __init__(self,
-                 parent: Container = None,
+                 parent: Optional[Container] = None,
                  left: float = DEFAULT_LEFT,
                  top: float = DEFAULT_TOP,
                  right: float = DEFAULT_RIGHT,
@@ -318,6 +318,16 @@ def centered(width_pct: float = 1.0, height_pct: float = 1.0) -> Layout:
     container.resize_width(width_pct, alignment=Alignment.CENTERED)
     container.resize_height(height_pct, alignment=Alignment.CENTERED)
     return container
+
+
+def from_envelope(verts: List[Tuple[float, float]]) -> Layout:
+    """Constructs a layout from a list of vertices which comprise a shape's
+    envelope."""
+    x_coords, y_coords = zip(*verts)
+    return Layout(left=min(x_coords),
+                  top=max(y_coords),
+                  right=max(x_coords),
+                  bottom=min(y_coords))
 
 
 def height_units(window_size: Tuple[float, float]) -> Layout:

--- a/bcipy/display/components/layout.py
+++ b/bcipy/display/components/layout.py
@@ -78,7 +78,7 @@ def envelope(pos: Tuple[float, float],
 
 
 def scaled_size(height: float,
-                window_size: [Tuple[float, float]],
+                window_size: Tuple[float, float],
                 units: str = 'norm') -> Tuple[float, float]:
     """Scales the provided height value to reflect the aspect ratio of a
     visual.Window. Used for creating squared stimulus. Returns (w,h) tuple"""
@@ -89,6 +89,17 @@ def scaled_size(height: float,
     win_width, win_height = window_size
     width = (win_height / win_width) * height
     return (width, height)
+
+
+def scaled_height(width: float,
+                  window_size: Tuple[float, float],
+                  units: str = 'norm') -> float:
+    """Given a width, find the equivalent height scaled to the aspect ratio of
+    a window with the given size"""
+    if units == 'height':
+        return width
+    win_width, win_height = window_size
+    return width / (win_height / win_width)
 
 
 class Layout(Container):

--- a/bcipy/display/demo/components/demo_layouts.py
+++ b/bcipy/display/demo/components/demo_layouts.py
@@ -9,7 +9,8 @@ from psychopy.visual.rect import Rect
 from psychopy.visual.shape import ShapeStim
 
 from bcipy.display.components.layout import (Layout, at_top, centered,
-                                             envelope, height_units)
+                                             envelope, height_units,
+                                             scaled_size)
 from bcipy.display.paradigm.vep.layout import BoxConfiguration, checkerboard
 
 
@@ -143,8 +144,7 @@ def demo_vep(win: visual.Window):
 
     for i, pos in enumerate(positions):
         color_tup: Tuple[str, str] = vep_colors[i]
-        board = checkerboard(layout,
-                             squares=16,
+        board = checkerboard(squares=16,
                              colors=color_tup,
                              center=pos,
                              board_size=layout.scaled_size(0.2))
@@ -166,13 +166,10 @@ def demo_vep(win: visual.Window):
 
 def demo_checkerboard(win: visual.Window):
     """Demo checkerboard"""
-    layout = centered(width_pct=0.9, height_pct=0.9)
-    layout.parent = win
-    board = checkerboard(layout,
-                         squares=16,
+    board = checkerboard(squares=16,
                          colors=('red', 'green'),
                          center=(0, 0),
-                         board_size=layout.scaled_size(0.6))
+                         board_size=scaled_size(0.6, win.size))
     for square in board:
         Rect(win,
              pos=square.pos,
@@ -223,24 +220,20 @@ def demo_height_units(win: visual.Window):
 
 def demo_checkerboard2(win: visual.Window):
     """Demo checkerboard rendered using a complex shapestim"""
-    layout = centered(width_pct=0.9, height_pct=0.9)
-    layout.parent = win
-
     board_pos = (0, 0)
-    board_size = layout.scaled_size(0.6)
+    board_size = scaled_size(0.6, win.size)
 
     colors = ('red', 'green')
-    board = checkerboard(layout,
-                         squares=25,
+    board = checkerboard(squares=25,
                          colors=colors,
                          center=board_pos,
                          board_size=board_size)
-    board_boundaries = envelope(layout, pos=board_pos, size=board_size)
+    board_boundaries = envelope(pos=board_pos, size=board_size)
 
     evens = []
     odds = []
     for square in board:
-        square_boundary = envelope(layout, pos=square.pos, size=square.size)
+        square_boundary = envelope(pos=square.pos, size=square.size)
         if square.color == colors[0]:
             evens.append(square_boundary)
         else:

--- a/bcipy/display/demo/components/demo_layouts.py
+++ b/bcipy/display/demo/components/demo_layouts.py
@@ -163,7 +163,7 @@ def demo_vep(win: visual.Window):
     layout = centered(width_pct=0.9, height_pct=0.9)
     layout.parent = win
 
-    box_config = BoxConfiguration(layout, num_boxes=4, height_pct=0.28)
+    box_config = BoxConfiguration(layout, num_boxes=6, height_pct=0.28)
     size = box_config.box_size()
     positions = box_config.positions
 
@@ -204,10 +204,10 @@ def demo_checkerboard(win: visual.Window):
     layout = centered(width_pct=0.9, height_pct=0.9)
     layout.parent = win
     board = checkerboard(layout,
-                         squares=16,
+                         squares=25,
                          colors=('red', 'green'),
                          center=(0, 0),
-                         board_size=layout.scaled_size(0.4))
+                         board_size=layout.scaled_size(0.6))
     for square in board:
         Rect(win,
              pos=square.pos,
@@ -284,7 +284,7 @@ def run(demo: Callable[[visual.Window], None], seconds=30):
         print('Demo complete.')
 
 
-# run(demo_vep)
+run(demo_vep)
 # run(demo_height_units)
 # run(show_layout_coords)
-run(demo_checkerboard)
+# run(demo_checkerboard)

--- a/bcipy/display/demo/components/demo_layouts.py
+++ b/bcipy/display/demo/components/demo_layouts.py
@@ -129,7 +129,7 @@ def demo_vep(win: visual.Window):
     layout.parent = win
 
     box_config = BoxConfiguration(layout, num_boxes=4, height_pct=0.28)
-    size = box_config.box_size()
+    size = box_config.box_size
     positions = box_config.positions
 
     draw_boundary(win, layout, color='gray', line_px=2)
@@ -281,8 +281,8 @@ def run(demo: Callable[[visual.Window], None], seconds=30):
         print('Demo complete.')
 
 
-# run(demo_vep)
+run(demo_vep)
 # run(demo_height_units)
 # run(show_layout_coords)
 # run(demo_checkerboard)
-run(demo_checkerboard2)
+# run(demo_checkerboard2)

--- a/bcipy/display/demo/components/demo_layouts.py
+++ b/bcipy/display/demo/components/demo_layouts.py
@@ -1,0 +1,290 @@
+"""Useful for viewing computed positions in a window"""
+import time
+from itertools import cycle
+from typing import Callable, List, Tuple, Union
+
+from psychopy import visual
+from psychopy.visual.circle import Circle
+from psychopy.visual.grating import GratingStim
+from psychopy.visual.line import Line
+from psychopy.visual.rect import Rect
+
+from bcipy.display.components.layout import (Layout, at_top, centered,
+                                             height_units)
+from bcipy.display.paradigm.vep.layout import BoxConfiguration, checkerboard
+
+
+def make_window():
+    """Make a sample window on which to draw."""
+    return visual.Window(size=[700, 500],
+                         fullscr=False,
+                         screen=0,
+                         waitBlanking=False,
+                         color='black',
+                         winType='pyglet')
+
+
+def draw_boundary(win,
+                  layout: Layout,
+                  color: str = 'blue',
+                  line_px: int = 5,
+                  name: str = None):
+    """Display the layout's outline."""
+    if name:
+        print(f"Drawing boundary for {name}")
+    top = Line(win=win,
+               units=layout.units,
+               start=(layout.left, layout.top),
+               end=(layout.right, layout.top),
+               lineColor=color,
+               lineWidth=line_px)
+
+    bottom = Line(win=win,
+                  units=layout.units,
+                  start=(layout.left, layout.bottom),
+                  end=(layout.right, layout.bottom),
+                  lineColor=color,
+                  lineWidth=line_px)
+
+    left = Line(win=win,
+                units=layout.units,
+                start=(layout.left, layout.top),
+                end=(layout.left, layout.bottom),
+                lineColor=color,
+                lineWidth=line_px)
+    right = Line(win=win,
+                 units=layout.units,
+                 start=(layout.right, layout.top),
+                 end=(layout.right, layout.bottom),
+                 lineColor=color,
+                 lineWidth=line_px)
+    border = [top, right, bottom, left]
+    for line in border:
+        print(f"Drawing line from {line.start} to {line.end}")
+        line.draw()
+
+
+def draw_position(win: visual.Window,
+                  pos: Tuple[float, float],
+                  color: str = 'blue',
+                  size: Union[float, Tuple[float, float]] = 0.025,
+                  name: str = None):
+    """Draw the provided positions"""
+    if name:
+        print(f"Drawing position {name} at {pos}")
+    circle = Circle(win, pos=pos, color=color, size=size)
+    circle.draw()
+
+
+def draw_positions(win: visual.Window,
+                   positions: List[Tuple[float, float]],
+                   color: str = 'blue',
+                   size: Union[float, Tuple[float, float]] = 0.025):
+    """Draw the provided positions"""
+    for pos in positions:
+        draw_position(win, pos, color, size)
+
+
+def show_layouts(window: visual.Window):
+    """Show boundaries for various layouts"""
+    draw_boundary(window, Layout(), 'red', 5, name='full_screen')
+    draw_boundary(window,
+                  at_top(window, 0.1),
+                  color='blue',
+                  line_px=5,
+                  name='task_bar')
+    draw_boundary(window,
+                  centered(width_pct=0.9, height_pct=0.9),
+                  color='green',
+                  line_px=5,
+                  name='main_display')
+
+    window.flip()
+
+
+def show_layout_coords(win: visual.Window):
+    """Show the points that make up a layout's envelope"""
+    layout = centered(width_pct=0.9, height_pct=0.9)
+    layout.parent = win
+    draw_boundary(win, layout, color='green')
+    draw_position(win, (layout.left, layout.top),
+                  size=layout.scaled_size(0.025),
+                  name='top_left')
+    draw_position(win, (layout.right, layout.bottom), name='bottom_right')
+
+    Rect(win,
+         pos=(layout.left, layout.top),
+         size=layout.scaled_size(0.05),
+         lineColor='blue').draw()
+    Rect(win,
+         pos=(layout.right, layout.bottom),
+         size=layout.scaled_size(0.05),
+         lineColor='blue').draw()
+    win.flip()
+
+
+def vep_box_quadrant(win: visual.Window, pos: Tuple[float, float], anchor: str,
+                     color: Tuple[str, str], size: Tuple[float, float]):
+
+    pattern1 = GratingStim(win=win,
+                           name=f'2x2-1-{pos}-{anchor}',
+                           tex=None,
+                           pos=pos,
+                           size=size,
+                           sf=1,
+                           phase=0.0,
+                           color=color[0],
+                           colorSpace='rgb',
+                           opacity=1,
+                           texRes=256,
+                           interpolate=True,
+                           depth=-1.0,
+                           anchor=anchor)
+    pattern2 = GratingStim(win=win,
+                           name=f'2x2-2-{pos}-{anchor}',
+                           tex=None,
+                           pos=pos,
+                           size=size,
+                           sf=1,
+                           phase=0.0,
+                           color=color[1],
+                           colorSpace='rgb',
+                           opacity=1,
+                           texRes=256,
+                           interpolate=True,
+                           depth=-1.0,
+                           anchor=anchor)
+    border = Rect(win, pos=pos, size=size, lineColor='white', anchor=anchor)
+    return [pattern1, pattern2, border]
+
+
+def demo_vep(win: visual.Window):
+    """Demo layout elements for VEP display"""
+    layout = centered(width_pct=0.9, height_pct=0.9)
+    layout.parent = win
+
+    box_config = BoxConfiguration(layout, num_boxes=4, height_pct=0.28)
+    size = box_config.box_size()
+    positions = box_config.positions
+
+    draw_boundary(win, layout, color='gray', line_px=2)
+    draw_positions(win,
+                   positions,
+                   color='blue',
+                   size=layout.scaled_size(0.025))
+
+    vep_colors = [('white', 'black'), ('red', 'green'), ('blue', 'yellow'),
+                  ('orange', 'green'), ('white', 'black'), ('red', 'green')]
+    colors = ['#00FF80', '#FFFFB3', '#CB99FF', '#FB8072', '#80B1D3', '#FF8232']
+    # draw boxes
+    anchor_points = ['right_bottom', 'left_bottom', 'left_top', 'right_top']
+
+    for i, pos in enumerate(positions):
+        gradient_colors: Tuple[str, str] = vep_colors[i]
+
+        for anchor, color in zip(
+                anchor_points,
+                cycle([gradient_colors,
+                       tuple(reversed(gradient_colors))])):
+            for stim in vep_box_quadrant(win, pos, anchor, color,
+                                         layout.scaled_size(0.1)):
+                stim.draw()
+
+        rect = visual.TextBox2(win,
+                               text=' ',
+                               borderColor=colors[i],
+                               pos=pos,
+                               size=size)
+        rect.draw()
+    win.flip()
+
+
+def demo_checkerboard(win: visual.Window):
+    """Demo checkerboard"""
+    layout = centered(width_pct=0.9, height_pct=0.9)
+    layout.parent = win
+    board = checkerboard(layout,
+                         squares=16,
+                         colors=('red', 'green'),
+                         center=(0, 0),
+                         board_size=layout.scaled_size(0.4))
+    for square in board:
+        Rect(win,
+             pos=square.pos,
+             size=square.size,
+             lineColor='white',
+             fillColor=square.color).draw()
+    win.flip()
+
+
+def demo_height_units(win: visual.Window):
+    """Demo behavior when using height units"""
+    norm_layout = centered(width_pct=0.85, height_pct=0.85)
+    draw_boundary(win, norm_layout, line_px=5, color='red')
+    layout = height_units(win.size)
+    layout.resize_width(0.85)
+    layout.resize_height(0.85)
+    draw_boundary(win, layout, line_px=3, color='green')
+
+    circle = Circle(win,
+                    pos=layout.center,
+                    color='blue',
+                    size=0.025,
+                    units='height')
+    circle.draw()
+    rects = [
+        Rect(win,
+             pos=layout.center,
+             size=layout.scaled_size(0.05),
+             lineColor='green',
+             units='height'),
+        # don't need to scale with height units
+        Rect(win,
+             pos=layout.left_top,
+             size=(0.05, 0.05),
+             lineColor='green',
+             units='height'),
+        # scaling the size should still work
+        Rect(win,
+             pos=layout.right_bottom,
+             size=layout.scaled_size(0.05),
+             lineColor='green',
+             units=layout.units)
+    ]
+    for rect in rects:
+        rect.draw()
+    win.flip()
+
+
+def run(demo: Callable[[visual.Window], None], seconds=30):
+    """Run the given function for the provided duration.
+
+    Parameters
+    ----------
+        demo - function to run; a Window object is passed to this function.
+        seconds - Window is closed after this duration.
+    """
+    try:
+        win = make_window()
+        print(
+            f'Displaying window for {seconds}s... (Interrupt [Ctl-C] to stop)\n'
+        )
+
+        demo(win)
+        while True:
+            time.sleep(seconds)
+            break
+    except KeyboardInterrupt:
+        print('Keyboard Interrupt: Demo stopped')
+    except Exception as other_exception:
+        print(f'{other_exception}')
+        raise other_exception
+    finally:
+        win.close()
+        print('Demo complete.')
+
+
+# run(demo_vep)
+# run(demo_height_units)
+# run(show_layout_coords)
+run(demo_checkerboard)

--- a/bcipy/display/demo/vep/demo_calibration_vep.py
+++ b/bcipy/display/demo/vep/demo_calibration_vep.py
@@ -1,8 +1,10 @@
 from psychopy import core, visual
 
 from bcipy.display import InformationProperties, VEPStimuliProperties
+from bcipy.display.components.layout import centered
 from bcipy.display.components.task_bar import CalibrationTaskBar
 from bcipy.display.paradigm.vep.display import VEPDisplay
+from bcipy.display.paradigm.vep.layout import BoxConfiguration
 from bcipy.helpers.clock import Clock
 
 info = InformationProperties(
@@ -13,10 +15,8 @@ info = InformationProperties(
     info_text=['VEP Display Demo'],
 )
 
-task_text = ['1/4', '2/4', '3/4', '4/4']
-task_color = [['white'], ['white'], ['white'], ['white']]
-num_boxes = 4
-start_positions_for_boxes = [(-.3, -.3), (.3, -.3), (.3, .3), (-.3, .3)]
+task_text = ['1/4'] #, '2/4', '3/4', '4/4']
+num_boxes = 6
 
 win = visual.Window(size=[700, 700],
                     fullscr=False,
@@ -34,11 +34,18 @@ frameRate = win.getActualFrameRate()
 
 print(f'Monitor refresh rate: {frameRate} Hz')
 
+start_positions_for_boxes =  [(-.3, -.3), (.3, -.3), (.3, .3), (-.3, .3)]
+
+box_colors = ['#00FF80', '#FFFFB3', '#CB99FF', '#FB8072', '#80B1D3', '#FF8232']
+stim_color = [[color] for i, color in enumerate(box_colors) if i < num_boxes]
+
+box_config = BoxConfiguration(layout=centered(width_pct=0.95, height_pct=0.80), num_boxes=num_boxes)
+
 experiment_clock = Clock()
 len_stimuli = 10
 stimuli = VEPStimuliProperties(
-    stim_color=[['blue'], ['purple'], ['red'], ['green']],
-    stim_pos=start_positions_for_boxes,
+    stim_color = stim_color,
+    stim_pos=box_config.positions,
     stim_height=0.1,
     stim_font='Arial',
     timing=(1, 0.5, 4),  # prompt, fixation, stimuli
@@ -48,15 +55,18 @@ task_bar = CalibrationTaskBar(win,
                               inquiry_count=4,
                               current_index=0,
                               font='Arial')
-vep = VEPDisplay(win, experiment_clock, stimuli, task_bar, info)
+vep = VEPDisplay(win, experiment_clock, stimuli, task_bar, info, box_config=box_config)
 timing = []
 wait_seconds = 2
 
 # loop over the text and colors, present the stimuli and record the timing
-for (txt, color) in zip(task_text, task_color):
+for txt in task_text:
     vep.update_task_bar(txt)
-    vep.schedule_to([['A', 'B'], ['Z'], ['P'], ['R', 'W']], [1, 0.5, 5],
-                    [['blue'], ['purple'], ['red'], ['green']])
+    if num_boxes == 4:
+        stim = [['A', 'B'], ['Z'], ['P'], ['R', 'W']]
+    if num_boxes == 6:
+        stim = [['A'], ['B'], ['Z'], ['P'], ['R'], ['W']]
+    vep.schedule_to(stim, [1, 0.5, 5], stim_color)
     timing += vep.do_inquiry()
 
     # show the wait screen, this will only happen once

--- a/bcipy/display/demo/vep/demo_calibration_vep.py
+++ b/bcipy/display/demo/vep/demo_calibration_vep.py
@@ -24,7 +24,7 @@ info = InformationProperties(
     info_text=['VEP Display Demo'],
 )
 
-task_text = ['1/4']  # , '2/4', '3/4', '4/4']
+task_text = ['1/4', '2/4', '3/4', '4/4']
 num_boxes = 6
 
 win = visual.Window(size=[700, 700],
@@ -43,13 +43,10 @@ frameRate = win.getActualFrameRate()
 
 print(f'Monitor refresh rate: {frameRate} Hz')
 
-start_positions_for_boxes = [(-.3, -.3), (.3, -.3), (.3, .3), (-.3, .3)]
-
 box_colors = ['#00FF80', '#FFFFB3', '#CB99FF', '#FB8072', '#80B1D3', '#FF8232']
 stim_color = [[color] for i, color in enumerate(box_colors) if i < num_boxes]
 
 layout = centered(width_pct=0.95, height_pct=0.80)
-layout.parent = win
 box_config = BoxConfiguration(layout, num_boxes=num_boxes)
 
 experiment_clock = Clock()
@@ -59,7 +56,7 @@ stimuli = VEPStimuliProperties(
     stim_pos=box_config.positions,
     stim_height=0.1,
     stim_font='Arial',
-    timing=(1, 0.5, 2, 4),  # prompt, fixation, stimuli
+    timing=(1, 0.5, 2, 4),  # prompt, fixation, animation, stimuli
     stim_length=1,  # how many times to stimuli
 )
 task_bar = CalibrationTaskBar(win,
@@ -76,7 +73,7 @@ for txt in task_text:
     if num_boxes == 4:
         stim = [['A', 'B'], ['Z'], ['P'], ['R', 'W']]
     if num_boxes == 6:
-        stim = [['A'], ['B'], ['Z'], ['P'], ['R'], ['W']]
+        stim = [['A'], ['B'], ['Z', 'X'], ['P', 'I'], ['R'], ['W', 'C']]
     vep.schedule_to(stimuli=stim)
     timing += vep.do_inquiry()
 

--- a/bcipy/display/demo/vep/demo_calibration_vep.py
+++ b/bcipy/display/demo/vep/demo_calibration_vep.py
@@ -9,7 +9,7 @@ info = InformationProperties(
     info_color=['White'],
     info_pos=[(-.5, -.75)],
     info_height=[0.1],
-    info_font=['Consolas'],
+    info_font=['Arial'],
     info_text=['VEP Display Demo'],
 )
 
@@ -37,7 +37,7 @@ print(f'Monitor refresh rate: {frameRate} Hz')
 experiment_clock = Clock()
 len_stimuli = 10
 stimuli = VEPStimuliProperties(
-    stim_color=[['white'] * num_boxes],
+    stim_color=[['blue'], ['purple'], ['red'], ['green']],
     stim_pos=start_positions_for_boxes,
     stim_height=0.1,
     stim_font='Arial',
@@ -56,7 +56,7 @@ wait_seconds = 2
 for (txt, color) in zip(task_text, task_color):
     vep.update_task_bar(txt)
     vep.schedule_to([['A', 'B'], ['Z'], ['P'], ['R', 'W']], [1, 0.5, 5],
-                    [['blue'], ['purple'], ['red'], ['white']])
+                    [['blue'], ['purple'], ['red'], ['green']])
     timing += vep.do_inquiry()
 
     # show the wait screen, this will only happen once

--- a/bcipy/display/demo/vep/demo_calibration_vep.py
+++ b/bcipy/display/demo/vep/demo_calibration_vep.py
@@ -24,7 +24,7 @@ info = InformationProperties(
     info_text=['VEP Display Demo'],
 )
 
-task_text = ['1/4'] #, '2/4', '3/4', '4/4']
+task_text = ['1/4']  # , '2/4', '3/4', '4/4']
 num_boxes = 6
 
 win = visual.Window(size=[700, 700],
@@ -43,19 +43,19 @@ frameRate = win.getActualFrameRate()
 
 print(f'Monitor refresh rate: {frameRate} Hz')
 
-start_positions_for_boxes =  [(-.3, -.3), (.3, -.3), (.3, .3), (-.3, .3)]
+start_positions_for_boxes = [(-.3, -.3), (.3, -.3), (.3, .3), (-.3, .3)]
 
 box_colors = ['#00FF80', '#FFFFB3', '#CB99FF', '#FB8072', '#80B1D3', '#FF8232']
 stim_color = [[color] for i, color in enumerate(box_colors) if i < num_boxes]
 
-layout=centered(width_pct=0.95, height_pct=0.80)
+layout = centered(width_pct=0.95, height_pct=0.80)
 layout.parent = win
 box_config = BoxConfiguration(layout, num_boxes=num_boxes)
 
 experiment_clock = Clock()
 len_stimuli = 10
 stimuli = VEPStimuliProperties(
-    stim_color = stim_color,
+    stim_color=stim_color,
     stim_pos=box_config.positions,
     stim_height=0.1,
     stim_font='Arial',

--- a/bcipy/display/demo/vep/demo_calibration_vep.py
+++ b/bcipy/display/demo/vep/demo_calibration_vep.py
@@ -1,8 +1,9 @@
 from psychopy import core, visual
 
+from bcipy.display import InformationProperties, VEPStimuliProperties
+from bcipy.display.components.task_bar import CalibrationTaskBar
 from bcipy.display.paradigm.vep.display import VEPDisplay
 from bcipy.helpers.clock import Clock
-from bcipy.display import InformationProperties, TaskDisplayProperties, VEPStimuliProperties
 
 info = InformationProperties(
     info_color=['White'],
@@ -11,19 +12,21 @@ info = InformationProperties(
     info_font=['Consolas'],
     info_text=['VEP Display Demo'],
 )
-task_display = TaskDisplayProperties(colors=['White'],
-                                     font='Consolas',
-                                     height=.1,
-                                     text='1/4')
 
 task_text = ['1/4', '2/4', '3/4', '4/4']
 task_color = [['white'], ['white'], ['white'], ['white']]
 num_boxes = 4
 start_positions_for_boxes = [(-.3, -.3), (.3, -.3), (.3, .3), (-.3, .3)]
 
-win = visual.Window(size=[700, 700], fullscr=False, screen=1, allowGUI=False,
-                    allowStencil=False, monitor='testMonitor', color='black',
-                    colorSpace='rgb', blendMode='avg',
+win = visual.Window(size=[700, 700],
+                    fullscr=False,
+                    screen=1,
+                    allowGUI=False,
+                    allowStencil=False,
+                    monitor='testMonitor',
+                    color='black',
+                    colorSpace='rgb',
+                    blendMode='avg',
                     waitBlanking=False,
                     winType='pyglet')
 win.recordFrameIntervals = True
@@ -31,31 +34,35 @@ frameRate = win.getActualFrameRate()
 
 print(f'Monitor refresh rate: {frameRate} Hz')
 
-clock = core.Clock()
 experiment_clock = Clock()
 len_stimuli = 10
 stimuli = VEPStimuliProperties(
     stim_color=[['white'] * num_boxes],
     stim_pos=start_positions_for_boxes,
     stim_height=0.1,
-    stim_font='Consolas',
+    stim_font='Arial',
     timing=(1, 0.5, 4),  # prompt, fixation, stimuli
     stim_length=1,  # how many times to stimuli
 )
-vep = VEPDisplay(win, experiment_clock, stimuli, task_display, info)
+task_bar = CalibrationTaskBar(win,
+                              inquiry_count=4,
+                              current_index=0,
+                              font='Arial')
+vep = VEPDisplay(win, experiment_clock, stimuli, task_bar, info)
 timing = []
-t = 2
+wait_seconds = 2
 
 # loop over the text and colors, present the stimuli and record the timing
 for (txt, color) in zip(task_text, task_color):
-    vep.update_task(txt, color[0])
-    vep.schedule_to([['A', 'B'], ['Z'], ['P'], ['R', 'W']], [1, 0.5, 5], [['blue'], ['purple'], ['red'], ['white']])
+    vep.update_task_bar(txt)
+    vep.schedule_to([['A', 'B'], ['Z'], ['P'], ['R', 'W']], [1, 0.5, 5],
+                    [['blue'], ['purple'], ['red'], ['white']])
     timing += vep.do_inquiry()
 
     # show the wait screen, this will only happen once
-    while t > 0:
-        t -= 1
-        vep.wait_screen(f"Waiting for {t}s", color='white')
+    while wait_seconds > 0:
+        wait_seconds -= 1
+        vep.wait_screen(f"Waiting for {wait_seconds}s", color='white')
         core.wait(1)
 
 print(timing)

--- a/bcipy/display/demo/vep/demo_calibration_vep.py
+++ b/bcipy/display/demo/vep/demo_calibration_vep.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 
-from psychopy import core, visual
+from psychopy import core
 
 from bcipy.display import (InformationProperties, VEPStimuliProperties,
                            init_display_window)

--- a/bcipy/display/demo/vep/demo_calibration_vep.py
+++ b/bcipy/display/demo/vep/demo_calibration_vep.py
@@ -3,7 +3,8 @@ import sys
 
 from psychopy import core, visual
 
-from bcipy.display import InformationProperties, VEPStimuliProperties
+from bcipy.display import (InformationProperties, VEPStimuliProperties,
+                           init_display_window)
 from bcipy.display.components.layout import centered
 from bcipy.display.components.task_bar import CalibrationTaskBar
 from bcipy.display.paradigm.vep.display import VEPDisplay
@@ -16,28 +17,26 @@ handler = logging.StreamHandler(sys.stdout)
 handler.setLevel(logging.DEBUG)
 root.addHandler(handler)
 
+font = 'Courier New'
 info = InformationProperties(
     info_color=['White'],
     info_pos=[(-.5, -.75)],
     info_height=[0.1],
-    info_font=['Arial'],
+    info_font=[font],
     info_text=['VEP Display Demo'],
 )
 
 task_text = ['1/4', '2/4', '3/4', '4/4']
 num_boxes = 6
 
-win = visual.Window(size=[700, 700],
-                    fullscr=False,
-                    screen=1,
-                    allowGUI=False,
-                    allowStencil=False,
-                    monitor='testMonitor',
-                    color='black',
-                    colorSpace='rgb',
-                    blendMode='avg',
-                    waitBlanking=False,
-                    winType='pyglet')
+window_parameters = {
+    'full_screen': False,
+    'window_height': 700,
+    'window_width': 700,
+    'stim_screen': 1,
+    'background_color': 'black'
+}
+win = init_display_window(window_parameters)
 win.recordFrameIntervals = True
 frameRate = win.getActualFrameRate()
 
@@ -55,14 +54,14 @@ stimuli = VEPStimuliProperties(
     stim_color=stim_color,
     stim_pos=box_config.positions,
     stim_height=0.1,
-    stim_font='Arial',
+    stim_font=font,
     timing=(1, 0.5, 2, 4),  # prompt, fixation, animation, stimuli
     stim_length=1,  # how many times to stimuli
 )
 task_bar = CalibrationTaskBar(win,
                               inquiry_count=4,
                               current_index=0,
-                              font='Arial')
+                              font=font)
 vep = VEPDisplay(win, experiment_clock, stimuli, task_bar, info, box_config=box_config)
 timing = []
 wait_seconds = 2

--- a/bcipy/display/demo/vep/demo_calibration_vep.py
+++ b/bcipy/display/demo/vep/demo_calibration_vep.py
@@ -16,7 +16,7 @@ info = InformationProperties(
 )
 
 task_text = ['1/4'] #, '2/4', '3/4', '4/4']
-num_boxes = 6
+num_boxes = 4
 
 win = visual.Window(size=[700, 700],
                     fullscr=False,
@@ -48,7 +48,7 @@ stimuli = VEPStimuliProperties(
     stim_pos=box_config.positions,
     stim_height=0.1,
     stim_font='Arial',
-    timing=(1, 0.5, 4),  # prompt, fixation, stimuli
+    timing=(1, 0.5, 2, 4),  # prompt, fixation, stimuli
     stim_length=1,  # how many times to stimuli
 )
 task_bar = CalibrationTaskBar(win,
@@ -66,7 +66,7 @@ for txt in task_text:
         stim = [['A', 'B'], ['Z'], ['P'], ['R', 'W']]
     if num_boxes == 6:
         stim = [['A'], ['B'], ['Z'], ['P'], ['R'], ['W']]
-    vep.schedule_to(stim, [1, 0.5, 5], stim_color)
+    vep.schedule_to(stimuli=stim)
     timing += vep.do_inquiry()
 
     # show the wait screen, this will only happen once

--- a/bcipy/display/demo/vep/demo_calibration_vep.py
+++ b/bcipy/display/demo/vep/demo_calibration_vep.py
@@ -1,3 +1,6 @@
+import logging
+import sys
+
 from psychopy import core, visual
 
 from bcipy.display import InformationProperties, VEPStimuliProperties
@@ -6,6 +9,12 @@ from bcipy.display.components.task_bar import CalibrationTaskBar
 from bcipy.display.paradigm.vep.display import VEPDisplay
 from bcipy.display.paradigm.vep.layout import BoxConfiguration
 from bcipy.helpers.clock import Clock
+
+root = logging.getLogger()
+root.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+handler.setLevel(logging.DEBUG)
+root.addHandler(handler)
 
 info = InformationProperties(
     info_color=['White'],
@@ -16,7 +25,7 @@ info = InformationProperties(
 )
 
 task_text = ['1/4'] #, '2/4', '3/4', '4/4']
-num_boxes = 4
+num_boxes = 6
 
 win = visual.Window(size=[700, 700],
                     fullscr=False,
@@ -39,7 +48,9 @@ start_positions_for_boxes =  [(-.3, -.3), (.3, -.3), (.3, .3), (-.3, .3)]
 box_colors = ['#00FF80', '#FFFFB3', '#CB99FF', '#FB8072', '#80B1D3', '#FF8232']
 stim_color = [[color] for i, color in enumerate(box_colors) if i < num_boxes]
 
-box_config = BoxConfiguration(layout=centered(width_pct=0.95, height_pct=0.80), num_boxes=num_boxes)
+layout=centered(width_pct=0.95, height_pct=0.80)
+layout.parent = win
+box_config = BoxConfiguration(layout, num_boxes=num_boxes)
 
 experiment_clock = Clock()
 len_stimuli = 10

--- a/bcipy/display/paradigm/matrix/layout.py
+++ b/bcipy/display/paradigm/matrix/layout.py
@@ -1,7 +1,8 @@
 """Functions for calculating matrix layouts"""
 from typing import List, Tuple
 
-from bcipy.display.components.layout import Layout
+from bcipy.display.components.layout import (Layout, above, below, left_of,
+                                             right_of)
 
 
 def symbol_positions(container: Layout,
@@ -35,29 +36,28 @@ def symbol_positions(container: Layout,
     # Work back from center to compute the starting position
     center_x, center_y = container.center
     spaces_left_of_center = int(columns / 2)
-    start_pos_left = container.left_of(center_x,
-                                       spaces_left_of_center * spacing)
+    start_pos_left = left_of(center_x, spaces_left_of_center * spacing)
     if columns % 2 == 0 and columns > 1:
         # even number of columns; adjust start_pos so that center_x is between
         # the middle two items.
-        start_pos_left = container.right_of(start_pos_left, half_space)
+        start_pos_left = right_of(start_pos_left, half_space)
 
     spaces_above_center = int(rows / 2)
-    start_pos_top = container.above(center_y, spaces_above_center * spacing)
+    start_pos_top = above(center_y, spaces_above_center * spacing)
     if rows % 2 == 0 and rows > 1:
-        start_pos_top = container.below(start_pos_top, half_space)
+        start_pos_top = below(start_pos_top, half_space)
 
     # adjust the beginning x,y values so adding a space results in the first
     # position.
-    x_coord = container.left_of(start_pos_left, spacing)
-    y_coord = container.above(start_pos_top, spacing)
+    x_coord = left_of(start_pos_left, spacing)
+    y_coord = above(start_pos_top, spacing)
 
     positions = []
     for _row in range(rows):
-        y_coord = container.below(y_coord, spacing)
-        x_coord = container.left_of(start_pos_left, spacing)
+        y_coord = below(y_coord, spacing)
+        x_coord = left_of(start_pos_left, spacing)
         for _col in range(columns):
-            x_coord = container.right_of(x_coord, spacing)
+            x_coord = right_of(x_coord, spacing)
             positions.append((x_coord, y_coord))
 
     return positions

--- a/bcipy/display/paradigm/vep/display.py
+++ b/bcipy/display/paradigm/vep/display.py
@@ -68,8 +68,10 @@ class VEPStim:
             elif square.color == colors[1]:
                 frame1_holes.append(square_boundary)
 
-        # checkerboard is represented as a polygon with holes, backed by a
+        # Checkerboard is represented as a polygon with holes, backed by a
         # simple square with the alternating color.
+        # This technique renders more efficiently and scales better than using
+        # separate shapes (Rect or Gradient) for each square.
         background = ShapeStim(self.window,
                                lineColor=colors[1],
                                fillColor=colors[1],
@@ -127,7 +129,6 @@ class VEPDisplay(Display):
         self.window = window
         self.window_size = self.window.size  # [w, h]
         self.refresh_rate = round(window.getActualFrameRate())
-        print(f"Refresh rate: {self.refresh_rate}")
         self.logger = logging.getLogger(__name__)
 
         # number of VEP text areas

--- a/bcipy/display/paradigm/vep/display.py
+++ b/bcipy/display/paradigm/vep/display.py
@@ -290,7 +290,6 @@ class VEPDisplay(Display):
                 # self.draw_static()
                 self.window.flip()
         ended_at = self.static_clock.getTime()
-        # TODO: should we have a trigger for VEP_STIM_END?
         self.logger.debug(
             f"Expected stim time: {self.timing_stimuli}; actual run time: {ended_at}"
         )

--- a/bcipy/display/paradigm/vep/display.py
+++ b/bcipy/display/paradigm/vep/display.py
@@ -111,9 +111,9 @@ class VEPStim:
             stim.draw()
 
 
-
 class VEPDisplay(Display):
     """Display for VEP paradigm"""
+
     def __init__(
             self,
             window: visual.Window,
@@ -178,7 +178,6 @@ class VEPDisplay(Display):
                                           num_squares=25)
 
         self.text_boxes = self._build_text_boxes(box_config)
-
 
     def check_configuration(self):
         """Check that configured properties are consistent"""
@@ -343,7 +342,6 @@ class VEPDisplay(Display):
 
         return self.sti
 
-
     def build_vep_stimuli(self,
                           positions: List[Tuple[float, float]],
                           codes: List[int],
@@ -361,7 +359,6 @@ class VEPDisplay(Display):
                         size=stim_size,
                         num_squares=num_squares))
         return stim
-
 
     def _trigger_pulse(self) -> None:
         """Trigger Pulse.
@@ -382,7 +379,8 @@ class VEPDisplay(Display):
             self.first_stim_time = calibration_time[-1]
             self.first_run = False
 
-    def schedule_to(self, stimuli: List[List[str]], timing: List[List[float]]=None, colors: List[List[str]]=None) -> None:
+    def schedule_to(self, stimuli: List[List[str]], timing: List[List[float]]
+                    = None, colors: List[List[str]] = None) -> None:
         """Schedule stimuli elements (works as a buffer).
         """
         self.stimuli_inquiry = stimuli
@@ -395,7 +393,7 @@ class VEPDisplay(Display):
         associated VEP Box.
         """
         positions = box_config.positions
-        size = box_config.box_size()
+        size = box_config.box_size
         return [
             visual.TextBox2(win=self.window,
                             text=" ",
@@ -412,7 +410,6 @@ class VEPDisplay(Display):
                             letterHeight=self.stimuli_height)
             for pos, color in zip(positions, cycle(self.stimuli_colors))
         ]
-
 
     def _reset_text_boxes(self) -> None:
         """Reset text boxes.

--- a/bcipy/display/paradigm/vep/layout.py
+++ b/bcipy/display/paradigm/vep/layout.py
@@ -122,7 +122,7 @@ class BoxConfiguration():
         assert self.num_boxes == 4 or self.num_boxes == 6, 'Number of boxes must be 4 or 6'
         assert self.height_pct <= 0.5, "Rows can't take more than 50% of the height"
 
-    def box_size(self, validate: bool = True) -> Tuple[float, float]:
+    def _box_size(self, validate: bool = True) -> Tuple[float, float]:
         """Computes the size of each box"""
         if validate:
             self.validate()
@@ -140,6 +140,11 @@ class BoxConfiguration():
         return (width, height)
 
     @property
+    def box_size(self) -> Tuple[float, float]:
+        """Size of each box"""
+        return self._box_size()
+
+    @property
     def units(self) -> str:
         """Position units"""
         return self.layout.units
@@ -152,7 +157,7 @@ class BoxConfiguration():
         """
         self.validate()
 
-        width, height = self.box_size(validate=False)
+        width, height = self._box_size(validate=False)
 
         layout = self.layout
         top = below(layout.top, (height / 2))

--- a/bcipy/display/paradigm/vep/layout.py
+++ b/bcipy/display/paradigm/vep/layout.py
@@ -13,6 +13,12 @@ class CheckerboardSquare(NamedTuple):
     color: str
     size: Tuple[float, float]
 
+    def inverse_color(self, colors: Tuple[str, str]) -> str:
+        """Get the inverse color of this square"""
+        if self.color == colors[0]:
+            return colors[1]
+        return colors[0]
+
     def inverse(self, colors: Tuple[str, str]) -> 'CheckerboardSquare':
         """Returns a new CheckerboardSquare whose color is the inverse
         of the current one.

--- a/bcipy/display/paradigm/vep/layout.py
+++ b/bcipy/display/paradigm/vep/layout.py
@@ -105,16 +105,15 @@ class BoxConfiguration():
                  num_boxes: int,
                  spacing_pct: Optional[float] = None,
                  height_pct: float = 0.25):
-        assert num_boxes == 4 or num_boxes == 6, 'Number of boxes must be 4 or 6'
-        assert height_pct <= 0.5, "Rows can't take more than 50% of the height"
-        self.num_boxes = num_boxes
         self.layout = layout
+        self.num_boxes = num_boxes
+        self.height_pct = height_pct
+        self.validate()
 
         default_spacing = {4: 0.1, 6: 0.05}
         if not spacing_pct:
             spacing_pct = default_spacing[num_boxes]
         self.spacing_pct = spacing_pct
-        self.height_pct = height_pct
         self._row_count = 2
 
     def validate(self):

--- a/bcipy/display/paradigm/vep/layout.py
+++ b/bcipy/display/paradigm/vep/layout.py
@@ -4,7 +4,8 @@ from itertools import cycle
 from math import sqrt
 from typing import List, NamedTuple, Optional, Tuple
 
-from bcipy.display.components.layout import Layout
+from bcipy.display.components.layout import (Layout, above, below, left_of,
+                                             right_of)
 
 
 class CheckerboardSquare(NamedTuple):
@@ -34,8 +35,8 @@ class CheckerboardSquare(NamedTuple):
         return CheckerboardSquare(self.pos, color, self.size)
 
 
-def checkerboard(layout: Layout, squares: int, colors: Tuple[str, str],
-                 center: Tuple[float, float],
+def checkerboard(squares: int, colors: Tuple[str, str], center: Tuple[float,
+                                                                      float],
                  board_size: Tuple[float, float]) -> List[CheckerboardSquare]:
     """Computes positions and colors for squares used to represent a
     checkerboard pattern. Returned positions are the center point of
@@ -43,8 +44,6 @@ def checkerboard(layout: Layout, squares: int, colors: Tuple[str, str],
 
     Parameters
     ----------
-        layout - layout in which the checkerboard will be rendered. Used for
-            positioning and scale.
         squares - total number of squares in the board; must be a perfect
             square (ex. 4, 9, 16, 25)
         colors - tuple of color names between which to alternate
@@ -65,22 +64,22 @@ def checkerboard(layout: Layout, squares: int, colors: Tuple[str, str],
     if squares % 2 == 0:
         # with an even number the center is on a vertex; adjust by half a box
         move_count -= 0.5
-    left = layout.left_of(center_x, square_width * move_count)
-    top = layout.above(center_y, square_height * move_count)
+    left = left_of(center_x, square_width * move_count)
+    top = above(center_y, square_height * move_count)
 
     # iterate starting at the top left and proceeding in a zig zag
     # pattern to correspond with alternating checkerboard colors.
     positions = []
     for row in range(boxes_per_row):
         if row > 0:
-            top = layout.below(top, square_height)
+            top = below(top, square_height)
         for col in range(boxes_per_row):
             positions.append((left, top))
             if col < boxes_per_row - 1:
                 if row % 2 == 0:
-                    left = layout.right_of(left, square_width)
+                    left = right_of(left, square_width)
                 else:
-                    left = layout.left_of(left, square_width)
+                    left = left_of(left, square_width)
     return [
         CheckerboardSquare(*args)
         for args in zip(positions, cycle(colors), cycle([square_size]))
@@ -153,15 +152,14 @@ class BoxConfiguration():
         """
         self.validate()
 
-        # size = box_size(num, layout, spacing_pct)
         width, height = self.box_size(validate=False)
 
         layout = self.layout
-        top = layout.below(layout.top, (height / 2))
-        bottom = layout.above(layout.bottom, (height / 2))
+        top = below(layout.top, (height / 2))
+        bottom = above(layout.bottom, (height / 2))
 
-        left = layout.right_of(layout.left, width / 2)
-        right = layout.left_of(layout.right, width / 2)
+        left = right_of(layout.left, width / 2)
+        right = left_of(layout.right, width / 2)
 
         positions = [(left, top), (right, top), (left, bottom),
                      (right, bottom)]

--- a/bcipy/display/paradigm/vep/layout.py
+++ b/bcipy/display/paradigm/vep/layout.py
@@ -1,0 +1,165 @@
+"""Functionality for computing positions for elements within a VEP display"""
+
+from itertools import cycle
+from math import sqrt
+from typing import List, NamedTuple, Optional, Tuple
+
+from bcipy.display.components.layout import Layout
+
+
+class CheckerboardSquare(NamedTuple):
+    """Represents a single square within a checkerboard"""
+    pos: Tuple[float, float]
+    color: str
+    size: Tuple[float, float]
+
+    def inverse(self, colors: Tuple[str, str]) -> 'CheckerboardSquare':
+        """Returns a new CheckerboardSquare whose color is the inverse
+        of the current one.
+
+        Parameters
+        ----------
+            colors - 2-tuple of color choices; the current square's color
+                must be included.
+        """
+        assert len(colors) == 2, "Colors must be a 2-tuple"
+        first, second = colors
+        color = {first: second, second: first}[self.color]
+        return CheckerboardSquare(self.pos, color, self.size)
+
+
+def checkerboard(layout: Layout, squares: int, colors: Tuple[str, str],
+                 center: Tuple[float, float],
+                 board_size: Tuple[float, float]) -> List[CheckerboardSquare]:
+    """Computes positions and colors for squares used to represent a
+    checkerboard pattern. Returned positions are the center point of
+    each square
+
+    Parameters
+    ----------
+        layout - layout in which the checkerboard will be rendered. Used for
+            positioning and scale.
+        squares - total number of squares in the board; must be a perfect
+            square (ex. 4, 9, 16, 25)
+        colors - tuple of color names between which to alternate
+        center - position of the center point of the board
+        board_size - size in layout units of the entire checkerboard; square
+            size will be computed from this.
+    """
+    boxes_per_row = int(sqrt(squares))
+    assert boxes_per_row**2 == squares, "Must be a perfect square"
+
+    square_width = board_size[0] / boxes_per_row
+    square_height = board_size[1] / boxes_per_row
+    square_size = (square_width, square_height)
+    center_x, center_y = center
+
+    # find the center position of the left_top square
+    move_count = int(boxes_per_row / 2)
+    if squares % 2 == 0:
+        # with an even number the center is on a vertex; adjust by half a box
+        move_count -= 0.5
+    left = layout.left_of(center_x, square_width * move_count)
+    top = layout.above(center_y, square_height * move_count)
+
+    # iterate starting at the top left and proceeding in a zig zag
+    # pattern to correspond with alternating checkerboard colors.
+    positions = []
+    for row in range(boxes_per_row):
+        if row > 0:
+            top = layout.below(top, square_height)
+        for col in range(boxes_per_row):
+            positions.append((left, top))
+            if col < boxes_per_row - 1:
+                if row % 2 == 0:
+                    left = layout.right_of(left, square_width)
+                else:
+                    left = layout.left_of(left, square_width)
+    return [
+        CheckerboardSquare(*args)
+        for args in zip(positions, cycle(colors), cycle([square_size]))
+    ]
+
+
+class BoxConfiguration():
+    """Computes box size and positions for a VEP display.
+
+    In this configuration, there is one row on top and one on the bottom.
+
+    Parameters
+    ----------
+        num_boxes - number of boxes; currently supports 4 or 6.
+        layout - defines the boundaries within a Window in which the text areas
+            will be placed
+        spacing_pct - used to specify spacing between boxes within a row.
+        row_pct - what percentage of the height each row should use.
+    """
+
+    def __init__(self,
+                 layout: Layout,
+                 num_boxes: int,
+                 spacing_pct: Optional[float] = None,
+                 height_pct: float = 0.25):
+        assert num_boxes == 4 or num_boxes == 6, 'Number of boxes must be 4 or 6'
+        assert height_pct <= 0.5, "Rows can't take more than 50% of the height"
+        self.num_boxes = num_boxes
+        self.layout = layout
+
+        default_spacing = {4: 0.1, 6: 0.05}
+        if not spacing_pct:
+            spacing_pct = default_spacing[num_boxes]
+        self.spacing_pct = spacing_pct
+        self.height_pct = height_pct
+        self._row_count = 2
+
+    def validate(self):
+        """Validate invariants"""
+        assert self.num_boxes == 4 or self.num_boxes == 6, 'Number of boxes must be 4 or 6'
+        assert self.height_pct <= 0.5, "Rows can't take more than 50% of the height"
+
+    def box_size(self, validate: bool = True) -> Tuple[float, float]:
+        """Computes the size of each box"""
+        if validate:
+            self.validate()
+        number_per_row = self.num_boxes / self._row_count
+
+        # left and right boxes go to the edges, with a space between each box
+        spaces_per_row = number_per_row - 1
+
+        total_box_width_pct = 1 - (self.spacing_pct * spaces_per_row)
+        width_pct = (total_box_width_pct / number_per_row)
+
+        width = self.layout.width * width_pct
+        height = self.layout.height * self.height_pct
+
+        return (width, height)
+
+    @property
+    def units(self) -> str:
+        """Position units"""
+        return self.layout.units
+
+    @property
+    def positions(self) -> List[Tuple]:
+        """Computes positions for text areas which contain symbols. Boxes are
+        positioned in the corners for 4 elements. With 6 there are also areas
+        in the middle.
+        """
+        self.validate()
+
+        # size = box_size(num, layout, spacing_pct)
+        width, height = self.box_size(validate=False)
+
+        layout = self.layout
+        top = layout.below(layout.top, (height / 2))
+        bottom = layout.above(layout.bottom, (height / 2))
+
+        left = layout.right_of(layout.left, width / 2)
+        right = layout.left_of(layout.right, width / 2)
+
+        positions = [(left, top), (right, top), (left, bottom),
+                     (right, bottom)]
+        if self.num_boxes == 6:
+            positions += [(layout.horizontal_middle, top),
+                          (layout.horizontal_middle, bottom)]
+        return positions

--- a/bcipy/display/tests/components/test_layout.py
+++ b/bcipy/display/tests/components/test_layout.py
@@ -4,7 +4,9 @@ import unittest
 from mockito import mock
 
 from bcipy.display.components.layout import (Alignment, Layout, at_bottom,
-                                             at_top, centered)
+                                             at_top, centered, envelope,
+                                             from_envelope, scaled_height,
+                                             scaled_size)
 
 
 class TestLayout(unittest.TestCase):
@@ -154,6 +156,45 @@ class TestLayout(unittest.TestCase):
         layout.resize_height(0.5, alignment=Alignment.BOTTOM)
         self.assertEqual(0.0, layout.top)
         self.assertEqual(-1.0, layout.bottom)
+
+    def test_envelope(self):
+        """Test calculation of a shape's envelope"""
+        pos = (0, 0)
+        width = 0.2
+        height = 0.1
+        verts = envelope(pos=pos, size=(width, height))
+        self.assertEqual(len(verts), 4)
+        self.assertTrue((-0.1, 0.05) in verts)
+        self.assertTrue((-0.1, -0.05) in verts)
+        self.assertTrue((0.1, -0.05) in verts)
+        self.assertTrue((0.1, 0.05) in verts)
+
+    def test_from_envelope(self):
+        """Test constructing a layout from an envelope"""
+        verts = envelope(pos=(0, 0), size=(0.2, 0.1))
+        layout = from_envelope(verts)
+        self.assertEqual(layout.top, 0.05)
+        self.assertEqual(layout.bottom, -0.05)
+        self.assertEqual(layout.left, -0.1)
+        self.assertEqual(layout.right, 0.1)
+        self.assertEqual(layout.center, (0, 0))
+
+    def test_scaled_size(self):
+        """Test scaling the size to make shapes that display as squares"""
+        self.assertEqual(
+            scaled_size(height=0.2, window_size=(500, 500)), (0.2, 0.2),
+            msg="Height and width should be the same in a square window")
+        self.assertEqual(
+            scaled_size(height=0.2, window_size=(800, 500)), (0.125, 0.2),
+            msg="Width should be proportional to the window aspect")
+
+        self.assertEqual(
+            scaled_size(height=0.2, window_size=(800, 500), units='height'), (0.2, 0.2),
+            msg="Width should be the same in 'height' units")
+
+    def test_scaled_height(self):
+        """Test calculation of scaled height based on width"""
+        self.assertEqual(scaled_height(0.125, window_size=(800, 500)), 0.2)
 
 
 if __name__ == '__main__':

--- a/bcipy/display/tests/vep/test_vep_layout.py
+++ b/bcipy/display/tests/vep/test_vep_layout.py
@@ -1,0 +1,130 @@
+"""Tests for VEP layout functions"""
+import unittest
+
+from mockito import mock
+
+from bcipy.display.components.layout import Layout
+from bcipy.display.paradigm.vep.layout import (BoxConfiguration,
+                                               CheckerboardSquare,
+                                               checkerboard)
+
+
+class TestVEPLayout(unittest.TestCase):
+    """Test VEP Layout functionality."""
+
+    def setUp(self):
+        """Set up needed items for test."""
+        self.window = mock({"size": (500, 500), "units": "norm"})
+        self.container = self.window
+
+    def test_2x2_checkerboard(self):
+        """Test creation of a 2x2 board"""
+        squares = checkerboard(squares=4,
+                               colors=('red', 'green'),
+                               center=(0, 0),
+                               board_size=(0.2, 0.2))
+        self.assertEqual(len(squares), 4)
+        self.assertTrue(all(sq.size == (0.1, 0.1) for sq in squares))
+        self.assertEqual(
+            [sq.pos for sq in squares], [(-0.05, 0.05), (0.05, 0.05),
+                                         (0.05, -0.05), (-0.05, -0.05)],
+            msg="Squares should be ordered in a zig-zag arrangement")
+        self.assertEqual([sq.color for sq in squares],
+                         ['red', 'green', 'red', 'green'],
+                         msg="colors should alternate")
+
+    def test_3x3_checkerboard(self):
+        """Test creation of a 3x3 board"""
+        colors = ('blue', 'yellow')
+        squares = checkerboard(squares=9,
+                               colors=colors,
+                               center=(0, 0),
+                               board_size=(0.48, 0.48))
+        self.assertEqual(len(squares), 9)
+        self.assertTrue(all(sq.size == (0.16, 0.16) for sq in squares))
+        self.assertEqual(squares[0].pos, (-0.16, 0.16))
+        self.assertEqual(
+            squares[3].pos, (0.16, 0.0),
+            msg="First item on second row should be at the far right")
+
+        for i, square in enumerate(squares):
+            self.assertEqual(colors[i % 2], square.color,
+                             "Colors should alternate")
+
+    def test_checkerboard_inverse(self):
+        """Test that a Checkerboard square can invert colors"""
+        colors = ('red', 'green')
+        square = CheckerboardSquare(pos=(0, 0), color='red', size=(0.1, 0.1))
+        self.assertEqual(
+            square.inverse(colors),
+            CheckerboardSquare(pos=(0, 0), color='green', size=(0.1, 0.1)))
+
+        self.assertEqual(square.inverse_color(colors), 'green')
+
+    def test_4_box_config_defaults(self):
+        """Test box configuration"""
+        full_window = Layout()
+        config = BoxConfiguration(layout=full_window,
+                                  num_boxes=4,
+                                  height_pct=0.25,
+                                  spacing_pct=0.1)
+        width, height = config.box_size
+        window_width, window_height = full_window.size
+
+        self.assertEqual(window_width, 2.0)
+        self.assertEqual(window_height, 2.0)
+        self.assertEqual(
+            width,
+            0.9,
+            msg="Box width should be half of the remaining width after accounting for the spacing."
+        )
+        self.assertEqual(
+            height,
+            0.5,
+            msg="Box height should be height_pct of the window height")
+
+        positions = config.positions
+        self.assertEqual(len(positions), 4)
+        self.assertTrue((-0.55, 0.75) in positions,
+                        msg="A box should be positioned at the top left")
+        self.assertTrue((0.55, 0.75) in positions,
+                        msg="A box should be positioned at the top right")
+        self.assertTrue((-0.55, -0.75) in positions,
+                        msg="A box should be positioned at the bottom left")
+        self.assertTrue((0.55, -0.75) in positions,
+                        msg="A box should be positioned at the bottom right")
+
+    def test_6_box_config_defaults(self):
+        """Test box configuration"""
+        full_window = Layout()
+        config = BoxConfiguration(layout=full_window,
+                                  num_boxes=6,
+                                  height_pct=0.25,
+                                  spacing_pct=0.05)
+        self.assertEqual(
+            config.box_size, (0.6, 0.5),
+            msg="width should account for 3 boxes in a row and 2 spaces")
+
+        positions = config.positions
+        self.assertEqual(len(positions), 6)
+        self.assertEqual(len([box for box in positions if box[0] == 0.0]),
+                         2,
+                         msg="Two boxes should be positioned in the middle")
+
+    def test_other_box_config(self):
+        """Test supported number of boxes"""
+        full_window = Layout()
+        with self.assertRaises(AssertionError):
+            BoxConfiguration(layout=full_window,
+                             num_boxes=2,
+                             height_pct=0.25,
+                             spacing_pct=0.05)
+
+    def test_height_pct_validation(self):
+        """Test validations"""
+        full_window = Layout()
+        with self.assertRaises(AssertionError):
+            BoxConfiguration(layout=full_window,
+                             num_boxes=4,
+                             height_pct=0.6,
+                             spacing_pct=0.1)


### PR DESCRIPTION
# Overview

Modified VEP Display to support a configurable number of text areas with provided positions, as well as configurable VEP stimulus that can use any size of checkerboard pattern.

## Ticket

https://www.pivotaltracker.com/story/show/184564386

## Contributions

- Added a module for computing box positions and checkerboard patterns.
- Updated the vep demo code.
- Refactored the display code to use the new positions, simplifying stim creation.
- Refactored the layout utilities to support computing square shapes in 'norm' units. Also refactored to support 'height' units.
- Created a demo module for demonstrating various positional elements.

## Test

- Ran all demo code
- Created unit tests for computations. Ran all unit tests.

## Discussion

With just 4 text areas and a 2x2 checkerboard to represent each VEPStimuli, the flicker rate was able to render in the allotted 1 second. However, with 6 text areas, this increased the total number of stimuli to be rendered in each frame and the rendering of a single flicker took longer than 1 second. This problem was worse when the checkerboard size was increased to 3x3 or above. This is because each square on the checkerboard was represented using two shapes, a GratingStim for 'on' and one for 'off'. With 6 areas, this resulted in 48 visual shapes just to represent the stim.

I was able to reduce the number of stimuli by rendering each VEP Stim (checkerboard) as two visual shapes, a polygon with the primary color that has holes for each alternating square, and a backing square with the secondary color. On my local machine with 6 text boxes and 6 corresponding 5x5 checkerboards, the timing was able to complete in the allowed second. I put logging in place to confirm that this will work on other machines. If not, we can reduce the checkerboard size or draw fewer static elements.

https://github.com/CAMBI-tech/BciPy/assets/2153447/1cf9efa4-ad5f-41bf-b745-828121a253a3


