### PR TITLE
Matrix row spacing

### DIFF
--- a/bcipy/display/components/layout.py
+++ b/bcipy/display/components/layout.py
@@ -102,6 +102,15 @@ def scaled_height(width: float,
     return width / (win_height / win_width)
 
 
+def scaled_width(height: float,
+                 window_size: Tuple[float, float],
+                 units: str = 'norm'):
+    """Given a height, find the equivalent width scaled to the aspect ratio of
+    a window with the given size"""
+    width, _height = scaled_size(height, window_size, units)
+    return width
+
+
 class Layout(Container):
     """Class with methods for positioning elements within a parent container.
     """
@@ -302,19 +311,22 @@ def at_bottom(parent: Container, height: float) -> Layout:
                   bottom=bottom)
 
 
-def centered(width_pct: float = 1.0, height_pct: float = 1.0) -> Layout:
+def centered(parent: Optional[Container] = None,
+             width_pct: float = 1.0,
+             height_pct: float = 1.0) -> Layout:
     """Constructs a layout that is centered on the screen. Default size is
     fullscreen but optional parameters can be used to adjust the width and
     height.
 
     Parameters
     ----------
+        parent - optional parent
         width_pct - optional; sets the width to a given percentage of
           fullscreen.
         height_pct - optional; sets the height to a given percentage of
           fullscreen.
     """
-    container = Layout()
+    container = Layout(parent=parent)
     container.resize_width(width_pct, alignment=Alignment.CENTERED)
     container.resize_height(height_pct, alignment=Alignment.CENTERED)
     return container

--- a/bcipy/display/demo/components/demo_layouts.py
+++ b/bcipy/display/demo/components/demo_layouts.py
@@ -1,4 +1,6 @@
 """Useful for viewing computed positions in a window"""
+import logging
+import sys
 import time
 from typing import Callable, List, Tuple, Union
 
@@ -11,7 +13,9 @@ from psychopy.visual.shape import ShapeStim
 from bcipy.display.components.layout import (Layout, at_top, centered,
                                              envelope, height_units,
                                              scaled_size)
+from bcipy.display.paradigm.matrix.layout import symbol_positions
 from bcipy.display.paradigm.vep.layout import BoxConfiguration, checkerboard
+from bcipy.helpers.symbols import alphabet
 
 
 def make_window():
@@ -253,6 +257,26 @@ def demo_checkerboard2(win: visual.Window):
     win.flip()
 
 
+def demo_matrix_positions(win: visual.Window):
+    """Demo matrix positions. Useful for visualizing how adjustments to layout
+    dimensions as well as the number of rows and columns affects positioning.
+    """
+    # norm_layout = centered(parent=win, width_pct=1., height_pct=0.5)
+    norm_layout = centered(parent=win, width_pct=0.75, height_pct=1)
+    positions = symbol_positions(norm_layout, rows=5, columns=6)
+
+    for sym, pos in zip(alphabet(), positions):
+        stim = visual.TextStim(win,
+                               text=sym,
+                               pos=pos,
+                               color='white',
+                               height=0.17)
+        stim.draw()
+    draw_boundary(win, norm_layout, line_px=5, color='gray')
+    draw_positions(win, positions, size=scaled_size(0.025, win.size))
+    win.flip()
+
+
 def run(demo: Callable[[visual.Window], None], seconds=30):
     """Run the given function for the provided duration.
 
@@ -261,6 +285,12 @@ def run(demo: Callable[[visual.Window], None], seconds=30):
         demo - function to run; a Window object is passed to this function.
         seconds - Window is closed after this duration.
     """
+    root = logging.getLogger()
+    root.setLevel(logging.DEBUG)
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setLevel(logging.DEBUG)
+    root.addHandler(handler)
+
     try:
         win = make_window()
         print(
@@ -281,8 +311,9 @@ def run(demo: Callable[[visual.Window], None], seconds=30):
         print('Demo complete.')
 
 
-run(demo_vep)
+# run(demo_vep)
 # run(demo_height_units)
 # run(show_layout_coords)
 # run(demo_checkerboard)
 # run(demo_checkerboard2)
+run(demo_matrix_positions)

--- a/bcipy/display/demo/matrix/demo_matrix_layout.py
+++ b/bcipy/display/demo/matrix/demo_matrix_layout.py
@@ -47,6 +47,7 @@ matrix_display = MatrixDisplay(win,
                                info=info,
                                rows=3,
                                columns=10,
+                               width_pct=0.9,
                                sort_order=qwerty_order(is_txt_stim=True))
 
 matrix_display.draw(grid_opacity=matrix_display.full_grid_opacity,

--- a/bcipy/display/paradigm/matrix/display.py
+++ b/bcipy/display/paradigm/matrix/display.py
@@ -42,7 +42,8 @@ class MatrixDisplay(Display):
                  info: InformationProperties,
                  rows: int = 5,
                  columns: int = 6,
-                 width_pct: float = 0.7,
+                 width_pct: float = 0.75,
+                 height_pct: float = 0.8,
                  trigger_type: str = 'text',
                  symbol_set: Optional[List[str]] = None,
                  should_prompt_target: bool = True,
@@ -88,7 +89,9 @@ class MatrixDisplay(Display):
         # Set position and parameters for grid of alphabet
         self.grid_stimuli_height = 0.17  # stimuli.stim_height
 
-        display_container = layout.centered(width_pct=width_pct)
+        display_container = layout.centered(parent=window,
+                                            width_pct=width_pct,
+                                            height_pct=height_pct)
         self.positions = symbol_positions(display_container, rows, columns)
         self.logger.info(
             f"Symbol positions ({display_container.units} units): {self.positions}"

--- a/bcipy/display/paradigm/matrix/display.py
+++ b/bcipy/display/paradigm/matrix/display.py
@@ -1,6 +1,6 @@
 """Display for presenting stimuli in a grid."""
 import logging
-from typing import Callable, Dict, List, NamedTuple, Optional
+from typing import Callable, Dict, List, NamedTuple, Optional, Tuple
 
 from psychopy import core, visual
 
@@ -93,9 +93,6 @@ class MatrixDisplay(Display):
                                             width_pct=width_pct,
                                             height_pct=height_pct)
         self.positions = symbol_positions(display_container, rows, columns)
-        self.logger.info(
-            f"Symbol positions ({display_container.units} units): {self.positions}"
-        )
 
         self.grid_color = 'white'
         self.start_opacity = 0.15
@@ -115,6 +112,20 @@ class MatrixDisplay(Display):
 
         self.stim_registry = self.build_grid()
         self.should_prompt_target = should_prompt_target
+
+        self.logger.info(
+            f"Symbol positions ({display_container.units} units):\n{self._stim_positions}"
+        )
+        self.logger.info(f"Matrix center position: {display_container.center}")
+
+    @property
+    def _stim_positions(self) -> Dict[str, Tuple[float, float]]:
+        """Returns a dict with the position for each stim"""
+        assert self.stim_registry, "stim_registry not yet initialized"
+        return {
+            sym: tuple(stim.pos)
+            for sym, stim in self.stim_registry.items()
+        }
 
     def schedule_to(self, stimuli: list, timing: list, colors: list) -> None:
         """Schedule stimuli elements (works as a buffer).

--- a/bcipy/display/paradigm/matrix/layout.py
+++ b/bcipy/display/paradigm/matrix/layout.py
@@ -1,63 +1,75 @@
 """Functions for calculating matrix layouts"""
+import logging
 from typing import List, Tuple
 
 from bcipy.display.components.layout import (Layout, above, below, left_of,
-                                             right_of)
+                                             right_of, scaled_height,
+                                             scaled_width)
+
+logger = logging.getLogger(__name__)
 
 
-def symbol_positions(container: Layout,
-                     rows: int,
-                     columns: int,
-                     spacing: float = None) -> List[Tuple[float, float]]:
+def symbol_positions(container: Layout, rows: int,
+                     columns: int, max_spacing: float = None) -> List[Tuple[float, float]]:
     """Compute the positions for arranging a number of symbols in a grid
     layout.
 
     Parameters
     ----------
-        container - container in which the grid should be placed
+        container - container in which the grid should be placed; must have a
+            visual.Window parent, which is used to determine the aspect ratio.
         rows - number of rows in the grid
         columns - number of columns in the grid
-        spacing - optional value to specify the space between positions
-            (in the same units of the container)
-
+        max_spacing - optional max spacing (in layout units) in the height
+            direction; width will be normalized to this value if provided
     Returns
     -------
         list of (x,y) tuples with (rows * columns) positions in row,col order
     """
+    assert container.parent, "Container must have a parent"
     assert rows >= 1 and columns >= 1, "There must be at least one row and one column"
 
-    if not spacing:
-        # compute the spacing (in container units) from the container width and height
-        horizontal_spacing = container.width / (rows + 1)
-        vertical_spacing = container.height / (columns + 1)
-        spacing = min(horizontal_spacing, vertical_spacing)
-    half_space = spacing / 2
+    # compute the spacing (in container units) from the container width and height
+    horizontal_spacing = container.width / (columns + 1)
+    vertical_spacing = container.height / (rows + 1)
+
+    if max_spacing and vertical_spacing > max_spacing:
+        vertical_spacing = max_spacing
+
+    # Use the minimum spacing
+    if horizontal_spacing < vertical_spacing:
+        vertical_spacing = scaled_height(horizontal_spacing,
+                                         container.parent.size)
+    else:
+        horizontal_spacing = scaled_width(vertical_spacing,
+                                          container.parent.size)
 
     # Work back from center to compute the starting position
     center_x, center_y = container.center
     spaces_left_of_center = int(columns / 2)
-    start_pos_left = left_of(center_x, spaces_left_of_center * spacing)
+    start_pos_left = left_of(center_x,
+                             spaces_left_of_center * horizontal_spacing)
     if columns % 2 == 0 and columns > 1:
         # even number of columns; adjust start_pos so that center_x is between
         # the middle two items.
-        start_pos_left = right_of(start_pos_left, half_space)
+        start_pos_left = right_of(start_pos_left, horizontal_spacing / 2)
 
     spaces_above_center = int(rows / 2)
-    start_pos_top = above(center_y, spaces_above_center * spacing)
+    start_pos_top = above(center_y, spaces_above_center * vertical_spacing)
     if rows % 2 == 0 and rows > 1:
-        start_pos_top = below(start_pos_top, half_space)
+        start_pos_top = below(start_pos_top, vertical_spacing / 2)
 
     # adjust the beginning x,y values so adding a space results in the first
     # position.
-    x_coord = left_of(start_pos_left, spacing)
-    y_coord = above(start_pos_top, spacing)
+    x_coord = left_of(start_pos_left, horizontal_spacing)
+    y_coord = above(start_pos_top, vertical_spacing)
 
     positions = []
     for _row in range(rows):
-        y_coord = below(y_coord, spacing)
-        x_coord = left_of(start_pos_left, spacing)
+        y_coord = below(y_coord, vertical_spacing)
+        x_coord = left_of(start_pos_left, horizontal_spacing)
         for _col in range(columns):
-            x_coord = right_of(x_coord, spacing)
+            x_coord = right_of(x_coord, horizontal_spacing)
             positions.append((x_coord, y_coord))
 
     return positions

--- a/bcipy/display/tests/components/test_layout.py
+++ b/bcipy/display/tests/components/test_layout.py
@@ -6,7 +6,7 @@ from mockito import mock
 from bcipy.display.components.layout import (Alignment, Layout, at_bottom,
                                              at_top, centered, envelope,
                                              from_envelope, scaled_height,
-                                             scaled_size)
+                                             scaled_size, scaled_width)
 
 
 class TestLayout(unittest.TestCase):
@@ -195,6 +195,12 @@ class TestLayout(unittest.TestCase):
     def test_scaled_height(self):
         """Test calculation of scaled height based on width"""
         self.assertEqual(scaled_height(0.125, window_size=(800, 500)), 0.2)
+
+    def test_scaled_width(self):
+        """Test calculation of a scaled width based on height"""
+        self.assertEqual(scaled_width(height=0.2, window_size=(500, 500)), 0.2)
+        self.assertEqual(scaled_width(height=0.2, window_size=(800, 500)),
+                         0.125)
 
 
 if __name__ == '__main__':

--- a/bcipy/display/tests/paradigm/matrix/test_matrix_display.py
+++ b/bcipy/display/tests/paradigm/matrix/test_matrix_display.py
@@ -39,10 +39,11 @@ class TestMatrixDisplay(unittest.TestCase):
         self.window = mock({"units": "norm", "size": (2.0, 2.0)})
         self.experiment_clock = mock()
         self.static_clock = mock()
-        self.text_stim_mock = mock(psychopy.visual.TextStim)
+        self.text_stim_mock = mock({'pos': (0, 0)}, spec=psychopy.visual.TextStim)
         when(self.text_stim_mock).setOpacity(...).thenReturn()
         when(self.text_stim_mock).setColor(...).thenReturn()
         when(self.text_stim_mock).draw(...).thenReturn()
+
         # grid item
         when(psychopy.visual).TextStim(
             win=self.window,

--- a/bcipy/display/tests/paradigm/matrix/test_matrix_layout.py
+++ b/bcipy/display/tests/paradigm/matrix/test_matrix_layout.py
@@ -103,6 +103,23 @@ class TestMatrixLayout(unittest.TestCase):
         self.assertEqual(row_spacing, column_spacing,
                          "Rows and columns should have the same spacing")
 
+    def test_max_spacing(self):
+        """Test max_spacing parameter"""
+        max_spacing = 0.1
+        positions = symbol_positions(self.layout,
+                                     rows=2,
+                                     columns=2,
+                                     max_spacing=max_spacing)
+
+        top_left = positions[0]
+        top_right = positions[1]
+        bottom_left = positions[2]
+
+        row_spacing = abs(top_left[1] - bottom_left[1])
+        column_spacing = abs(top_right[0] - top_left[0])
+        self.assertEqual(row_spacing, max_spacing)
+        self.assertEqual(column_spacing, max_spacing)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Overview

Fixed computed positions for matrix layout to display equally spaced regardless of the Window's aspect ratio. Rows and columns should appear the same distance apart.

## Ticket

[Link a pivotal ticket here](https://www.pivotaltracker.com/story/show/185935799)

## Contributions

- Updated the matrix layout module to account for the window aspect ration when computing spacing. Also added a parameter for max_spacing to allow.
- Added demo for visualizing different matrix layout parameters.
- Added code to log the position of each symbol stim in the matrix display

## Test

- Ran all unit tests
- Ran relevant demos
