### PR TITLE
Passive device bug

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,13 +112,14 @@ jobs:
         python-version: [3.8, 3.9]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: update pip & install custom dependencies
       run: |
+        brew install labstreaminglayer/tap/lsl
         python -m pip install --upgrade pip
         pip install kenlm==0.1 --global-option="--max_order=12"
         pip install psychopy==2023.2.1 --no-deps

--- a/bcipy/acquisition/multimodal.py
+++ b/bcipy/acquisition/multimodal.py
@@ -89,8 +89,8 @@ class ClientManager():
         """Returns a list of ContentTypes provided by the active configured
         devices."""
         return [
-            content_type for content_type, spec in self._clients.items()
-            if spec.is_active
+            content_type for content_type, client in self._clients.items()
+            if client.device_spec.is_active
         ]
 
     @property

--- a/bcipy/acquisition/tests/test_client_manager.py
+++ b/bcipy/acquisition/tests/test_client_manager.py
@@ -90,8 +90,8 @@ class TestClientManager(unittest.TestCase):
         self.assertTrue(ContentType.EEG in manager.device_content_types)
         self.assertTrue(ContentType.EYETRACKER in manager.device_content_types)
 
-        self.assertEqual([ContentType.EEG], manager.active_device_content_types)
-
+        self.assertEqual([ContentType.EEG],
+                         manager.active_device_content_types)
 
     def test_dispatching_properties(self):
         """Test that property calls may be dispatched to the default client"""

--- a/bcipy/acquisition/tests/test_client_manager.py
+++ b/bcipy/acquisition/tests/test_client_manager.py
@@ -14,6 +14,7 @@ class TestClientManager(unittest.TestCase):
         self.eeg_device_mock.name = 'DSI-24'
         self.eeg_device_mock.content_type = 'EEG'
         self.eeg_device_mock.sample_rate = 300
+        self.eeg_device_mock.is_active = True
 
         self.eeg_client_mock = Mock()
         self.eeg_client_mock.device_spec = self.eeg_device_mock
@@ -24,6 +25,7 @@ class TestClientManager(unittest.TestCase):
         self.gaze_device_mock = Mock()
         self.gaze_device_mock.content_type = 'Eyetracker'
         self.gaze_device_mock.sample_rate = 60
+        self.gaze_device_mock.is_active = False
         self.gaze_client_mock = Mock()
         self.gaze_client_mock.device_spec = self.gaze_device_mock
 
@@ -79,6 +81,17 @@ class TestClientManager(unittest.TestCase):
         manager.add_client(self.gaze_client_mock)
         self.assertEqual(2, len(manager.device_specs))
         self.assertTrue(self.gaze_device_mock in manager.device_specs)
+
+    def test_device_content_types(self):
+        """Test properties related to content types"""
+        manager = ClientManager()
+        manager.add_client(self.eeg_client_mock)
+        manager.add_client(self.gaze_client_mock)
+        self.assertTrue(ContentType.EEG in manager.device_content_types)
+        self.assertTrue(ContentType.EYETRACKER in manager.device_content_types)
+
+        self.assertEqual([ContentType.EEG], manager.active_device_content_types)
+
 
     def test_dispatching_properties(self):
         """Test that property calls may be dispatched to the default client"""


### PR DESCRIPTION
# Overview

Fixed a bug related to determining which devices were active in a Copy Phrase task.

## Ticket

https://www.pivotaltracker.com/story/show/186890663

## Test

- Added unit tests isolating the bug.

## Discussion

I had previously fixed this bug locally but forgot to push it before the PR was merged.