### PR TITLE
Bump wxpython version

### DIFF
--- a/requirements-winmac.txt
+++ b/requirements-winmac.txt
@@ -1,1 +1,1 @@
-WxPython==4.1.1
+WxPython==4.2.1


### PR DESCRIPTION
# Overview

Bump wxpython version requirements needed for successful installation on Apple M2 computers.

## Discussion

I was able to successfully install BciPy on a new Apple M2 computer without using Rosetta. One of the changes needed to do so was to install dependencies needed for the `tables` library. The other was to update the version of wxpython, which fixes an issue in 4.1.1 in which it can't find the libtiff header file.

The needed dependency was hdf5, which I resolved with the following:
`brew install hdf5`
`export HDF5_DIR=/opt/homebrew/Cellar/hdf5/1.14.3`
