### PR TITLE
Matrix Grid Always On

### DIFF
--- a/bcipy/display/demo/matrix/demo_calibration_matrix.py
+++ b/bcipy/display/demo/matrix/demo_calibration_matrix.py
@@ -40,37 +40,22 @@ matrix_display = MatrixDisplay(win,
                                task_bar=task_bar,
                                info=info)
 
-time_target = 2
-time_fixation = 2
+time_target = 1
+time_fixation = 0.5
 time_flash = 0.25
 timing = [time_target] + [time_fixation] + [time_flash] * 5
 colors = ['green', 'lightgray'] + ['white'] * 5
 task_buffer = 2
 
-matrix_display.schedule_to(stimuli=['A', '+', 'F', '<', 'A', 'B', 'C'],
-                           timing=timing,
-                           colors=colors)
-matrix_display.update_task_bar()
-matrix_display.do_inquiry()
-core.wait(task_buffer)
+inquiries = [
+    ['A', '+', 'F', '<', 'A', 'B', 'C'],
+    ['B', '+', 'F', '<', 'A', 'B', 'C'],
+    ['C', '+', 'F', '<', 'A', 'B', 'C'],
+    ['<', '+', 'F', '<', 'A', 'B', 'C']
+]
 
-matrix_display.schedule_to(stimuli=['B', '+', 'F', '<', 'A', 'B', 'C'],
-                           timing=timing,
-                           colors=colors)
-matrix_display.update_task_bar()
-matrix_display.do_inquiry()
-core.wait(task_buffer)
-
-matrix_display.schedule_to(stimuli=['C', '+', 'F', '<', 'A', 'B', 'C'],
-                           timing=timing,
-                           colors=colors)
-matrix_display.update_task_bar()
-matrix_display.do_inquiry()
-core.wait(task_buffer)
-
-matrix_display.schedule_to(stimuli=['<', '+', 'F', '<', 'A', 'B', 'C'],
-                           timing=timing,
-                           colors=colors)
-matrix_display.update_task_bar()
-matrix_display.do_inquiry()
-core.wait(task_buffer)
+for inquiry in inquiries:
+    matrix_display.schedule_to(stimuli=inquiry, timing=timing, colors=colors)
+    matrix_display.update_task_bar()
+    matrix_display.do_inquiry()
+    core.wait(task_buffer)

--- a/bcipy/display/demo/matrix/demo_copyphrase_matrix.py
+++ b/bcipy/display/demo/matrix/demo_copyphrase_matrix.py
@@ -10,7 +10,7 @@ from bcipy.display import (InformationProperties, StimuliProperties,
 from bcipy.display.components.task_bar import CopyPhraseTaskBar
 from bcipy.display.paradigm.matrix.display import MatrixDisplay
 
-font = "Overpass Mono Medium"
+font = "Overpass Mono"
 info = InformationProperties(
     info_color=['White'],
     info_pos=[(-.5, -.75)],
@@ -82,9 +82,9 @@ display = MatrixDisplay(win,
 
 counter = 0
 
-for idx_o in range(len(spelled_text)):
+for spelled in spelled_text:
 
-    display.update_task_bar(text=spelled_text[idx_o])
+    display.update_task_bar(text=spelled)
     display.draw_static()
     win.flip()
 

--- a/bcipy/display/paradigm/matrix/display.py
+++ b/bcipy/display/paradigm/matrix/display.py
@@ -137,7 +137,7 @@ class MatrixDisplay(Display):
         self.draw_grid(opacity=self.full_grid_opacity)
         tmp_task_bar = self.task_bar.current_index
         self.task_bar.current_index = 0
-        self.draw_static()
+        self.draw_components()
         self.window.flip()
 
         # capture the screenshot and save it to the specified file path
@@ -273,7 +273,7 @@ class MatrixDisplay(Display):
                        color=grid_color or self.grid_color,
                        highlight=highlight,
                        highlight_color=highlight_color)
-        self.draw_static()
+        self.draw_components()
         self.window.flip()
         if duration:
             core.wait(duration)
@@ -342,6 +342,11 @@ class MatrixDisplay(Display):
 
     def draw_static(self) -> None:
         """Draw static elements in a stimulus."""
+        self.draw_grid(self.start_opacity)
+        self.draw_components()
+
+    def draw_components(self) -> None:
+        """Draw task bar and info text components."""
         if self.task_bar:
             self.task_bar.draw()
 

--- a/bcipy/display/tests/paradigm/matrix/test_matrix_display.py
+++ b/bcipy/display/tests/paradigm/matrix/test_matrix_display.py
@@ -163,6 +163,7 @@ class TestMatrixDisplay(unittest.TestCase):
         when(self.matrix.window).callOnFlip(any(), any()).thenReturn()
         # mock the drawing of text stims
         when(self.matrix).draw_static().thenReturn()
+        when(self.matrix).draw_components().thenReturn()
         when(self.text_stim_mock).draw().thenReturn()
         when(self.matrix.window).flip().thenReturn()
         # skip the core wait


### PR DESCRIPTION
# Overview

Modified the matrix display code so the matrix is always shown in the Calibration and Copy Phrase tasks.

## Ticket

https://www.pivotaltracker.com/story/show/186539584

## Test

- Ran all unit tests
- Ran Matrix calibration to confirm that the display appeared as expected
- Ran Matrix Copy Phrase task
