### PR TITLE
Static Offset per Device

### DIFF
--- a/bcipy/acquisition/tests/test_client_manager.py
+++ b/bcipy/acquisition/tests/test_client_manager.py
@@ -15,6 +15,7 @@ class TestClientManager(unittest.TestCase):
         self.eeg_device_mock.content_type = 'EEG'
         self.eeg_device_mock.sample_rate = 300
         self.eeg_device_mock.is_active = True
+        self.eeg_device_mock.static_offset = 0.1
 
         self.eeg_client_mock = Mock()
         self.eeg_client_mock.device_spec = self.eeg_device_mock
@@ -26,6 +27,7 @@ class TestClientManager(unittest.TestCase):
         self.gaze_device_mock.content_type = 'Eyetracker'
         self.gaze_device_mock.sample_rate = 60
         self.gaze_device_mock.is_active = False
+        self.gaze_device_mock.static_offset = 0.0
         self.gaze_client_mock = Mock()
         self.gaze_client_mock.device_spec = self.gaze_device_mock
 
@@ -115,6 +117,7 @@ class TestClientManager(unittest.TestCase):
         switch_device_mock.name = 'Test-switch-2000'
         switch_device_mock.content_type = 'Markers'
         switch_device_mock.sample_rate = 0.0
+        switch_device_mock.static_offset = 0.2
 
         switch_client_mock = Mock()
         switch_client_mock.device_spec = switch_device_mock
@@ -141,11 +144,11 @@ class TestClientManager(unittest.TestCase):
                                              ContentType.MARKERS
                                          ])
 
-        self.eeg_client_mock.get_data.assert_called_once_with(start=100,
+        self.eeg_client_mock.get_data.assert_called_once_with(start=100.1,
                                                               limit=1500)
         self.gaze_client_mock.get_data.assert_called_once_with(start=100,
                                                                limit=300)
-        switch_client_mock.get_data.assert_called_with(start=100, end=105)
+        switch_client_mock.get_data.assert_called_with(start=100.2, end=105.2)
 
         self.assertTrue(ContentType.EEG in results)
         self.assertTrue(ContentType.EYETRACKER in results)

--- a/bcipy/helpers/convert.py
+++ b/bcipy/helpers/convert.py
@@ -4,7 +4,7 @@ import logging
 import os
 import tarfile
 from pathlib import Path
-from typing import Dict, List, Tuple, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import mne
 import numpy as np
@@ -12,6 +12,7 @@ from mne.io import RawArray
 from pyedflib import FILETYPE_BDFPLUS, FILETYPE_EDFPLUS, EdfWriter
 from tqdm import tqdm
 
+from bcipy.acquisition.devices import preconfigured_device
 from bcipy.config import (DEFAULT_PARAMETER_FILENAME, RAW_DATA_FILENAME,
                           TRIGGER_FILENAME)
 from bcipy.helpers.load import load_json_parameters, load_raw_data
@@ -177,6 +178,7 @@ def pyedf_convert(data_dir: str,
                                   value_cast=True)
     data = load_raw_data(str(Path(data_dir, f'{RAW_DATA_FILENAME}.csv')))
     fs = data.sample_rate
+    device_spec = preconfigured_device(data.daq_type)
     if pre_filter:
         default_transform = get_default_transform(
             sample_rate_hz=data.sample_rate,
@@ -194,7 +196,7 @@ def pyedf_convert(data_dir: str,
     else:
         raw_data, _ = data.by_channel()
     durations = trigger_durations(params) if use_event_durations else {}
-    static_offset = params['static_trigger_offset']
+    static_offset = device_spec.static_offset
     logger.info(f'Static offset: {static_offset}')
 
     trigger_type, trigger_timing, trigger_label = trigger_decoder(

--- a/bcipy/helpers/demo/demo_visualization.py
+++ b/bcipy/helpers/demo/demo_visualization.py
@@ -44,7 +44,8 @@ if __name__ == '__main__':
     if not path:
         path = load_experimental_data()
 
-    parameters = load_json_parameters(f'{path}/{DEFAULT_PARAMETER_FILENAME}', value_cast=True)
+    parameters = load_json_parameters(f'{path}/{DEFAULT_PARAMETER_FILENAME}',
+                                      value_cast=True)
 
     # extract all relevant parameters
     trial_window = parameters.get("trial_window", (0, 0.5))
@@ -59,11 +60,15 @@ if __name__ == '__main__':
     filter_high = parameters.get("filter_high")
     filter_low = parameters.get("filter_low")
     filter_order = parameters.get("filter_order")
-    static_offset = parameters.get("static_trigger_offset")
+
     raw_data = load_raw_data(Path(path, f'{RAW_DATA_FILENAME}.csv'))
     channels = raw_data.channels
     type_amp = raw_data.daq_type
     sample_rate = raw_data.sample_rate
+
+    devices.load(Path(path, DEFAULT_DEVICE_SPEC_FILENAME))
+    device_spec = devices.preconfigured_device(raw_data.daq_type)
+    static_offset = device_spec.static_offset
 
     # setup filtering
     default_transform = get_default_transform(
@@ -82,8 +87,6 @@ if __name__ == '__main__':
     )
     labels = [0 if label == 'nontarget' else 1 for label in trigger_targetness]
 
-    devices.load(Path(path, DEFAULT_DEVICE_SPEC_FILENAME))
-    device_spec = devices.preconfigured_device(raw_data.daq_type)
     channel_map = analysis_channels(channels, device_spec)
 
     save_path = None if not args.save else path

--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -180,7 +180,6 @@ def get_data_for_decision(inquiry_timing: List[Tuple[str, float]],
 def get_device_data_for_decision(
         inquiry_timing: List[Tuple[str, float]],
         daq: ClientManager,
-        offset: float = 0.0,
         prestim: float = 0.0,
         poststim: float = 0.0) -> Dict[ContentType, List[Record]]:
     """Queries the acquisition client manager for a slice of data from each
@@ -206,13 +205,13 @@ def get_device_data_for_decision(
     _, last_stim_time = inquiry_timing[-1]
 
     # adjust for offsets
-    time1 = first_stim_time + offset - prestim
-    time2 = last_stim_time + offset
+    time1 = first_stim_time - prestim
+    time2 = last_stim_time
 
     if time2 < time1:
         raise InsufficientDataException(
             f'Invalid data query [{time1}-{time2}] with parameters:'
-            f'[inquiry={inquiry_timing}, offset={offset}, prestim={prestim}, poststim={poststim}]'
+            f'[inquiry={inquiry_timing}, prestim={prestim}, poststim={poststim}]'
         )
 
     data = daq.get_data_by_device(start=time1,

--- a/bcipy/helpers/tests/resources/mock_session/parameters.json
+++ b/bcipy/helpers/tests/resources/mock_session/parameters.json
@@ -58,14 +58,6 @@
     ],
     "type": "str"
   },
-  "static_trigger_offset": {
-    "value": ".1",
-    "section": "bci_config",
-    "readableName": "Static Trigger Offset",
-    "helpTip": "Specifies the static trigger offset (in seconds) used to align triggers properly with EEG data from LSL. The system includes built-in offset correction, but there is still a hardware-limited offset between EEG and trigger timing values for which the system does not account. The default value of 0.1 has been verified for OHSU hardware. The correct value may be different for other computers, and must be determined on a case-by-case basis. Default: .1",
-    "recommended_values": "",
-    "type": "float"
-  },
   "k_folds": {
     "value": "10",
     "section": "signal_config",

--- a/bcipy/helpers/visualization.py
+++ b/bcipy/helpers/visualization.py
@@ -1,8 +1,8 @@
 # mypy: disable-error-code="attr-defined,union-attr,arg-type"
 # needed for the ERPTransformParams
 import logging
-from typing import List, Dict, Optional, Tuple, Union
 from pathlib import Path
+from typing import Dict, List, Optional, Tuple, Union
 
 import matplotlib.pyplot as plt
 import mne
@@ -16,12 +16,13 @@ from mne.io import read_raw_edf
 from scipy import linalg
 
 import bcipy.acquisition.devices as devices
-from bcipy.config import (DEFAULT_DEVICE_SPEC_FILENAME, RAW_DATA_FILENAME,
-                          DEFAULT_GAZE_IMAGE_PATH, TRIGGER_FILENAME)
+from bcipy.config import (DEFAULT_DEVICE_SPEC_FILENAME,
+                          DEFAULT_GAZE_IMAGE_PATH, RAW_DATA_FILENAME,
+                          TRIGGER_FILENAME)
 from bcipy.helpers.acquisition import analysis_channels
-from bcipy.helpers.parameters import Parameters
 from bcipy.helpers.convert import convert_to_mne
 from bcipy.helpers.load import choose_csv_file, load_raw_data
+from bcipy.helpers.parameters import Parameters
 from bcipy.helpers.raw_data import RawData
 from bcipy.helpers.stimuli import mne_epochs
 from bcipy.helpers.triggers import TriggerType, trigger_decoder
@@ -684,7 +685,6 @@ def visualize_session_data(session_path: str, parameters: Union[dict, Parameters
     """
     # extract all relevant parameters
     trial_window = parameters.get("trial_window")
-    static_offset = parameters.get("static_trigger_offset")
 
     raw_data = load_raw_data(str(Path(session_path, f'{RAW_DATA_FILENAME}.csv')))
     channels = raw_data.channels
@@ -707,7 +707,7 @@ def visualize_session_data(session_path: str, parameters: Union[dict, Parameters
     )
     # Process triggers.txt files
     trigger_targetness, trigger_timing, _ = trigger_decoder(
-        offset=static_offset,
+        offset=device_spec.static_offset,
         trigger_path=f"{session_path}/{TRIGGER_FILENAME}",
         exclusion=[TriggerType.PREVIEW, TriggerType.EVENT, TriggerType.FIXATION],
         device_type='EEG',

--- a/bcipy/parameters/devices.json
+++ b/bcipy/parameters/devices.json
@@ -125,6 +125,6 @@
         "description": "Tobii Nano. For use with the Tobii Pro SDK.",
         "excluded_from_analysis": ["device_ts", "system_ts", "left_pupil", "right_pupil"],
         "status": "active",
-        "static_offset": 0.0
+        "static_offset": 0.1
     }
 ]

--- a/bcipy/parameters/devices.json
+++ b/bcipy/parameters/devices.json
@@ -41,7 +41,8 @@
             "F3", "F4",
             "C3", "C4"
         ],
-        "status": "active"
+        "status": "active",
+        "static_offset": 0.1
     },
     {
         "name": "DSI-VR300",
@@ -59,7 +60,8 @@
         "sample_rate": 300,
         "description": "Wearable Sensing DSI-VR300",
         "excluded_from_analysis": ["TRG", "F7"],
-        "status": "active"
+        "status": "active",
+        "static_offset": 0.1
     },
     {
         "name": "DSI-Flex",
@@ -77,7 +79,8 @@
         "sample_rate": 300.0,
         "description": "Wearable Sensing DSI-Flex",
         "excluded_from_analysis": ["TRG"],
-        "status": "active"
+        "status": "active",
+        "static_offset": 0.1
     },
     {
         "name": "g.USBamp-1",
@@ -102,7 +105,8 @@
         ],
         "sample_rate": 256,
         "description": "GTec g.USBamp",
-        "status": "active"
+        "status": "active",
+        "static_offset": 0.1
     },
     {
         "name": "Tobii Nano",
@@ -120,6 +124,7 @@
         "sample_rate": 60.0,
         "description": "Tobii Nano. For use with the Tobii Pro SDK.",
         "excluded_from_analysis": ["device_ts", "system_ts", "left_pupil", "right_pupil"],
-        "status": "active"
+        "status": "active",
+        "static_offset": 0.0
     }
 ]

--- a/bcipy/parameters/devices.json
+++ b/bcipy/parameters/devices.json
@@ -125,6 +125,6 @@
         "description": "Tobii Nano. For use with the Tobii Pro SDK.",
         "excluded_from_analysis": ["device_ts", "system_ts", "left_pupil", "right_pupil"],
         "status": "active",
-        "static_offset": 0.1
+        "static_offset": 0.0
     }
 ]

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -32,14 +32,6 @@
     ],
     "type": "str"
   },
-  "static_trigger_offset": {
-    "value": "0.1",
-    "section": "bci_config",
-    "readableName": "Static Trigger Offset",
-    "helpTip": "Specifies the static trigger offset (in seconds) used to align triggers properly with EEG data from LSL. The system includes built-in offset correction, but there is still a hardware-limited offset between EEG and trigger timing values for which the system does not account. The default value of 0.1 has been verified for OHSU hardware. The correct value may be different for other computers, and must be determined on a case-by-case basis. Default: 0.1",
-    "recommended_values": "",
-    "type": "float"
-  },
   "k_folds": {
     "value": "10",
     "section": "signal_config",

--- a/bcipy/signal/model/offline_analysis.py
+++ b/bcipy/signal/model/offline_analysis.py
@@ -111,7 +111,7 @@ def analyze_erp(erp_data, parameters, device_spec, data_folder, estimate_balance
     # Get signal filtering information
     transform_params = parameters.instantiate(ERPTransformParams)
     downsample_rate = transform_params.down_sampling_rate
-    static_offset = parameters.get("static_trigger_offset")
+    static_offset = device_spec.static_offset
 
     log.info(
         f"\nData processing settings: \n"

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -98,7 +98,7 @@ class RSVPCopyPhraseTask(Task):
         'show_feedback', 'feedback_duration',
         'show_preview_inquiry', 'preview_inquiry_isi',
         'preview_inquiry_key_input', 'preview_inquiry_length', 'preview_inquiry_progress_method',
-        'spelled_letters_count', 'static_trigger_offset',
+        'spelled_letters_count',
         'stim_color', 'stim_height', 'stim_jitter', 'stim_length', 'stim_number',
         'stim_order', 'stim_pos_x', 'stim_pos_y', 'stim_space_char', 'target_color',
         'task_buffer_length', 'task_color', 'task_height', 'task_text',
@@ -599,7 +599,6 @@ class RSVPCopyPhraseTask(Task):
         device_data = get_device_data_for_decision(
             inquiry_timing=inquiry_timing,
             daq=self.daq,
-            offset=self.parameters['static_trigger_offset'],
             prestim=prestim_buffer,
             poststim=post_stim_buffer + window_length)
 

--- a/bcipy/task/tests/paradigm/matrix/test_matrix_calibration.py
+++ b/bcipy/task/tests/paradigm/matrix/test_matrix_calibration.py
@@ -47,7 +47,6 @@ class TestMatrixCalibration(unittest.TestCase):
             'preview_inquiry_length': 5.0,
             'show_feedback': False,
             'show_preview_inquiry': False,
-            'static_trigger_offset': 0.1,
             'stim_color': 'white',
             'stim_height': 0.6,
             'stim_jitter': 0.0,

--- a/bcipy/task/tests/paradigm/rsvp/calibration/test_rsvp_calibration.py
+++ b/bcipy/task/tests/paradigm/rsvp/calibration/test_rsvp_calibration.py
@@ -45,7 +45,6 @@ class TestRSVPCalibration(unittest.TestCase):
             'preview_inquiry_length': 5.0,
             'show_feedback': False,
             'show_preview_inquiry': False,
-            'static_trigger_offset': 0.1,
             'stim_color': 'white',
             'stim_height': 0.6,
             'stim_jitter': 0.0,

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -58,7 +58,6 @@ class TestCopyPhrase(unittest.TestCase):
             'show_feedback': False,
             'show_preview_inquiry': False,
             'spelled_letters_count': 0,
-            'static_trigger_offset': 0.1,
             'stim_color': 'white',
             'stim_height': 0.6,
             'stim_length': 10,


### PR DESCRIPTION
# Overview

Refactored code to allow configuration of a static_offset value for each device, rather than a global value set in the parameters.json.

## Ticket

https://www.pivotaltracker.com/story/show/187737714

## Contributions

- Added a static_offset to the DeviceSpec; added a new default value for each device in devices.json
- Updated any code using previous offset from the parameters file to read the offset for the device of interest (in particular, see offline_analysis and copy phrase)
- Fixed unit tests

## Test

- Ran all unit tests
- Ran RSVP Calibration -> Offline Analysis -> Copy Phrase to ensure that typing still worked.