### PR TITLE
Data buffering issue

### DIFF
--- a/bcipy/acquisition/__init__.py
+++ b/bcipy/acquisition/__init__.py
@@ -1,9 +1,10 @@
-from bcipy.acquisition.protocols.lsl.lsl_client import (LslAcquisitionClient,
-                                                        discover_device_spec)
 from bcipy.acquisition.datastream.lsl_server import LslDataServer, await_start
 from bcipy.acquisition.multimodal import ClientManager
+from bcipy.acquisition.protocols.lsl.lsl_client import (LslAcquisitionClient,
+                                                        discover_device_spec)
+from bcipy.acquisition.record import Record
 
 __all__ = [
     'LslAcquisitionClient', 'LslDataServer', 'await_start',
-    'discover_device_spec', 'ClientManager'
+    'discover_device_spec', 'ClientManager', 'Record'
 ]

--- a/bcipy/acquisition/protocols/lsl/lsl_client.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_client.py
@@ -222,12 +222,12 @@ class LslAcquisitionClient:
         """Pull a chunk of samples from LSL and record in the buffer.
         Returns the count of samples pulled.
         """
-        log.info(f"Pulling from LSL (max_samples: {self.max_samples})")
+        log.debug(f"Pulling from LSL (max_samples: {self.max_samples})")
         # A timeout of 0.0 gets currently available samples without blocking.
         samples, timestamps = self.inlet.pull_chunk(
             timeout=0.0, max_samples=self.max_samples)
         count = len(samples)
-        log.info(f"\tReceived {count} samples")
+        log.debug(f"\tReceived {count} samples")
         for sample, stamp in zip(samples, timestamps):
             self.buffer.append(Record(sample, stamp))
         return count

--- a/bcipy/acquisition/protocols/lsl/lsl_client.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_client.py
@@ -1,7 +1,8 @@
 """DataAcquisitionClient for LabStreamingLayer data sources."""
 import logging
-from typing import Optional, List
+from typing import Dict, List, Optional
 
+import pandas as pd
 from pylsl import (StreamInfo, StreamInlet, local_clock, resolve_byprop,
                    resolve_stream)
 
@@ -54,6 +55,26 @@ class LslAcquisitionClient:
         self.max_buffer_len = max_buffer_len
         self.save_directory = save_directory
         self.raw_data_file_name = raw_data_file_name
+        self._max_samples = None
+
+    @property
+    def first_sample_time(self) -> float:
+        """Timestamp returned by the first sample. If the data is being
+        recorded this value reflects the timestamp of the first recorded sample"""
+        if self.recorder:
+            return self.recorder.first_sample_time
+        return self._first_sample_time
+
+    @property
+    def max_samples(self) -> int:
+        """Maximum number of samples available at any given time."""
+        if self._max_samples is None:
+            if self.device_spec.sample_rate == IRREGULAR_RATE:
+                self._max_samples = int(self.max_buffer_len)
+            else:
+                self._max_samples = int(self.max_buffer_len *
+                                        self.device_spec.sample_rate)
+        return self._max_samples
 
     def start_acquisition(self) -> bool:
         """Connect to the datasource and start acquiring data.
@@ -74,7 +95,7 @@ class LslAcquisitionClient:
 
         self.inlet = StreamInlet(
             stream_info,
-            max_buflen=self.max_buffer_len,
+            max_buflen=4 * self.max_buffer_len,  # TODO: revisit this value
             max_chunklen=1)
 
         if self.device_spec:
@@ -94,14 +115,6 @@ class LslAcquisitionClient:
             self.buffer = RingBuffer(size_max=self.max_samples)
         _, self._first_sample_time = self.inlet.pull_sample()
         return True
-
-    @property
-    def first_sample_time(self) -> float:
-        """Timestamp returned by the first sample. If the data is being
-        recorded this value reflects the timestamp of the first recorded sample"""
-        if self.recorder:
-            return self.recorder.first_sample_time
-        return self._first_sample_time
 
     def stop_acquisition(self) -> None:
         """Disconnect from the data source."""
@@ -126,11 +139,33 @@ class LslAcquisitionClient:
         """Context manager exit method to clean up resources."""
         self.stop_acquisition()
 
+    def _data_stats(self, data: List[Record]) -> Dict[str, float]:
+        """Summarize a list of records for logging and inspection."""
+        if data:
+            diffs = pd.DataFrame(data)['timestamp'].diff()
+            data_start = data[0].timestamp
+            data_end = data[-1].timestamp
+            precision = 3
+            return {
+                'count': len(data),
+                'seconds': round(data_end - data_start, precision),
+                'from': round(data_start, precision),
+                'to': round(data_end, precision),
+                'expected_diff': round(1 / self.device_spec.sample_rate,
+                                       precision),
+                'mean_diff': round(diffs.mean(), precision),
+                'max_diff': round(diffs.max(), precision)
+            }
+        return {}
+
     def get_data(self,
                  start: Optional[float] = None,
                  end: Optional[float] = None,
                  limit: Optional[int] = None) -> List[Record]:
         """Get data in time range.
+
+        Only data in the current buffer is available to query;
+        requests for data outside of this will fail.
 
         Parameters
         ----------
@@ -142,38 +177,31 @@ class LslAcquisitionClient:
         -------
             List of Records
         """
-        log.info(f"Getting data from: {start} to: {end} limit: {limit}")
+        log.info(f"Requesting data from: {start} to: {end} limit: {limit}")
 
-        # Only data in the current buffer is available to query;
-        # requests for data outside of this will fail. Buffer size is
-        # set using the max_buffer_len parameter.
         data = self.get_latest_data()
-
         if not data:
             log.info('No records available')
             return []
 
-        log.info((f'{len(data)} records available '
-                  f'(From: {data[0].timestamp} To: {data[-1].timestamp})'))
-        start = start or data[0].timestamp
-        end = end or data[-1].timestamp
-        limit = limit or -1
-        assert start >= data[0].timestamp, (
-            f'Start time of {start} is out of range: '
-            f'({data[0].timestamp} to {data[-1].timestamp}).')
+        data_start = data[0].timestamp
+        data_end = data[-1].timestamp
+        log.info(f'Available data: {self._data_stats(data)}')
+
+        if start is None:
+            start = data_start
+        if end is None:
+            end = data_end
+
+        assert start >= data_start, 'Start time out of range'
+        assert end <= data_end, 'End time out of range'
 
         data_slice = [
             record for record in data if start <= record.timestamp <= end
         ][0:limit]
-        log.info(f'{len(data_slice)} records returned')
-        return data_slice
+        log.info(f"Filtered records: {self._data_stats(data_slice)}")
 
-    @property
-    def max_samples(self) -> int:
-        """Maximum number of samples available at any given time."""
-        if self.device_spec.sample_rate == IRREGULAR_RATE:
-            return int(self.max_buffer_len)
-        return int(self.max_buffer_len * self.device_spec.sample_rate)
+        return data_slice
 
     def get_latest_data(self) -> List[Record]:
         """Add all available samples in the inlet to the buffer.
@@ -182,14 +210,27 @@ class LslAcquisitionClient:
         max_buffer_len and the amount of data available in the inlet."""
         if not self.buffer:
             return []
-        samples, timestamps = self.inlet.pull_chunk(
-            max_samples=self.max_samples)
 
-        for i, sample in enumerate(samples):
-            self.buffer.append(
-                Record(data=sample, timestamp=timestamps[i], rownum=None))
+        count = self._pull_chunk()
+        # Pull all the data from LSL and append it to the local buffer.
+        while count == self.max_samples:
+            count = self._pull_chunk()
 
         return self.buffer.get()
+
+    def _pull_chunk(self) -> int:
+        """Pull a chunk of samples from LSL and record in the buffer.
+        Returns the count of samples pulled.
+        """
+        log.info(f"Pulling from LSL (max_samples: {self.max_samples})")
+        # A timeout of 0.0 gets currently available samples without blocking.
+        samples, timestamps = self.inlet.pull_chunk(
+            timeout=0.0, max_samples=self.max_samples)
+        count = len(samples)
+        log.info(f"\tReceived {count} samples")
+        for sample, stamp in zip(samples, timestamps):
+            self.buffer.append(Record(sample, stamp))
+        return count
 
     def convert_time(self, experiment_clock: Clock, timestamp: float) -> float:
         """

--- a/bcipy/acquisition/record.py
+++ b/bcipy/acquisition/record.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 """Defines the Record namedtuple"""
-from collections import namedtuple
+from typing import Any, List, NamedTuple
 
-Record = namedtuple('Record', ['data', 'timestamp', 'rownum'])
-Record.__doc__ = """Domain object used for storing data and timestamp
-information, where data is a single reading from a device and is a list
-of channel information (float)."""
+
+class Record(NamedTuple):
+    """Domain object used for storing data and timestamp
+    information, where data is a single reading from a device and is a list
+    of channel information (float)."""
+    data: List[Any]
+    timestamp: float
+    rownum: int = None

--- a/bcipy/acquisition/record.py
+++ b/bcipy/acquisition/record.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Defines the Record namedtuple"""
-from typing import Any, List, NamedTuple
+from typing import Any, List, NamedTuple, Optional
 
 
 class Record(NamedTuple):
@@ -9,4 +9,4 @@ class Record(NamedTuple):
     of channel information (float)."""
     data: List[Any]
     timestamp: float
-    rownum: int = None
+    rownum: Optional[int] = None

--- a/bcipy/helpers/acquisition.py
+++ b/bcipy/helpers/acquisition.py
@@ -165,7 +165,9 @@ def init_lsl_client(parameters: dict,
     """Initialize a client that acquires data from LabStreamingLayer."""
 
     data_buffer_seconds = round(max_inquiry_duration(parameters))
-    log.info(f"Setting an acquisition buffer of {data_buffer_seconds} seconds")
+    log.info(
+        f"Setting an acquisition buffer for {device_spec.name} of {data_buffer_seconds} seconds"
+    )
     return LslAcquisitionClient(max_buffer_len=data_buffer_seconds,
                                 device_spec=device_spec,
                                 save_directory=save_folder,

--- a/bcipy/helpers/acquisition.py
+++ b/bcipy/helpers/acquisition.py
@@ -165,7 +165,7 @@ def init_lsl_client(parameters: dict,
     """Initialize a client that acquires data from LabStreamingLayer."""
 
     data_buffer_seconds = round(max_inquiry_duration(parameters))
-
+    log.info(f"Setting an acquisition buffer of {data_buffer_seconds} seconds")
     return LslAcquisitionClient(max_buffer_len=data_buffer_seconds,
                                 device_spec=device_spec,
                                 save_directory=save_folder,

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ scipy==1.10.1
 scikit-learn==1.2.2
 seaborn==0.9.0
 matplotlib==3.7.2
-pylsl==1.16
+pylsl==1.16.2
 pandas==1.5.3
 psutil==5.7.2
 Pillow==9.4.0


### PR DESCRIPTION
# Overview

Restructured the `lsl_client` to pull data from LSL for querying in a way that ensures the latest data is available in the buffer for querying.

## Ticket

https://www.pivotaltracker.com/story/show/186539529

## Contributions

- Additional logging in lsl_client to better track what's happening during data pulls.
- Increased buffer size of the LSL StreamInlet so it would not lose data during long pauses (app startup; after letter selection; etc).

## Test

- Ran Copy Phrase task and analyzed logs to ensure that sufficient data was queried to make a decision.

## Discussion

According to the LSL docs (https://labstreaminglayer.readthedocs.io/info/faqs.html), setting the `max_buflen` on a `StreamInlet` should ensure that it keeps only that amount of data (in seconds) and discards the rest. We were relying on this functionality to get data for a decision. However, in recent versions of LSL it seems to sometimes be discarding too much data. This seems to occur after long pauses. When we queried for the latest (2400 records), we would sometimes only get 200-300. I'm still working on creating a minimal example to replicate this problem.

Note also that I am still getting application crashes (Segmentation fault) if the application sits too long on the opening screen or if a task is paused for a while. I'm not sure what's causing this.