### PR TITLE
Random uniform

### DIFF
--- a/bcipy/acquisition/multimodal.py
+++ b/bcipy/acquisition/multimodal.py
@@ -89,8 +89,8 @@ class ClientManager():
         """Returns a list of ContentTypes provided by the active configured
         devices."""
         return [
-            content_type for content_type, spec in self._clients.items()
-            if spec.is_active
+            content_type for content_type, client in self._clients.items()
+            if client.device_spec.is_active
         ]
 
     @property

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -678,11 +678,11 @@
     "type": "str"
   },
   "lm_backspace_prob": {
-    "value": "0.05",
+    "value": "0.0",
     "section": "bci_config",
     "readableName": "Backspace Probability",
-    "helpTip": "Specifies the initial probability assigned to the backspace character in the language model. Possible value range: 0.0-1.0. Default: 0.05",
-    "recommended_values": "",
+    "helpTip": "Specifies the minimum probability assigned to the backspace character in the language model. Possible value range: 0.0-1.0. Default: 0.0",
+    "recommended_values": "0.05",
     "type": "float"
   },
   "show_preview_inquiry": {

--- a/bcipy/task/control/query.py
+++ b/bcipy/task/control/query.py
@@ -81,12 +81,28 @@ class NBestStimuliAgent(StimuliAgent):
     def reset(self):
         pass
 
-    def return_stimuli(self, list_distribution: np.ndarray, constants: Optional[List[str]] = None):
-        p = list_distribution[-1]
-        tmp = [i for i in self.alphabet]
-        query = best_selection(tmp, p, self.len_query, always_included=constants)
+    def return_stimuli(self,
+                       list_distribution: np.ndarray,
+                       constants: Optional[List[str]] = None) -> List[str]:
+        """Returns a list of the n most likely symbols based on the provided
+        probabilities, where n is self.len_query. Symbols of the same
+        probability will be ordered randomly.
+        
+        Parameters
+        ----------
+            list_distribution - list of lists of probabilities. Only the last list will
+                be used.
+            constants - optional list of symbols which should appear every result
+        """
+        symbol_probs = list(zip(self.alphabet, list_distribution[-1]))
+        randomized = random.sample(symbol_probs, len(symbol_probs))
+        symbols, probs = zip(*randomized)
+        return best_selection(selection_elements=list(symbols),
+                              val=list(probs),
+                              len_query=self.len_query,
+                              always_included=constants)
 
-        return query
+
 
     def do_series(self):
         pass

--- a/bcipy/task/control/query.py
+++ b/bcipy/task/control/query.py
@@ -87,7 +87,7 @@ class NBestStimuliAgent(StimuliAgent):
         """Returns a list of the n most likely symbols based on the provided
         probabilities, where n is self.len_query. Symbols of the same
         probability will be ordered randomly.
-        
+
         Parameters
         ----------
             list_distribution - list of lists of probabilities. Only the last list will
@@ -101,8 +101,6 @@ class NBestStimuliAgent(StimuliAgent):
                               val=list(probs),
                               len_query=self.len_query,
                               always_included=constants)
-
-
 
     def do_series(self):
         pass

--- a/bcipy/task/control/query.py
+++ b/bcipy/task/control/query.py
@@ -1,7 +1,8 @@
-import numpy as np
 import random
-from typing import List, Optional
 from abc import ABC, abstractmethod
+from typing import List, Optional
+
+import numpy as np
 
 from bcipy.helpers.stimuli import best_selection
 

--- a/bcipy/task/tests/core/test_query.py
+++ b/bcipy/task/tests/core/test_query.py
@@ -1,23 +1,143 @@
 import unittest
-from bcipy.task.control.query import best_selection
+
+from bcipy.task.control.query import (NBestStimuliAgent, RandomStimuliAgent,
+                                      best_selection)
 
 
 class TestQueryMechanisms(unittest.TestCase):
+    """Tests for query functions"""
+
     def test_best_selection(self):
-        list_el = ["A", "E", "I", "O", "U"]
-        values = [0.4, 0.1, 0.25, 0.1, 0.15]
-        len_query = 3
-        self.assertEqual(["A", "I", "U"], best_selection(list_el, values, len_query))
+        """Test best_selection function"""
+        self.assertEqual(["A", "I", "U"],
+                         best_selection(
+                             selection_elements=["A", "E", "I", "O", "U"],
+                             val=[0.4, 0.1, 0.25, 0.1, 0.15],
+                             len_query=3))
 
-        list_el = ["A", "E", "I", "O", "U"]
-        values = [0.15, 0.4, 0.1, 0.25, 0.1]
-        len_query = 3
-        self.assertEqual(["E", "O", "A"], best_selection(list_el, values, len_query))
+        self.assertEqual(["E", "O", "A"],
+                         best_selection(
+                             selection_elements=["A", "E", "I", "O", "U"],
+                             val=[0.15, 0.4, 0.1, 0.25, 0.1],
+                             len_query=3))
 
-        list_el = ["A", "E", "I", "O", "U"]
-        values = [0.1, 0.2, 0.2, 0.2, 0.2]
-        len_query = 3
-        self.assertEqual(["E", "I", "O"], best_selection(list_el, values, len_query))
+        self.assertEqual(["E", "I", "O"],
+                         best_selection(
+                             selection_elements=["A", "E", "I", "O", "U"],
+                             val=[0.1, 0.2, 0.2, 0.2, 0.2],
+                             len_query=3))
+
+        self.assertEqual(
+            ["A", "E", "I"],
+            best_selection(selection_elements=["A", "E", "I", "O", "U"],
+                           val=[0.2, 0.2, 0.2, 0.2, 0.2],
+                           len_query=3),
+            msg="equally probable items should be in alphabetical order")
+
+        self.assertEqual(["A", "U", "I"],
+                         best_selection(
+                             selection_elements=["A", "E", "I", "O", "U"],
+                             val=[0.4, 0.1, 0.0, 0.1, 0.4],
+                             len_query=3,
+                             always_included=["I"]),
+                         msg="always_included items should be in the results")
+
+        self.assertEqual(
+            ["A", "U", "E"],
+            best_selection(selection_elements=["A", "E", "I", "O", "U"],
+                           val=[0.4, 0.1, 0.0, 0.1, 0.4],
+                           len_query=3,
+                           always_included=["<"]),
+            msg="Always included items are only applied if present")
+
+
+class TestNBestStimuliAgent(unittest.TestCase):
+    """Tests for NBestStimuliAgent"""
+
+    def test_highest_probs(self):
+        """Test the NBestStimuliAgent should select symbols with the highest
+        probabilities"""
+        agent = NBestStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
+                                  len_query=3)
+        self.assertEqual(["A", "I", "U"],
+                         agent.return_stimuli(
+                             list_distribution=[[0.4, 0.1, 0.25, 0.1, 0.15]],
+                             constants=None))
+
+    def test_multiple_value_lists(self):
+        """Test with multiple values in the list distribution."""
+        agent = NBestStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
+                                  len_query=3)
+        self.assertEqual(
+            ["E", "O", "A"],
+            agent.return_stimuli(
+                list_distribution=[[0.4, 0.1, 0.25, 0.1, 0.15],
+                                   [0.15, 0.4, 0.1, 0.25, 0.1]],
+                constants=None),
+            msg="Last list of probabilities should be used for selection")
+
+    def test_all_equal_probs(self):
+        """Test where all probabilities are equal"""
+        agent = NBestStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
+                                  len_query=3)
+
+        self.assertEqual(["A", "E", "I"],
+                         agent.return_stimuli(
+                             list_distribution=[[0.2, 0.2, 0.2, 0.2, 0.2]],
+                             constants=None),
+                         msg="Should return the first n values")
+
+    def test_constants(self):
+        """Test with constant items included in results."""
+        agent = NBestStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
+                                  len_query=3)
+
+        self.assertEqual(["E", "I", "U"],
+                         agent.return_stimuli(
+                             list_distribution=[[0.1, 0.3, 0.3, 0.2, 0.1]],
+                             constants=["U"]))
+
+
+class TestRandomStimuliAgent(unittest.TestCase):
+    """Tests for RandomStimuliAgent"""
+
+    def test_randomness(self):
+        """Test that symbols are not selected based on probabilities."""
+        agent = RandomStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
+                                   len_query=3)
+
+        # Generate 100 queries
+        queries = [
+            agent.return_stimuli([[0.3, 0.3, 0.2, 0.1, 0.1]])
+            for i in range(100)
+        ]
+        # Turn each list of symbols into a string to make them easier to compare
+        strings = [''.join(query) for query in queries]
+        self.assertTrue(len(set(strings)) > 1,
+                        msg="All queries should not be the same")
+
+        all_queries: str = ''.join(strings)
+        self.assertTrue(
+            "O" in all_queries or "U" in all_queries,
+            msg="Not only the highest probability symbols should be returned.")
+
+    def test_ordering(self):
+        """Test that ordering is not always alphabetical"""
+        agent = RandomStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
+                                   len_query=3)
+        queries = [
+            agent.return_stimuli([[0.3, 0.3, 0.2, 0.1, 0.1]])
+            for i in range(10)
+        ]
+        self.assertFalse(all(sorted(query) == query for query in queries))
+
+    def test_constants(self):
+        """Test that constants are always added."""
+        agent = RandomStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
+                                   len_query=3)
+        query = agent.return_stimuli([[0.3, 0.3, 0.2, 0.1, 0.1]],
+                                     constants=["O"])
+        self.assertTrue("O" in query)
 
 
 if __name__ == '__main__':

--- a/bcipy/task/tests/core/test_query.py
+++ b/bcipy/task/tests/core/test_query.py
@@ -11,43 +11,79 @@ class TestNBestStimuliAgent(unittest.TestCase):
         probabilities"""
         agent = NBestStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
                                   len_query=3)
-        self.assertEqual(["A", "I", "U"],
-                         agent.return_stimuli(
-                             list_distribution=[[0.4, 0.1, 0.25, 0.1, 0.15]],
-                             constants=None))
+        stim = agent.return_stimuli(
+            list_distribution=[[0.4, 0.1, 0.25, 0.1, 0.15]], constants=None)
+        self.assertTrue("A" in stim)
+        self.assertTrue("I" in stim)
+        self.assertTrue("U" in stim)
+
+    def test_highest_probs_ordering(self):
+        """Test the NBestStimuliAgent should order the returned symbols
+        by decreasing probability."""
+        agent = NBestStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
+                                  len_query=3)
+        stims = [
+            agent.return_stimuli(
+                list_distribution=[[0.4, 0.1, 0.25, 0.1, 0.15]],
+                constants=None) for _ in range(10)
+        ]
+
+        self.assertTrue(all([stim == ['A', 'I', 'U'] for stim in stims]),
+                        msg="All queries should be the same")
 
     def test_multiple_value_lists(self):
         """Test with multiple values in the list distribution."""
         agent = NBestStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
                                   len_query=3)
-        self.assertEqual(
-            ["E", "O", "A"],
-            agent.return_stimuli(
-                list_distribution=[[0.4, 0.1, 0.25, 0.1, 0.15],
-                                   [0.15, 0.4, 0.1, 0.25, 0.1]],
-                constants=None),
-            msg="Last list of probabilities should be used for selection")
+        stim = agent.return_stimuli(
+            list_distribution=[[0.4, 0.1, 0.25, 0.1, 0.15],
+                               [0.15, 0.4, 0.1, 0.25, 0.1]],
+            constants=None)
+        self.assertTrue("E" in stim)
+        self.assertTrue("O" in stim)
+        self.assertTrue("A" in stim)
 
     def test_all_equal_probs(self):
         """Test where all probabilities are equal"""
         agent = NBestStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
                                   len_query=3)
+        stims = [
+            agent.return_stimuli(list_distribution=[[0.2, 0.2, 0.2, 0.2, 0.2]],
+                                 constants=None) for _ in range(10)
+        ]
+        stim_strings = [''.join(sorted(stim)) for stim in stims]
+        self.assertTrue(len(set(stim_strings)) > 1,
+                        msg="All queries should not have the same symbols")
 
-        self.assertEqual(["A", "E", "I"],
-                         agent.return_stimuli(
-                             list_distribution=[[0.2, 0.2, 0.2, 0.2, 0.2]],
-                             constants=None),
-                         msg="Should return the first n values")
+    def test_some_equal_probs(self):
+        """Test ordering where some probabilities are equal."""
+        agent = NBestStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
+                                  len_query=3)
+        stims = [
+            agent.return_stimuli(list_distribution=[[0.4, 0.1, 0.2, 0.1, 0.2]],
+                                 constants=None) for _ in range(10)
+        ]
+
+        unsorted_stim_strings = [''.join(stim) for stim in stims]
+        self.assertTrue(len(set(unsorted_stim_strings)) > 1,
+                        msg="All queries should not have the same ordering")
+
+        sorted_stim_strings = [''.join(sorted(stim)) for stim in stims]
+        self.assertEqual(1,
+                         len(set(sorted_stim_strings)),
+                         msg="All queries should have the same symbols")
+        self.assertEqual("AIU", list(set(sorted_stim_strings))[0])
 
     def test_constants(self):
         """Test with constant items included in results."""
         agent = NBestStimuliAgent(alphabet=["A", "E", "I", "O", "U"],
                                   len_query=3)
 
-        self.assertEqual(["E", "I", "U"],
-                         agent.return_stimuli(
-                             list_distribution=[[0.1, 0.3, 0.3, 0.2, 0.1]],
-                             constants=["U"]))
+        stims = agent.return_stimuli(
+            list_distribution=[[0.1, 0.3, 0.3, 0.2, 0.1]], constants=["U"])
+        self.assertTrue("E" in stims)
+        self.assertTrue("I" in stims)
+        self.assertTrue("U" in stims)
 
 
 class TestRandomStimuliAgent(unittest.TestCase):

--- a/bcipy/task/tests/core/test_query.py
+++ b/bcipy/task/tests/core/test_query.py
@@ -1,54 +1,6 @@
 import unittest
 
-from bcipy.task.control.query import (NBestStimuliAgent, RandomStimuliAgent,
-                                      best_selection)
-
-
-class TestQueryMechanisms(unittest.TestCase):
-    """Tests for query functions"""
-
-    def test_best_selection(self):
-        """Test best_selection function"""
-        self.assertEqual(["A", "I", "U"],
-                         best_selection(
-                             selection_elements=["A", "E", "I", "O", "U"],
-                             val=[0.4, 0.1, 0.25, 0.1, 0.15],
-                             len_query=3))
-
-        self.assertEqual(["E", "O", "A"],
-                         best_selection(
-                             selection_elements=["A", "E", "I", "O", "U"],
-                             val=[0.15, 0.4, 0.1, 0.25, 0.1],
-                             len_query=3))
-
-        self.assertEqual(["E", "I", "O"],
-                         best_selection(
-                             selection_elements=["A", "E", "I", "O", "U"],
-                             val=[0.1, 0.2, 0.2, 0.2, 0.2],
-                             len_query=3))
-
-        self.assertEqual(
-            ["A", "E", "I"],
-            best_selection(selection_elements=["A", "E", "I", "O", "U"],
-                           val=[0.2, 0.2, 0.2, 0.2, 0.2],
-                           len_query=3),
-            msg="equally probable items should be in alphabetical order")
-
-        self.assertEqual(["A", "U", "I"],
-                         best_selection(
-                             selection_elements=["A", "E", "I", "O", "U"],
-                             val=[0.4, 0.1, 0.0, 0.1, 0.4],
-                             len_query=3,
-                             always_included=["I"]),
-                         msg="always_included items should be in the results")
-
-        self.assertEqual(
-            ["A", "U", "E"],
-            best_selection(selection_elements=["A", "E", "I", "O", "U"],
-                           val=[0.4, 0.1, 0.0, 0.1, 0.4],
-                           len_query=3,
-                           always_included=["<"]),
-            msg="Always included items are only applied if present")
+from bcipy.task.control.query import NBestStimuliAgent, RandomStimuliAgent
 
 
 class TestNBestStimuliAgent(unittest.TestCase):


### PR DESCRIPTION
# Overview

Updated Copy Phrase task machinery so that when using the Uniform language model, the first Inquiry of symbols are selected randomly, rather than taking the first n letters of the alphabet.

## Ticket

https://www.pivotaltracker.com/story/show/186571653

## Contributions

- Updated the NBestStimuliAgent used in Copy Phrase to randomize the order of inputs prior to sorting by descending probability. This ensures that symbols with the same probability values are ordered randomly.
- Updated the default value of the lm_backspace_prob  parameter so by default it is given the same initial probability as any other symbol.
- Bug fix

## Test

- Added unit tests for Stimuli agents
- Ran all linting and unit tests
- Ran a Copy Phrase task and inspected the session.xlsx output to determine that the symbols were initially ordered randomly, followed by the highest likely symbols.