### PR TITLE
VEP calibration session data

### DIFF
--- a/bcipy/display/paradigm/vep/display.py
+++ b/bcipy/display/paradigm/vep/display.py
@@ -113,6 +113,7 @@ class VEPDisplay(Display):
         self.info_text = info.build_info_text(window)
 
         # build the VEP stimuli
+        self.flicker_rates = flicker_rates
         self.logger.info(f"VEP flicker rates (hz): {flicker_rates}")
         rate = round_refresh_rate(frame_rate)
         codes = [

--- a/bcipy/display/paradigm/vep/vep_stim.py
+++ b/bcipy/display/paradigm/vep/vep_stim.py
@@ -31,12 +31,14 @@ class VEPStim:
                  num_squares: int = 4):
         self.window = win
         self.code = code
+        self.colors = colors
 
         squares = checkerboard(squares=num_squares,
                                colors=colors,
                                center=center,
                                board_size=size)
         board_boundary = envelope(pos=center, size=size)
+        self.bounds = board_boundary
 
         frame1_holes = []
         frame2_holes = []

--- a/bcipy/helpers/stimuli.py
+++ b/bcipy/helpers/stimuli.py
@@ -8,20 +8,20 @@ from abc import ABC, abstractmethod
 from collections import Counter
 from enum import Enum
 from os import path, sep
-from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Tuple, Union
+from typing import (Any, Dict, Iterator, List, NamedTuple, Optional, Tuple,
+                    Union)
 
 import mne
 import numpy as np
 import sounddevice as sd
 import soundfile as sf
-
 from mne import Annotations, Epochs
 from mne.io import RawArray
 from pandas import Series
 from PIL import Image
 from psychopy import core
 
-from bcipy.config import DEFAULT_TEXT_FIXATION, DEFAULT_FIXATION_PATH
+from bcipy.config import DEFAULT_FIXATION_PATH, DEFAULT_TEXT_FIXATION
 from bcipy.helpers.exceptions import BciPyCoreException
 from bcipy.helpers.list import grouper
 
@@ -85,7 +85,7 @@ class InquirySchedule(NamedTuple):
     - durations: `List[List[float]]`
     - colors: `List[List[str]]`
     """
-    stimuli: Union[List[List[str]], List[str]]
+    stimuli: List[Any]
     durations: Union[List[List[float]], List[float]]
     colors: Union[List[List[str]], List[str]]
 

--- a/bcipy/task/data.py
+++ b/bcipy/task/data.py
@@ -70,7 +70,7 @@ class Inquiry:
     """
 
     def __init__(self,
-                 stimuli: List[str],
+                 stimuli: List[Any],
                  timing: List[float],
                  triggers: List[Tuple[str, float]],
                  target_info: List[str],
@@ -150,7 +150,7 @@ class Inquiry:
 
     def as_dict(self) -> Dict:
         """Dict representation"""
-        data = {
+        data: Dict = {
             'stimuli': self.stimuli,
             'timing': self.timing,
             'triggers': self.triggers,
@@ -312,7 +312,7 @@ class Session:
                         stim_dict = stim.as_dict()
                     series_dict[series_counter][str(series_index)] = stim_dict
 
-        task_info = {
+        task_info: Dict = {
             'session': self.save_location,
             'task': self.task,
             'mode': self.mode,
@@ -324,7 +324,7 @@ class Session:
 
         series_info = {'series': series_dict}
 
-        summary_info = {
+        summary_info: Dict = {
             'total_time_spent': round(self.total_time_spent, self.time_spent_precision),
             'total_minutes': round(self.total_time_spent / 60, self.time_spent_precision),
             'total_number_series': self.total_number_series,

--- a/bcipy/task/data.py
+++ b/bcipy/task/data.py
@@ -66,6 +66,7 @@ class Inquiry:
         lm_evidence - language model evidence for each stimulus
         eeg_evidence - eeg evidence for each stimulus
         likelihood - combined likelihood for each stimulus
+        task_data - task-specific information about the inquiry that may be useful in training a model
     """
 
     def __init__(self,
@@ -78,7 +79,8 @@ class Inquiry:
                  target_text: Optional[str] = None,
                  selection: Optional[str] = None,
                  next_display_state: Optional[str] = None,
-                 likelihood: Optional[List[float]] = None) -> None:
+                 likelihood: Optional[List[float]] = None,
+                 task_data: Optional[Dict] = None) -> None:
         super().__init__()
         self.stimuli = stimuli
         self.timing = timing
@@ -92,6 +94,7 @@ class Inquiry:
 
         self.evidences: Dict[EvidenceType, List[float]] = {}
         self.likelihood = likelihood or []
+        self.task_data = task_data or {}
         # Precision used for serialization of evidence values. By default, no precision.
         self.precision: int = 0
 
@@ -164,6 +167,8 @@ class Inquiry:
 
         if self.likelihood:
             data['likelihood'] = self.format(self.likelihood)
+        if self.task_data:
+            data['task_data'] = self.task_data
         return data
 
     def stim_evidence(self,
@@ -211,7 +216,8 @@ class Session:
                  symbol_set: List[str],
                  task: str = 'Copy Phrase',
                  mode: str = 'RSVP',
-                 decision_threshold: Optional[float] = None) -> None:
+                 decision_threshold: Optional[float] = None,
+                 task_data: Optional[Dict[str, Any]] = None) -> None:
         super().__init__()
         self.save_location = save_location
         self.task = task
@@ -222,6 +228,7 @@ class Session:
         self.task_summary: Dict[str, Any] = {}
         self.symbol_set = symbol_set
         self.decision_threshold = decision_threshold
+        self.task_data = task_data or {}
 
     @property
     def total_number_series(self) -> int:
@@ -305,24 +312,30 @@ class Session:
                         stim_dict = stim.as_dict()
                     series_dict[series_counter][str(series_index)] = stim_dict
 
-        info = {
+        task_info = {
             'session': self.save_location,
             'task': self.task,
             'mode': self.mode,
             'symbol_set': self.symbol_set,
-            'decision_threshold': self.decision_threshold,
-            'series': series_dict,
-            'total_time_spent': round(self.total_time_spent,
-                                      self.time_spent_precision),
+            'decision_threshold': self.decision_threshold
+        }
+        if self.task_data:
+            task_info['task_data'] = self.task_data
+
+        series_info = {'series': series_dict}
+
+        summary_info = {
+            'total_time_spent': round(self.total_time_spent, self.time_spent_precision),
             'total_minutes': round(self.total_time_spent / 60, self.time_spent_precision),
             'total_number_series': self.total_number_series,
             'total_inquiries': self.total_inquiries,
             'total_selections': self.total_number_decisions,
             'inquiries_per_selection': self.inquiries_per_selection
         }
-
         if self.task_summary:
-            info['task_summary'] = self.task_summary
+            summary_info['task_summary'] = self.task_summary
+
+        info = {**task_info, **series_info, **summary_info}
         return info
 
     @classmethod

--- a/bcipy/task/paradigm/vep/calibration.py
+++ b/bcipy/task/paradigm/vep/calibration.py
@@ -81,6 +81,7 @@ class VEPCalibrationTask(Task):
         self.daq = daq
         self.static_clock = core.StaticPeriod(screenHz=self.frame_rate)
         self.experiment_clock = Clock()
+        self.start_time = self.experiment_clock.getTime()
         self.buffer_val = parameters['task_buffer_length']
         self.symbol_set = alphabet(parameters)
 
@@ -280,6 +281,7 @@ class VEPCalibrationTask(Task):
                        target_letter=inquiry[0],
                        task_data=task_data)
         self.session.add_sequence(data)
+        self.session.total_time_spent = self.experiment_clock.getTime() - self.start_time
         self.write_session_data()
 
     def name(self):

--- a/bcipy/task/tests/core/test_data.py
+++ b/bcipy/task/tests/core/test_data.py
@@ -5,9 +5,8 @@ import unittest
 from bcipy.task.data import EvidenceType, Inquiry, Session
 
 SYMBOL_SET = [
-    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
-    'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-    '<', '_'
+    'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
+    'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '<', '_'
 ]
 
 
@@ -288,6 +287,32 @@ class TestSessionData(unittest.TestCase):
         session.add_sequence(sample_stim_seq())
         session.add_sequence(sample_stim_seq(include_evidence=True))
         self.assertTrue(session.has_evidence())
+
+    def test_task_data(self):
+        """Test that task-specific data can be added to the session."""
+        session = Session(save_location=".",
+                          symbol_set=SYMBOL_SET,
+                          task_data={
+                              "greeting": "Hello",
+                              "count": 10
+                          })
+        serialized = session.as_dict()
+        self.assertTrue("task_data" in serialized)
+        self.assertEqual(serialized['task_data']['greeting'], "Hello")
+        self.assertEqual(serialized['task_data']['count'], 10)
+
+    def test_task_inquiry_data(self):
+        """Test that inquiries may have task-specific data."""
+        data = {"color": "blue", "flicker_rate": 10}
+        inq = Inquiry(stimuli=[],
+                      timing=[],
+                      triggers=[],
+                      target_info=[],
+                      task_data=data)
+        inq_dict = inq.as_dict()
+        self.assertTrue("task_data" in inq_dict)
+        self.assertEqual(inq_dict['task_data']['color'], 'blue')
+        self.assertEqual(inq_dict['task_data']['flicker_rate'], 10)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Overview

Added session.json output for VEP Calibration task to capture data needed for creating a model.

## Ticket

https://www.pivotaltracker.com/story/show/186522989

## Contributions

- Updated task data module to allow for task-specific Inquiry and Session data
- Added properties to display elements useful for recording in the session data.
- Added functionality to VEP Calibration task for outputting session data. General task data includes information about each box (coordinates, colors, flicker rate). Each Inquiry has information about which stimuli were presented in each box, which box contained the target symbol, as well as the flicker rate of that box.

## Test

- Ran all unit tests
- Ran a VEP calibration task and inspected the resulting session.json file.