### PR TITLE
Stimuli test fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Our last release candidate before the official 2.0 release!
     - Change default log level to INFO to prevent too many messages in the experiment logs #288 
     - Upgrade requirements for m1/2 chips #299/#300
     - Fix GitHub actions build issues with macOS
+    - Fix occasionally failing test in `test_stimuli`
 
 
 # 2.0.0-rc.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Our last release candidate before the official 2.0 release!
     - Change default log level to INFO to prevent too many messages in the experiment logs #288 
     - Upgrade requirements for m1/2 chips #299/#300
     - Fix GitHub actions build issues with macOS
-    - Fix occasionally failing test in `test_stimuli`
+    - Fix occasionally failing test in `test_stimuli` #326
 
 
 # 2.0.0-rc.3

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -762,9 +762,9 @@ class TestStimuliGeneration(unittest.TestCase):
 
         self.assertEqual([1] + ([0.2] * n), times[0])
         self.assertEqual(['red'] + (['white'] * n), colors[0])
-    
+
     def test_best_case_inq_gen_is_random(self):
-        """Test that best_case_inq_gen produces random results. While this test can technically fail, 
+        """Test that best_case_inq_gen produces random results. While this test can technically fail,
         the odds are incredibly low, around 1 in 1 million"""
         samps = []
         for i in range(25):
@@ -779,7 +779,7 @@ class TestStimuliGeneration(unittest.TestCase):
             samps.append(tuple(samples[0]))
         set(samps)
         self.assertTrue(len(set(samps)) > 1, 'Should produce random results')
-        
+
 
 class TestJitteredTiming(unittest.TestCase):
 

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -762,7 +762,24 @@ class TestStimuliGeneration(unittest.TestCase):
 
         self.assertEqual([1] + ([0.2] * n), times[0])
         self.assertEqual(['red'] + (['white'] * n), colors[0])
-
+    
+    def test_best_case_inq_gen_is_random(self):
+        """Test that best_case_inq_gen produces random results. While this test can technically fail, 
+        the odds are incredibly low, around 1 in 1 million"""
+        samps = []
+        for i in range(25):
+            alp = ['a', 'b', 'c', 'd', 'e', 'f', 'g', '<']
+            samples, _, _ = best_case_rsvp_inq_gen(
+                alp=alp,
+                session_stimuli=[0.1, 0.1, 0.1, 0.2, 0.2, 0.1, 0.2, 0.0],
+                stim_number=1,
+                stim_length=8,
+                is_txt=True,
+                inq_constants=['<'])
+            samps.append(tuple(samples[0]))
+        set(samps)
+        self.assertTrue(len(set(samps)) > 1, 'Should produce random results')
+        
 
 class TestJitteredTiming(unittest.TestCase):
 

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -766,7 +766,7 @@ class TestStimuliGeneration(unittest.TestCase):
     def test_best_case_inq_gen_is_random(self):
         """Test that best_case_inq_gen produces random results. While this test can technically fail,
         the odds are incredibly low, around 1 in 1 million"""
-        samps = []
+        samps = set()
         for i in range(25):
             alp = ['a', 'b', 'c', 'd', 'e', 'f', 'g', '<']
             samples, _, _ = best_case_rsvp_inq_gen(
@@ -776,9 +776,8 @@ class TestStimuliGeneration(unittest.TestCase):
                 stim_length=8,
                 is_txt=True,
                 inq_constants=['<'])
-            samps.append(tuple(samples[0]))
-        set(samps)
-        self.assertTrue(len(set(samps)) > 1, 'Should produce random results')
+            samps.add(tuple(samples[0]))
+        self.assertTrue(len(samps) > 1, '`best_case_rsvp_inq_gen` Should produce random results')
 
 
 class TestJitteredTiming(unittest.TestCase):

--- a/bcipy/helpers/tests/test_stimuli.py
+++ b/bcipy/helpers/tests/test_stimuli.py
@@ -730,7 +730,6 @@ class TestStimuliGeneration(unittest.TestCase):
 
     def test_best_case_inquiry_gen_with_inq_constants(self):
         """Test best_case_rsvp_inq_gen with inquiry constants"""
-
         alp = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
         n = 5
 
@@ -761,7 +760,6 @@ class TestStimuliGeneration(unittest.TestCase):
         for letter in expected:
             self.assertTrue(letter in first_inq)
 
-        self.assertNotEqual(expected, first_inq, 'Should be in random order.')
         self.assertEqual([1] + ([0.2] * n), times[0])
         self.assertEqual(['red'] + (['white'] * n), colors[0])
 


### PR DESCRIPTION
# Overview

Refactored stimuli test to remove random test failure

## Ticket

[Pivotal Ticket](https://www.pivotaltracker.com/story/show/186455473)

## Contributions

- Removed failing test case from `test_best_case_inquiry_gen_with_inq_constants`
- Added `test_best_case_inq_gen_is_random` test to assert that multiple inquiries are in a random order

## Test

- Ran the tests to ensure they worked

## Documentation

- No documentation required other than method comment

## Changelog

- Yes
