### PR TITLE
Parameters Save As Bug

### DIFF
--- a/bcipy/gui/BCInterface.py
+++ b/bcipy/gui/BCInterface.py
@@ -1,20 +1,15 @@
 import subprocess
 import sys
-
 from typing import List
 
-from bcipy.config import BCIPY_ROOT, DEFAULT_PARAMETERS_PATH, STATIC_IMAGES_PATH
-from bcipy.gui.main import (
-    AlertMessageResponse,
-    AlertMessageType,
-    AlertResponse,
-    app,
-    BCIGui,
-    contains_special_characters,
-    contains_whitespaces,
-    invalid_length,
-)
-from bcipy.helpers.load import load_json_parameters, load_experiments, copy_parameters, load_users
+from bcipy.config import (BCIPY_ROOT, DEFAULT_PARAMETERS_PATH,
+                          STATIC_IMAGES_PATH)
+from bcipy.gui.main import (AlertMessageResponse, AlertMessageType,
+                            AlertResponse, BCIGui, app,
+                            contains_special_characters, contains_whitespaces,
+                            invalid_length)
+from bcipy.helpers.load import (copy_parameters, load_experiments,
+                                load_json_parameters, load_users)
 from bcipy.task import TaskType
 
 
@@ -317,9 +312,11 @@ class BCInterface(BCIGui):
                 else:
                     return None
 
-            subprocess.call(
+            output = subprocess.check_output(
                 f'python {BCIPY_ROOT}/gui/parameters/params_form.py -p {self.parameter_location}',
                 shell=True)
+            if output:
+                self.parameter_location = output.decode().strip()
 
     def check_input(self) -> bool:
         """Check Input.

--- a/bcipy/gui/parameters/params_form.py
+++ b/bcipy/gui/parameters/params_form.py
@@ -418,11 +418,14 @@ class MainPanel(QWidget):
                 self.repaint()
 
 
-def main(json_file, title='BCI Parameters', size=(450, 550)):
+def main(json_file, title='BCI Parameters', size=(450, 550)) -> str:
     """Set up the GUI components and start the main loop."""
     app = QApplication(sys.argv)
-    _panel = MainPanel(json_file, title, size)
-    sys.exit(app.exec())
+    panel = MainPanel(json_file, title, size)
+    app.exec()
+    json_file = panel.json_file
+    app.quit()
+    return json_file
 
 
 if __name__ == '__main__':
@@ -439,4 +442,6 @@ if __name__ == '__main__':
                         default=DEFAULT_PARAMETERS_PATH,
                         help='Path to parameters.json configuration file.')
     args = parser.parse_args()
-    main(args.parameters)
+    # Note that this write to stdout is important for the interaction with
+    # the BCInterface main GUI.
+    print(main(args.parameters), file=sys.stdout)


### PR DESCRIPTION
# Overview

Updated the main GUI with the new parameter location after using the Save As functionality in the params_form GUI.

## Ticket

https://www.pivotaltracker.com/story/show/185720052

## Contributions

- Updated params_form to return the json data path of the parameters file.
- Refactored main GUI to use subprocess check_output to get the new value and use that to update the parameter location.

## Test

- Ran the main GUI, edited the parameters, saved the parameters file to a new location, closed the params form, then started an experiment. Confirmed that the experiment was using the new parameters. Inspected the experiment parameters.json to confirm that the parameter_location was referencing the correct value.
