### PR TITLE
Adds tests to rehsapers

### DIFF
--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -221,7 +221,7 @@ class InquiryReshaper:
 
                 try:
                     new_trials.append(inquiries[:, inquiry_idx, start:end])
-                except IndexError:
+                except IndexError: # pragma: no cover
                     raise BciPyCoreException(
                         f'InquiryReshaper.extract_trials: index out of bounds. \n'
                         f'Inquiry: [{inquiry_idx}] from {start}:{end}. init_time: {time}, '

--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -221,7 +221,7 @@ class InquiryReshaper:
 
                 try:
                     new_trials.append(inquiries[:, inquiry_idx, start:end])
-                except IndexError: # pragma: no cover
+                except IndexError:  # pragma: no cover
                     raise BciPyCoreException(
                         f'InquiryReshaper.extract_trials: index out of bounds. \n'
                         f'Inquiry: [{inquiry_idx}] from {start}:{end}. init_time: {time}, '

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -883,8 +883,9 @@ class TestTrialReshaper(unittest.TestCase):
         )
         trial_length_samples = int(sample_rate * trial_length_s)
         expected_shape = (self.channel_number, len(self.target_info), trial_length_samples)
-        self.assertTrue(np.all(labels== [1, 0, 0]))
+        self.assertTrue(np.all(labels == [1, 0, 0]))
         self.assertTrue(reshaped_trials.shape == expected_shape)
+
 
 class TestInquiryReshaper(unittest.TestCase):
 

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -713,6 +713,22 @@ class TestStimuliGeneration(unittest.TestCase):
         self.assertEqual([1] + ([0.2] * n), times[0])
         self.assertEqual(['red'] + (['white'] * n), colors[0])
 
+    def test_best_case_inquiry_gen_invalid_alp(self):
+        """Test best_case_rsvp_inq_gen throws error when passed invalid alp shape"""
+        alp = ['a', 'b', 'c', 'd']
+        session_stimuli = [0.1, 0.1, 0.1, 0.2, 0.2, 0.1, 0.2]
+        n = 5
+        with self.assertRaises(BciPyCoreException, msg='Missing information about the alphabet.'):
+            best_case_rsvp_inq_gen(
+                alp=alp,
+                session_stimuli=session_stimuli,
+                timing=[1, 0.2],
+                color=['red', 'white'],
+                stim_number=1,
+                stim_length=n,
+                is_txt=True
+            )
+
     def test_best_case_inquiry_gen_with_inq_constants(self):
         """Test best_case_rsvp_inq_gen with inquiry constants"""
 

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -854,6 +854,21 @@ class TestTrialReshaper(unittest.TestCase):
         self.assertTrue(np.all(labels == [1, 0, 0]))
         self.assertTrue(reshaped_trials.shape == expected_shape)
 
+    def test_trial_reshaper_with_no_channel_map(self):
+        sample_rate = 256
+        trial_length_s = 0.5
+        reshaped_trials, labels = TrialReshaper()(
+            trial_targetness_label=self.target_info,
+            timing_info=self.timing_info,
+            eeg_data=self.eeg,
+            sample_rate=sample_rate,
+            channel_map=None,
+            poststimulus_length=trial_length_s
+        )
+        trial_length_samples = int(sample_rate * trial_length_s)
+        expected_shape = (self.channel_number, len(self.target_info), trial_length_samples)
+        self.assertTrue(np.all(labels== [1, 0, 0]))
+        self.assertTrue(reshaped_trials.shape == expected_shape)
 
 class TestInquiryReshaper(unittest.TestCase):
 

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -717,7 +717,7 @@ class TestStimuliGeneration(unittest.TestCase):
         """Test best_case_rsvp_inq_gen throws error when passed invalid alp shape"""
         alp = ['a', 'b', 'c', 'd']
         session_stimuli = [0.1, 0.1, 0.1, 0.2, 0.2, 0.1, 0.2]
-        n = 5
+        stim_length = 5
         with self.assertRaises(BciPyCoreException, msg='Missing information about the alphabet.'):
             best_case_rsvp_inq_gen(
                 alp=alp,
@@ -725,7 +725,7 @@ class TestStimuliGeneration(unittest.TestCase):
                 timing=[1, 0.2],
                 color=['red', 'white'],
                 stim_number=1,
-                stim_length=n,
+                stim_length=stim_length,
                 is_txt=True
             )
 

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -918,6 +918,20 @@ class TestInquiryReshaper(unittest.TestCase):
         self.assertTrue(reshaped_data.shape == expected_shape)
         self.assertTrue(np.all(labels == self.true_labels))
 
+    def test_inquiry_reshaper_with_no_channel_map(self):
+        reshaped_data, labels, _ = InquiryReshaper()(
+            trial_targetness_label=self.target_info,
+            timing_info=self.timing_info,
+            eeg_data=self.eeg,
+            sample_rate=self.sample_rate,
+            trials_per_inquiry=self.trials_per_inquiry,
+            channel_map=None,
+            poststimulus_length=self.trial_length
+        )
+        expected_shape = (self.n_channel, self.n_inquiry, self.samples_per_inquiry)
+        self.assertTrue(reshaped_data.shape == expected_shape)
+        self.assertTrue(np.all(labels == self.true_labels))
+
     def test_inquiry_reshaper_trial_extraction(self):
         timing = [[1, 3, 4], [1, 4, 5], [1, 2, 3], [4, 5, 6]]
         # make a fake eeg data array (n_channels, n_inquiry, n_samples)


### PR DESCRIPTION
# Overview

Add unit tests to reshapers to increase coverage. 

## Ticket

[Inquiry and Trial reshaping test](https://www.pivotaltracker.com/story/show/184957545)

## Contributions

- `test_stimuli`: added to reshaper tests

## Test

- `make test-all`

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Verify the updates you did here.

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? Not yet.
