### PR TITLE
Pause error

### DIFF
--- a/bcipy/acquisition/protocols/lsl/connect.py
+++ b/bcipy/acquisition/protocols/lsl/connect.py
@@ -1,0 +1,26 @@
+"""Utility functions for connecting to an LSL Stream"""
+from typing import Optional
+
+from pylsl import StreamInfo, resolve_stream
+
+from bcipy.acquisition.devices import DEFAULT_DEVICE_TYPE, DeviceSpec
+from bcipy.acquisition.protocols.lsl.lsl_connector import channel_names
+
+
+def resolve_device_stream(
+        device_spec: Optional[DeviceSpec] = None) -> StreamInfo:
+    """Get the LSL stream for the given device."""
+    content_type = device_spec.content_type if device_spec else DEFAULT_DEVICE_TYPE
+    streams = resolve_stream('type', content_type)
+    if not streams:
+        raise Exception(
+            f'LSL Stream not found for content type {content_type}')
+    return streams[0]
+
+
+def device_from_metadata(metadata: StreamInfo) -> DeviceSpec:
+    """Create a device_spec from the data stream metadata."""
+    return DeviceSpec(name=metadata.name(),
+                      channels=channel_names(metadata),
+                      sample_rate=metadata.nominal_srate(),
+                      content_type=metadata.type())

--- a/bcipy/acquisition/protocols/lsl/lsl_client.py
+++ b/bcipy/acquisition/protocols/lsl/lsl_client.py
@@ -1,22 +1,43 @@
 """DataAcquisitionClient for LabStreamingLayer data sources."""
 import logging
+from multiprocessing import Queue
 from typing import Dict, List, Optional
 
 import pandas as pd
-from pylsl import (StreamInfo, StreamInlet, local_clock, resolve_byprop,
-                   resolve_stream)
+from pylsl import StreamInlet, local_clock, resolve_byprop
 
-from bcipy.acquisition.devices import (DEFAULT_DEVICE_TYPE, IRREGULAR_RATE,
-                                       DeviceSpec)
+from bcipy.acquisition.devices import IRREGULAR_RATE, DeviceSpec
 from bcipy.acquisition.exceptions import InvalidClockError
-from bcipy.acquisition.protocols.lsl.lsl_connector import (channel_names,
-                                                           check_device)
+from bcipy.acquisition.protocols.lsl.connect import (device_from_metadata,
+                                                     resolve_device_stream)
+from bcipy.acquisition.protocols.lsl.lsl_connector import check_device
 from bcipy.acquisition.protocols.lsl.lsl_recorder import LslRecordingThread
 from bcipy.acquisition.record import Record
+from bcipy.config import MAX_PAUSE_SECONDS
 from bcipy.gui.viewer.ring_buffer import RingBuffer
 from bcipy.helpers.clock import Clock
 
 log = logging.getLogger(__name__)
+
+
+def time_range(stamps: List[float],
+               precision: int = 3,
+               sep: str = " to ") -> str:
+    """Utility for printing a range of timestamps"""
+    if stamps:
+        return "".join([
+            str(round(stamps[0], precision)), sep,
+            str(round(stamps[-1], precision))
+        ])
+    return ""
+
+
+def request_desc(start: Optional[float], end: Optional[float],
+                 limit: Optional[int]):
+    """Returns a description of the request which can be logged."""
+    start_str = round(start, 3) if start else "None"
+    end_str = round(end, 3) if end else "None"
+    return f"Requesting data from: {start_str} to: {end_str} limit: {limit}"
 
 
 class LslAcquisitionClient:
@@ -61,8 +82,6 @@ class LslAcquisitionClient:
     def first_sample_time(self) -> float:
         """Timestamp returned by the first sample. If the data is being
         recorded this value reflects the timestamp of the first recorded sample"""
-        if self.recorder:
-            return self.recorder.first_sample_time
         return self._first_sample_time
 
     @property
@@ -86,17 +105,13 @@ class LslAcquisitionClient:
         if self.inlet:
             return False
 
-        content_type = self.device_spec.content_type if self.device_spec else DEFAULT_DEVICE_TYPE
-        streams = resolve_stream('type', content_type)
-        if not streams:
-            raise Exception(
-                f'LSL Stream not found for content type {content_type}')
-        stream_info = streams[0]
-
+        stream_info = resolve_device_stream(self.device_spec)
         self.inlet = StreamInlet(
             stream_info,
-            max_buflen=4 * self.max_buffer_len,  # TODO: revisit this value
+            max_buflen=MAX_PAUSE_SECONDS + 5,
             max_chunklen=1)
+        log.info("Acquiring data from data stream:")
+        log.info(self.inlet.info().as_xml())
 
         if self.device_spec:
             check_device(self.device_spec, self.inlet.info())
@@ -104,16 +119,22 @@ class LslAcquisitionClient:
             self.device_spec = device_from_metadata(self.inlet.info())
 
         if self.save_directory:
+            msg_queue = Queue()
             self.recorder = LslRecordingThread(
-                stream_info,
-                self.save_directory,
-                self.raw_data_file_name,
-                self.device_spec)
+                directory=self.save_directory,
+                filename=self.raw_data_file_name,
+                device_spec=self.device_spec,
+                queue=msg_queue)
             self.recorder.start()
+            log.info("Waiting for first sample from lsl_recorder")
+            self._first_sample_time = msg_queue.get(block=True, timeout=5.0)
+            log.info(f"First sample time: {self.first_sample_time}")
 
+        self.inlet.open_stream(timeout=5.0)
         if self.max_buffer_len and self.max_buffer_len > 0:
             self.buffer = RingBuffer(size_max=self.max_samples)
-        _, self._first_sample_time = self.inlet.pull_sample()
+        if not self._first_sample_time:
+            _, self._first_sample_time = self.inlet.pull_sample()
         return True
 
     def stop_acquisition(self) -> None:
@@ -178,7 +199,7 @@ class LslAcquisitionClient:
         -------
             List of Records
         """
-        log.info(f"Requesting data from: {start} to: {end} limit: {limit}")
+        log.info(request_desc(start, end, limit))
 
         data = self.get_latest_data()
         if not data:
@@ -223,12 +244,12 @@ class LslAcquisitionClient:
         """Pull a chunk of samples from LSL and record in the buffer.
         Returns the count of samples pulled.
         """
-        log.debug(f"Pulling from LSL (max_samples: {self.max_samples})")
+        log.debug(f"\tPulling chunk (max_samples: {self.max_samples})")
         # A timeout of 0.0 gets currently available samples without blocking.
         samples, timestamps = self.inlet.pull_chunk(
             timeout=0.0, max_samples=self.max_samples)
         count = len(samples)
-        log.debug(f"\tReceived {count} samples")
+        log.debug(f"\t-> received {count} samples: {time_range(timestamps)}")
         for sample, stamp in zip(samples, timestamps):
             self.buffer.append(Record(sample, stamp))
         return count
@@ -357,11 +378,3 @@ def discover_device_spec(content_type: str) -> DeviceSpec:
     spec = device_from_metadata(inlet.info())
     inlet.close_stream()
     return spec
-
-
-def device_from_metadata(metadata: StreamInfo) -> DeviceSpec:
-    """Create a device_spec from the data stream metadata."""
-    return DeviceSpec(name=metadata.name(),
-                      channels=channel_names(metadata),
-                      sample_rate=metadata.nominal_srate(),
-                      content_type=metadata.type())

--- a/bcipy/acquisition/tests/protocols/lsl/test_lsl_client.py
+++ b/bcipy/acquisition/tests/protocols/lsl/test_lsl_client.py
@@ -150,12 +150,14 @@ class TestDataAcquisitionClient(unittest.TestCase):
         """Test that recording works."""
 
         temp_dir = tempfile.mkdtemp()
-        path = Path(temp_dir, f'eeg_data_{DEVICE_NAME.lower()}.csv')
+        filename = f'eeg_data_{DEVICE_NAME.lower()}.csv'
+        path = Path(temp_dir, filename)
 
         self.assertFalse(path.exists())
 
         client = LslAcquisitionClient(max_buffer_len=1,
-                                      save_directory=temp_dir)
+                                      save_directory=temp_dir,
+                                      raw_data_file_name=filename)
         client.start_acquisition()
         time.sleep(0.1)
         client.stop_acquisition()

--- a/bcipy/acquisition/tests/protocols/lsl/test_lsl_recorder.py
+++ b/bcipy/acquisition/tests/protocols/lsl/test_lsl_recorder.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import pytest
 
 from bcipy.acquisition.datastream.lsl_server import LslDataServer
-from bcipy.acquisition.datastream.mock.eye_tracker_server import eye_tracker_server
+from bcipy.acquisition.datastream.mock.eye_tracker_server import \
+    eye_tracker_server
 from bcipy.acquisition.devices import preconfigured_device
 from bcipy.acquisition.protocols.lsl.lsl_recorder import LslRecorder
 from bcipy.helpers.raw_data import TIMESTAMP_COLUMN, load
@@ -16,6 +17,7 @@ DEVICE_NAME = 'DSI-24'
 DEVICE = preconfigured_device(DEVICE_NAME)
 
 
+@pytest.mark.slow
 class TestLslRecorder(unittest.TestCase):
     """Main Test class for LslRecorder code."""
 
@@ -39,13 +41,14 @@ class TestLslRecorder(unittest.TestCase):
 
     def test_recorder(self):
         """Test basic recording functionality"""
-        path = Path(self.temp_dir, f'eeg_data_{DEVICE_NAME.lower()}.csv')
-        recorder = LslRecorder(path=self.temp_dir)
+        filename = f'eeg_data_{DEVICE_NAME.lower()}.csv'
+        path = Path(self.temp_dir, filename)
+        recorder = LslRecorder(path=self.temp_dir, filenames={'EEG': filename})
         self.assertFalse(path.exists())
         recorder.start()
         time.sleep(0.1)
-        self.assertTrue(path.exists())
         recorder.stop(wait=True)
+        self.assertTrue(path.exists())
 
         raw_data = load(path)
         self.assertEqual(raw_data.daq_type, DEVICE_NAME)
@@ -54,7 +57,6 @@ class TestLslRecorder(unittest.TestCase):
         self.assertEqual(raw_data.columns[0], TIMESTAMP_COLUMN)
         self.assertEqual(raw_data.columns[1:-1], DEVICE.channels)
         self.assertEqual(raw_data.columns[-1], 'lsl_timestamp')
-        self.assertTrue(len(raw_data.rows) > 0)
 
     def test_multiple_sources(self):
         """Test that recorder works with multiple sources and can be customized

--- a/bcipy/config.py
+++ b/bcipy/config.py
@@ -51,6 +51,6 @@ STIMULI_POSITIONS_FILENAME = 'stimuli_positions.json'
 
 # misc configuration
 WAIT_SCREEN_MESSAGE = 'Press Space to start or Esc to exit'
-MAX_PAUSE_SECONDS = 360
+MAX_PAUSE_SECONDS = 365
 SESSION_COMPLETE_MESSAGE = 'Complete! Saving data...'
 REMOTE_SERVER = "https://github.com/CAMBI-tech/BciPy/"

--- a/bcipy/config.py
+++ b/bcipy/config.py
@@ -51,5 +51,6 @@ STIMULI_POSITIONS_FILENAME = 'stimuli_positions.json'
 
 # misc configuration
 WAIT_SCREEN_MESSAGE = 'Press Space to start or Esc to exit'
+MAX_PAUSE_SECONDS = 360
 SESSION_COMPLETE_MESSAGE = 'Complete! Saving data...'
 REMOTE_SERVER = "https://github.com/CAMBI-tech/BciPy/"

--- a/bcipy/gui/viewer/data_source/lsl_data_source.py
+++ b/bcipy/gui/viewer/data_source/lsl_data_source.py
@@ -1,6 +1,7 @@
 """Streams data from pylsl and puts it into a Queue."""
 import pylsl
-from bcipy.acquisition.protocols.lsl.lsl_client import device_from_metadata
+
+from bcipy.acquisition.protocols.lsl.connect import device_from_metadata
 from bcipy.gui.viewer.data_source.data_source import DataSource
 
 

--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -1,13 +1,14 @@
 import logging
 import random
-from typing import Optional, Any, Dict, List, Tuple, Union
+import time
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 from psychopy import core, event, visual
 
 from bcipy.acquisition.multimodal import ClientManager, ContentType
 from bcipy.acquisition.record import Record
-from bcipy.config import SESSION_COMPLETE_MESSAGE
+from bcipy.config import MAX_PAUSE_SECONDS, SESSION_COMPLETE_MESSAGE
 from bcipy.helpers.clock import Clock
 from bcipy.helpers.stimuli import get_fixation
 from bcipy.task.exceptions import InsufficientDataException
@@ -314,38 +315,45 @@ def get_user_input(window, message, color, first_run=False):
 
     Parameters
     ----------
-
         window[psychopy task window]: task window.  *assumes wait_screen method
+        message: message to display in the wait screen
+        color: wait screen color
+        first_run: the first_run will always pause.
 
     Returns
     -------
-        True/False: whether or not to stop a trial (based on escape key).
+        True to continue the task, False to stop and exit.
     """
-    if not first_run:
-        pause = False
-        # check user input to make sure we should be going
-        keys = event.getKeys(keyList=['space', 'escape'])
-
-        if keys:
-            # pause?
-            if keys[0] == 'space':
-                pause = True
-
-            # escape?
-            if keys[0] == 'escape':
-                return False
-
+    if first_run:
+        return pause_on_wait_screen(window, message, color)
     else:
-        pause = True
-
-    while pause:
-        window.wait_screen(message, color)
         keys = event.getKeys(keyList=['space', 'escape'])
-
         if keys:
+            if keys[0] == 'space':
+                return pause_on_wait_screen(window, message, color)
             if keys[0] == 'escape':
                 return False
-            pause = False
+    return True
+
+
+def pause_on_wait_screen(window, message, color) -> bool:
+    """Pause on the wait screen until the user presses the Space key to resume,
+    or the Escape key to exit.
+
+    Returns
+    -------
+        True to resume; False to exit.
+    """
+    pause_start = time.time()
+    window.wait_screen(message, color)
+    keys = event.waitKeys(keyList=['space', 'escape'])
+
+    elapsed_seconds = time.time() - pause_start
+    if elapsed_seconds >= MAX_PAUSE_SECONDS:
+        log.info("Pause exceeded the allowed time. Ending task.")
+        return False
+    if keys[0] == 'escape':
+        return False
 
     return True
 

--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -350,7 +350,7 @@ def pause_on_wait_screen(window, message, color) -> bool:
 
     elapsed_seconds = time.time() - pause_start
     if elapsed_seconds >= MAX_PAUSE_SECONDS:
-        log.info("Pause exceeded the allowed time. Ending task.")
+        log.info(f"Pause exceeded the allowed time ({MAX_PAUSE_SECONDS} seconds). Ending task.")
         return False
     if keys[0] == 'escape':
         return False

--- a/bcipy/task/tests/paradigm/matrix/test_matrix_calibration.py
+++ b/bcipy/task/tests/paradigm/matrix/test_matrix_calibration.py
@@ -1,9 +1,9 @@
 import unittest
 
-from mockito import any, mock, unstub, verify, when
-from mock import mock_open, patch
-import psychopy
 import numpy as np
+import psychopy
+from mock import mock_open, patch
+from mockito import any, mock, unstub, verify, when
 
 import bcipy.task.paradigm.matrix.calibration
 from bcipy.acquisition import LslAcquisitionClient
@@ -112,7 +112,10 @@ class TestMatrixCalibration(unittest.TestCase):
 
         when(TriggerHandler).add_triggers(any()).thenReturn()
 
-        when(psychopy.event).getKeys(keyList=any()).thenReturn(['space'])
+        when(psychopy.event).getKeys(keyList=['space', 'escape'],
+                                     modifiers=False,
+                                     timeStamped=False).thenReturn(['space'])
+        when(psychopy.event).getKeys(keyList=['space', 'escape']).thenReturn(['space'])
         when(psychopy.core).wait(any()).thenReturn(None)
 
     def tearDown(self):

--- a/bcipy/task/tests/paradigm/rsvp/calibration/test_rsvp_calibration.py
+++ b/bcipy/task/tests/paradigm/rsvp/calibration/test_rsvp_calibration.py
@@ -1,9 +1,8 @@
 import unittest
 
-from mockito import any, mock, unstub, verify, when
-from mock import mock_open, patch
-
 import psychopy
+from mock import mock_open, patch
+from mockito import any, mock, unstub, verify, when
 
 import bcipy.task.paradigm.rsvp.calibration.calibration
 from bcipy.acquisition import LslAcquisitionClient
@@ -11,7 +10,8 @@ from bcipy.acquisition.devices import DeviceSpec
 from bcipy.acquisition.multimodal import ContentType
 from bcipy.helpers.parameters import Parameters
 from bcipy.helpers.triggers import TriggerHandler, TriggerType
-from bcipy.task.paradigm.rsvp.calibration.calibration import RSVPCalibrationTask
+from bcipy.task.paradigm.rsvp.calibration.calibration import \
+    RSVPCalibrationTask
 
 
 class TestRSVPCalibration(unittest.TestCase):
@@ -111,7 +111,10 @@ class TestRSVPCalibration(unittest.TestCase):
         when(TriggerHandler).write().thenReturn()
         when(TriggerHandler).add_triggers(any()).thenReturn()
 
-        when(psychopy.event).getKeys(keyList=any()).thenReturn(['space'])
+        when(psychopy.event).getKeys(keyList=['space', 'escape'],
+                                     modifiers=False,
+                                     timeStamped=False).thenReturn(['space'])
+        when(psychopy.event).getKeys(keyList=['space', 'escape']).thenReturn(['space'])
         when(psychopy.core).wait(any()).thenReturn(None)
 
     def tearDown(self):

--- a/scripts/python/lsl_buffer_test.py
+++ b/scripts/python/lsl_buffer_test.py
@@ -1,0 +1,92 @@
+"""Example to demonstrate behavior when the StreamInlet max_buflen is exceeded.
+
+Prior to running, start a data streamer, such as the SendData.py example
+script included in pylsl.
+
+Example usage:
+$ python3 lsl_buffer_test.py --buffer=1 --seconds=2
+"""
+
+import time
+
+from pylsl import StreamInlet, resolve_stream
+
+
+def pull_all_data(inlet: StreamInlet, max_samples: int) -> None:
+    """Pull all buffered data in the given stream inlet."""
+
+    print("\nPulling buffered data:")
+    count = pull_chunk(inlet, max_samples)
+    while count == max_samples:
+        count = pull_chunk(inlet, max_samples)
+
+
+def pull_chunk(inlet: StreamInlet, max_samples: int) -> int:
+    """Pull a chunk of samples from a stream inlet.
+    Returns the count of samples pulled."""
+
+    _chunk, timestamps = inlet.pull_chunk(timeout=0.0, max_samples=max_samples)
+    count = len(timestamps)
+
+    time_range = ""
+    if timestamps:
+        time_range = f"{round(timestamps[0], 3)} to {round(timestamps[-1], 3)}"
+
+    print(f"-> pulled {count} samples: {time_range};",
+          f"sorted: {timestamps == sorted(timestamps)}")
+
+    return count
+
+
+def main(max_buflen: int, max_samples: int, sleep_seconds: int) -> None:
+    """Continuously read from a StreamInlet, pausing for a given time between
+    reads and then consuming all data in the stream.
+    
+    Parameters
+    ----------
+        max_buflen - StreamInlet max_buflen; buffer size in seconds
+        max_samples - maximum samples to pull in a single chunk
+        sleep_seconds - seconds to sleep between data pulls
+    """
+
+    # first resolve an EEG stream on the lab network
+    print("looking for an EEG stream...")
+    streams = resolve_stream('type', 'EEG')
+
+    # create a new inlet to read from the stream
+    print("\n---")
+    print(f"max_buflen seconds: {max_buflen}")
+    print(f"max_samples: {max_samples}")
+    print(f"sleep_seconds: {sleep_seconds}")
+    print("---")
+    inlet = StreamInlet(streams[0], max_buflen=max_buflen)
+
+    while True:
+        # pull all available samples
+        pull_all_data(inlet, max_samples)
+        time.sleep(sleep_seconds)
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-b',
+                        '--buffer',
+                        help='StreamInlet max_buflen (seconds)',
+                        default=360,
+                        type=int)
+    parser.add_argument('-c',
+                        '--chunk',
+                        help='Maximum samples per chunk',
+                        default=1024,
+                        type=int)
+    parser.add_argument('-s',
+                        '--seconds',
+                        help='Seconds to sleep between data pulls',
+                        default=2,
+                        type=int)
+    args = parser.parse_args()
+    main(max_buflen=args.buffer,
+         max_samples=args.chunk,
+         sleep_seconds=args.seconds)


### PR DESCRIPTION
# Overview

- Fixed an issue where BciPy would crash after a long pause. 
- Fixed a bug with segfaults when running BciPy on Macs.

## Ticket

https://www.pivotaltracker.com/story/show/187261791

## Contributions

- Refactored the acquisition module to use multiprocessing, rather than threading (see discussion below). 
- Added a configuration for the max number of seconds allowed for pausing.
- UI handling to end a task after a max pause duration has been reached.

## Discussion

### Segfault issue

The LSL library has methods which must be run on the main thread of execution on linux/Mac computers. Running them in a separate thread was causing segfaults to occur. By refactoring to use multiprocessing, each of the objects that use LSL are essentially acting as the main thread, which resolves this issue. Note that we should do a timing test to confirm that the static offsets are still the same.

### Pause bug

Previously we calculated the max buffer for LSL based on the maximum possible duration of an inquiry. However, we did not account for pause length. I was making the assumption that the LSL buffer would continue to accumulate data and only retain the latest (like what would happen in a ring buffer data structure). However, LSL has undefined behavior when the StreamInlet `max_buflen` is exceeded. When you attempt to retrieve data after this maximum is exceeded some of the data is missing and what is returned may not even be in monotonic order. I was able to replicate this behavior without using BciPy in the `lsl_buffer_test.py` script. This script will allow us to test future versions of LSL in case we want to change our approach. Currently, the resolution is to set a fixed maximum buffer size in the configuration that accounts for the maximum amount of time we may want to pause during a session. If this is exceeded the task gracefully shuts down.

## Test

- Ran a calibration task and paused on the wait screen (before starting the task) for different durations to confirm the behavior is correct.
- Ran the calibration task and paused after one or more inquiries. Confirmed that the task was able to resume if the wait time was less than the configured max.