### PR TITLE
Add Data Source

### DIFF
--- a/bcipy/simulator/helpers/data_engine.py
+++ b/bcipy/simulator/helpers/data_engine.py
@@ -2,7 +2,7 @@ import logging
 import os
 from abc import ABC
 from pathlib import Path
-from typing import Optional, List
+from typing import List, NamedTuple, Optional
 
 import numpy as np
 import pandas as pd
@@ -11,8 +11,8 @@ from bcipy.config import DEFAULT_PARAMETER_FILENAME
 from bcipy.helpers import load
 from bcipy.helpers.list import grouper
 from bcipy.helpers.parameters import Parameters
-from bcipy.simulator.helpers.signal_helpers import ExtractedExperimentData, \
-    process_raw_data_for_model
+from bcipy.simulator.helpers.signal_helpers import (ExtractedExperimentData,
+                                                    process_raw_data_for_model)
 
 log = logging.getLogger(__name__)
 
@@ -31,6 +31,27 @@ class DataEngine(ABC):
     def get_parameters(self) -> List[Parameters]:
         ...
 
+class Trial(NamedTuple):
+    """Data for a given trial (a symbol within an Inquiry).
+
+    TODO: add series to facilitate easier lookup in session data.
+
+    Attrs
+    -----
+        source - directory of the data source
+        inquiry_n - starts at 0; does not reset at each series
+        inquiry_pos  - starts at 1; position in which the symbol was presented
+        symbol - alphabet symbol that was presented
+        target - 1 or 0 indicating a boolean of whether this was a target symbol
+        eeg - EEG data associated with this trial
+    """
+    source: str
+    # series_n: int
+    inquiry_n: int
+    inquiry_pos: int
+    symbol: str
+    target: int
+    eeg: np.ndarray
 
 class RawDataEngine(DataEngine):
     """
@@ -63,12 +84,13 @@ class RawDataEngine(DataEngine):
         """
         log.debug(f"Loading data from {len(self.source_dirs)} source directories")
 
-        self.data: List[ExtractedExperimentData] = [
-            process_raw_data_for_model(source_dir, self.parameters) for source_dir in
-            self.source_dirs]
+        self.data = [
+            process_raw_data_for_model(source_dir, self.parameters)
+            for source_dir in self.source_dirs
+        ]
 
         for data_source in self.data:
-            trigger_targetness, trigger_timing, trigger_symbols = data_source.decoded_triggers
+            _trigger_targetness, _trigger_timing, trigger_symbols = data_source.decoded_triggers
             self.trials_by_inquiry.append(
                 np.split(data_source.trials, data_source.inquiries.shape[1], 1))
             self.symbols_by_inquiry.append([list(group) for group in
@@ -84,7 +106,7 @@ class RawDataEngine(DataEngine):
     def transform(self) -> DataEngine:
         """
         Organizes all data into the following schema
-            - Dataframe {"series_n":int, "inquiry_n":int, "trial_n":int, "symbol":str, "target":int, "eeg":ndarray}
+            - Dataframe {"inquiry_n":int, "trial_n":int, "symbol":str, "target":int, "eeg":ndarray}
 
         The "eeg" data for trial looks like this
             - ndarray.shape = (channel_n, sample_n)
@@ -94,10 +116,10 @@ class RawDataEngine(DataEngine):
             self for chaining
         """
 
-        # TODO store how good evidence was in session | store data source as well
+        # TODO store how good evidence was in session
 
         rows = []
-        for d_i in range(len(self.data)):
+        for d_i, data_source in enumerate(self.data):
             for i in range(len(self.trials_by_inquiry[d_i])):
                 symbols = self.symbols_by_inquiry[d_i][i]
                 inquiry_labels = self.labels_by_inquiry[d_i][i]
@@ -107,11 +129,12 @@ class RawDataEngine(DataEngine):
                 for t_i, symbol in enumerate(symbols):
                     channel_eeg_samples_for_t = [channel[t_i] for channel in
                                                  inquiry_eeg]  # (channel_n, sample_n)
-                    row = {'inquiry_n': i, 'trial_n': t_i, 'symbol': symbol,
-                           'target': inquiry_labels[t_i],
-                           'eeg': np.array(channel_eeg_samples_for_t)}
-
-                    symbol_rows.append(row)
+                    symbol_rows.append(Trial(source=data_source.source_dir,
+                                  inquiry_n=i,
+                                  inquiry_pos=t_i + 1,
+                                  symbol=symbol,
+                                  target=inquiry_labels[t_i],
+                                  eeg=np.array(channel_eeg_samples_for_t)))
 
                 rows.extend(symbol_rows)
 

--- a/bcipy/simulator/helpers/data_engine.py
+++ b/bcipy/simulator/helpers/data_engine.py
@@ -101,22 +101,16 @@ class RawDataEngine(DataEngine):
 
         rows = []
         for data_source in self.data:
-            _targets, _times, trigger_symbols = data_source.decoded_triggers
-            eeg_by_inquiry = np.split(data_source.trials, data_source.inquiries.shape[1], 1)
-            symbols_by_inquiry = [
-                    list(group)
-                    for group in grouper(trigger_symbols,
-                                         self.parameters.get('stim_length'),
-                                         incomplete="ignore")
-                ]
+            symbols_by_inquiry = data_source.symbols_by_inquiry
+            labels_by_inquiry = data_source.labels_by_inquiry
 
-            for i, inquiry_eeg in enumerate(eeg_by_inquiry):
+            for i, inquiry_eeg in enumerate(data_source.trials_by_inquiry):
                 # iterate through each inquiry
-                symbols = symbols_by_inquiry[i]
-                inquiry_labels = data_source.labels[i]
+                inquiry_symbols = symbols_by_inquiry[i]
+                inquiry_labels = labels_by_inquiry[i]
 
-                for sym_i, symbol in enumerate(symbols):
-                    # iterate through each trial in the inquiry
+                for sym_i, symbol in enumerate(inquiry_symbols):
+                    # iterate through each symbol in the inquiry
                     eeg_samples = [channel[sym_i] for channel in inquiry_eeg
                                    ]  # (channel_n, sample_n)
                     rows.append(Trial(source=data_source.source_dir,

--- a/bcipy/simulator/helpers/signal_helpers.py
+++ b/bcipy/simulator/helpers/signal_helpers.py
@@ -6,23 +6,22 @@ from typing import List
 import numpy as np
 
 from bcipy.acquisition import devices
-from bcipy.config import (
-    RAW_DATA_FILENAME,
-    TRIGGER_FILENAME,
-    DEFAULT_DEVICE_SPEC_FILENAME,
-)
+from bcipy.config import (DEFAULT_DEVICE_SPEC_FILENAME, RAW_DATA_FILENAME,
+                          TRIGGER_FILENAME)
 from bcipy.helpers.acquisition import analysis_channels
 from bcipy.helpers.exceptions import TaskConfigurationException
 from bcipy.helpers.load import load_raw_data
-from bcipy.helpers.stimuli import update_inquiry_timing, InquiryReshaper
+from bcipy.helpers.stimuli import InquiryReshaper, update_inquiry_timing
 from bcipy.helpers.triggers import TriggerType, trigger_decoder
-from bcipy.signal.process import get_default_transform, filter_inquiries, ERPTransformParams
+from bcipy.signal.process import (ERPTransformParams, filter_inquiries,
+                                  get_default_transform)
 
 log = logger.getLogger(__name__)
 
 
 @dataclass()
 class ExtractedExperimentData:  # TODO clean up design
+    source_dir: str
     inquiries: np.ndarray
     trials: np.ndarray
     labels: List
@@ -128,5 +127,5 @@ def process_raw_data_for_model(data_folder, parameters,
     # define the training classes using integers, where 0=nontargets/1=targets
     # labels = inquiry_labels.flatten()
 
-    return ExtractedExperimentData(inquiries, trials, inquiry_labels, inquiry_timing,
+    return ExtractedExperimentData(data_folder, inquiries, trials, inquiry_labels, inquiry_timing,
                                    (trigger_targetness, trigger_timing, trigger_symbols))


### PR DESCRIPTION
# Overview

Added the data source to the sampled trial data to allow us to confirm that the sampled likelihoods match the values in the session data.

## Contributions

- Created a named tuple for storing Trial data; documented the fields.
- Refactored data engine to simplify the needed data processing by moving some of this to computed fields in the ExtractedExperimentData class

## Test

- Ran the simulator and spot checked that the sampled values in the log matched the EEG likelihoods in the corresponding session.xlsx file.