### PR TITLE
GitHub actions MacOS build fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+      - macOS_build_fix
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,7 +116,7 @@ jobs:
       run: |
         sh scripts/shell/m2chip_install.sh
         brew install labstreaminglayer/tap/lsl
-        python -m pip install --upgrade pip settuptools wheel
+        python -m pip install --upgrade pip
     - name: install dependencies
       run: |
         make dev-install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,6 +120,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: update pip & install custom dependencies
       run: |
+        sh scripts/shell/m2chip_install.sh
         brew install labstreaminglayer/tap/lsl
         python -m pip install --upgrade pip
         pip install kenlm==0.1 --global-option="--max_order=12"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,8 +114,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: update pip & install custom dependencies
       run: |
+        sh scripts/shell/m2chip_install.sh
+        brew install labstreaminglayer/tap/lsl
         python -m pip install --upgrade pip
-        make dev-install-mac
     - name: install dependencies
       run: |
         make dev-install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,13 +37,10 @@ jobs:
         sudo apt-get install libsndfile*
         sudo apt-get install xvfb
         python -m pip install --upgrade pip
-        pip install kenlm==0.1 --global-option="--max_order=12"
-        pip install psychopy==2023.2.1 --no-deps
         pip install attrdict3
     - name: Install dependencies
       run: |
-        pip install -r dev_requirements.txt
-        pip install -e .
+        make dev-install
     - name: Unit test
       if: always()
       run: |
@@ -61,10 +58,10 @@ jobs:
         fi
     - name: type-check
       run: |
-        mypy bcipy
+        make type
     - name: lint
       run: |
-        flake8 bcipy
+        make lint
 
   build-windows:
 
@@ -83,26 +80,23 @@ jobs:
     - name: update pip & install custom dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install kenlm==0.1 --global-option="--max_order=12"
-        pip install psychopy==2023.2.1 --no-deps
     - name: install manually downloaded pyWinhook wheel for Python 3.9
       if: matrix.python-version == 3.9
       run: |
         pip install ./.bcipy/downloads/pyWinhook-1.6.2-cp39-cp39-win_amd64.whl
     - name: install dependencies
       run: |
-        pip install -r dev_requirements.txt
-        pip install -e .
+        make dev-install
     - name: unittest
       if: always()
       run: |
-        coverage run --branch --source=bcipy -m pytest --mpl -k "not slow"
+        make coverage-report
     - name: type-check
       run: |
-        mypy bcipy
+        make type
     - name: lint
       run: |
-        flake8 bcipy
+        make lint
 
   build-macos:
 
@@ -122,20 +116,19 @@ jobs:
       run: |
         sh scripts/shell/m2chip_install.sh
         brew install labstreaminglayer/tap/lsl
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip settuptools wheel
     - name: install dependencies
       run: |
         make dev-install
     - name: unittest
       if: always()
       run: |
-        coverage run --branch --source=bcipy -m pytest --mpl -k "not slow"
-        coverage report
+        make coverage-report
     - name: type-check
       run: |
-        mypy bcipy
+        make type
     - name: lint
       run: |
-        flake8 bcipy
+        make lint
 
     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,9 +114,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: update pip & install custom dependencies
       run: |
-        sh scripts/shell/m2chip_install.sh
-        brew install labstreaminglayer/tap/lsl
         python -m pip install --upgrade pip
+        make dev-install-mac
     - name: install dependencies
       run: |
         make dev-install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,12 +123,9 @@ jobs:
         sh scripts/shell/m2chip_install.sh
         brew install labstreaminglayer/tap/lsl
         python -m pip install --upgrade pip
-        pip install kenlm==0.1 --global-option="--max_order=12"
-        pip install psychopy==2023.2.1 --no-deps
     - name: install dependencies
       run: |
-        pip install -r dev_requirements.txt
-        pip install -e .
+        make dev-install
     - name: unittest
       if: always()
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-      - macOS_build_fix
   pull_request:
     branches:
       - '**'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Our last release candidate before the official 2.0 release!
     - Add mypy typing to the codebase #301
     - Change default log level to INFO to prevent too many messages in the experiment logs #288 
     - Upgrade requirements for m1/2 chips #299/#300
+    - Fix GitHub actions build issues with macOS
 
 
 # 2.0.0-rc.3

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ dev-install:
 
 make dev-install-mac:
 	sh scripts/shell/m2chip_install.sh
-	brew install labstreaminglayer/tap/lsl
+    brew install labstreaminglayer/tap/lsl
 	make dev-install
 
 test-all:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ dev-install:
 
 make dev-install-mac:
 	sh scripts/shell/m2chip_install.sh
-    brew install labstreaminglayer/tap/lsl
+	brew install labstreaminglayer/tap/lsl
 	make dev-install
 
 test-all:

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,6 @@ dev-install:
 	pip install kenlm==0.1 --global-option="--max_order=12"
 	make install
 
-make dev-install-mac:
-	sh scripts/shell/m2chip_install.sh
-    brew install labstreaminglayer/tap/lsl
-	make dev-install
-
 test-all:
 	make coverage-report
 	make type

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ dev-install:
 	pip install kenlm==0.1 --global-option="--max_order=12"
 	make install
 
+make dev-install-mac:
+	sh scripts/shell/m2chip_install.sh
+    brew install labstreaminglayer/tap/lsl
+	make dev-install
+
 test-all:
 	make coverage-report
 	make type

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ PyQt6==6.6.0
 PyQt6-Qt6==6.6.0
 pywavelets==1.4.1
 tqdm==4.62.2
+tables==3.7.0

--- a/scripts/shell/m2chip_install.sh
+++ b/scripts/shell/m2chip_install.sh
@@ -27,6 +27,6 @@ export HDF5_DIR=/opt/homebrew/opt/hdf5
 python -m pip install pyaudio
 # your path may be different to the portaudio version
 pip install --global-option='build_ext' --global-option='-I/usr/local/Cellar/portaudio/19.7.0/include' --global-option='-L/usr/local/Cellar/portaudio/19.7.0/lib' pyo   
-# pip install Psychopy==2023.2.1 --no-deps    # install psychopy without dependencies
-# pip install -e .
-# pip install kenlm==0.1 --global-option="--max_order=12" # install kenlm with max_order=12 for language model. Not required for BciPy to run in most places.
+pip install Psychopy==2023.2.1 --no-deps    # install psychopy without dependencies
+pip install -e .
+pip install kenlm==0.1 --global-option="--max_order=12" # install kenlm with max_order=12 for language model. Not required for BciPy to run in most places.

--- a/scripts/shell/m2chip_install.sh
+++ b/scripts/shell/m2chip_install.sh
@@ -27,6 +27,6 @@ export HDF5_DIR=/opt/homebrew/opt/hdf5
 python -m pip install pyaudio
 # your path may be different to the portaudio version
 pip install --global-option='build_ext' --global-option='-I/usr/local/Cellar/portaudio/19.7.0/include' --global-option='-L/usr/local/Cellar/portaudio/19.7.0/lib' pyo   
-pip install Psychopy==2023.2.1 --no-deps    # install psychopy without dependencies
-pip install -e .
-pip install kenlm==0.1 --global-option="--max_order=12" # install kenlm with max_order=12 for language model. Not required for BciPy to run in most places.
+# pip install Psychopy==2023.2.1 --no-deps    # install psychopy without dependencies
+# pip install -e .
+# pip install kenlm==0.1 --global-option="--max_order=12" # install kenlm with max_order=12 for language model. Not required for BciPy to run in most places.

--- a/scripts/shell/m2chip_install.sh
+++ b/scripts/shell/m2chip_install.sh
@@ -1,6 +1,6 @@
 """Mac M2 install script. 
 
-This script is intended to be run from the root of the BciPy repository. It may work for M1 chips, but
+This script is intended to be run from the root of the BciPy repository. It has been tested on M2 and M3 chips. It may work for M1 chips, but
 this has not been tested and may require use of Rosetta 2.
 
 This script will install the necessary dependencies for the M2 chip on a Mac. It will also install


### PR DESCRIPTION
# Overview

Fixes issue where macOS builds on the GitHub actions would fail, and refactors GitHub actions to use makefile.

## Ticket

[Pivotal ticket](https://www.pivotaltracker.com/story/show/187517298)

## Contributions

- Fixed macOS build issues in GitHub actions
- Refactored GitHub actions configuration to use the makefile for most of its install tasks.

## Test

- Successfully ran the install process locally on my mac
- Ran the GitHub actions for this branch, and successfully completed all builds.

## Documentation

Updated comment in `m2chip_install.sh` to indicate it has been tested on M3. other than that, the changes don't require additional documentation

## Changelog

- Changelog is updated
