### PR TITLE
Experiment Protocol Gui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Experiment Action
-
+# Experiment Refactor
 - Refactors the Experiment Field Collection GUI to be an action
+- Allows task protocol to be defined in the orchestrator
 
 # Orchestrator Parameters
 Adds parsing functions for action sequences required for the Session Orchestrator

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -6,6 +6,7 @@ from bcipy.gui.main import BCIGui, app, AlertMessageType, AlertMessageResponse, 
 from bcipy.config import BCIPY_ROOT, DEFAULT_EXPERIMENT_PATH, EXPERIMENT_FILENAME
 from bcipy.helpers.load import load_experiments, load_fields
 from bcipy.helpers.save import save_experiment_data
+from bcipy.task.task_registry import TaskRegistry
 
 
 class ExperimentRegistry(BCIGui):
@@ -32,11 +33,13 @@ class ExperimentRegistry(BCIGui):
         self.name_input = None
         self.summary_input = None
         self.field_input = None
+        self.protocol_input = None
         self.panel = None
         self.line_items = None
 
         # fields is for display of registered fields
         self.fields = []
+        self.tasks = TaskRegistry().list()
         self.registered_fields = load_fields()
         self.name = None
         self.summary = None
@@ -214,6 +217,14 @@ class ExperimentRegistry(BCIGui):
             font_size=font_size)
         text_y += self.padding
         self.add_static_textbox(
+            text='Protocol',
+            position=[text_x, text_y],
+            size=[300, 50],
+            background_color='black',
+            text_color='white',
+            font_size=font_size)
+        text_y += self.padding
+        self.add_static_textbox(
             text='Fields',
             position=[text_x, text_y],
             size=[300, 50],
@@ -254,6 +265,15 @@ class ExperimentRegistry(BCIGui):
             background_color='white',
             text_color='black')
 
+        input_y += self.padding
+        self.protocol_input = self.add_combobox(
+            position=[input_x, input_y],
+            size=input_size,
+            editable=True,
+            items=self.tasks,
+            background_color='white',
+            text_color='black')
+        
         input_y += self.padding
         self.field_input = self.add_combobox(
             position=[input_x, input_y],

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -352,14 +352,7 @@ class ExperimentRegistry(BCIGui):
             text_color='white',
             font_size=font_size)
         text_y += self.padding + 45
-        # self.add_static_textbox(
-        #     text='Registered fields *click to toggle required field*',
-        #     position=[text_x, text_y],
-        #     size=[300, 50],
-        #     background_color='black',
-        #     text_color='white',
-        #     font_size=14)
-
+        
     def build_inputs(self) -> None:
         """Build Inputs.
 
@@ -410,7 +403,6 @@ class ExperimentRegistry(BCIGui):
         """
         btn_create_x = self.width - self.padding - 10
         btn_create_y = self.height - self.padding - 500
-        # btn_create_y = self.height - self.padding - 100
         size = 150
 
         btn_field_x = (self.width / 2) + 150

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -352,7 +352,7 @@ class ExperimentRegistry(BCIGui):
             text_color='white',
             font_size=font_size)
         text_y += self.padding + 45
-        
+
     def build_inputs(self) -> None:
         """Build Inputs.
 

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -80,7 +80,7 @@ class ExperimentRegistry(BCIGui):
 
         Reconstruct the line items from the registered fields and refresh the scrollable panel of registered fields.
         """
-        self.build_protocol_line_items_from_fields()
+        self.build_protocol_line_items()
         self.protocol_panel.refresh(self.protocol_line_items)
 
     def toggle_required_field(self) -> None:
@@ -130,6 +130,34 @@ class ExperimentRegistry(BCIGui):
         task_name = self.window.sender().get_id()
         self.protocol_tasks.remove(task_name)
         self.refresh_protocol_panel()
+
+    def move_task_up(self) -> None:
+        """Move Task Up.
+
+        *Button Action*
+
+        Using the field_name retrieved from the button (get_id), find the field in self.experiment_fields and remove it
+            from the list.
+        """
+        task_name = self.window.sender().get_id()
+        index = self.protocol_tasks.index(task_name)
+        if index > 0:
+            self.protocol_tasks[index], self.protocol_tasks[index - 1] = self.protocol_tasks[index - 1], self.protocol_tasks[index]
+            self.refresh_protocol_panel()
+
+    def move_task_down(self) -> None:
+        """Move Task Down.
+
+        *Button Action*
+
+        Using the field_name retrieved from the button (get_id), find the field in self.experiment_fields and remove it
+            from the list.
+        """
+        task_name = self.window.sender().get_id()
+        index = self.protocol_tasks.index(task_name)
+        if index < len(self.protocol_tasks) - 1:
+            self.protocol_tasks[index], self.protocol_tasks[index + 1] = self.protocol_tasks[index + 1], self.protocol_tasks[index]
+            self.refresh_protocol_panel()
 
     def remove_field(self) -> None:
         """Remove Field.
@@ -211,7 +239,7 @@ class ExperimentRegistry(BCIGui):
         # finally, set the new line items for rendering
         self.field_line_items = LineItems(items, self.width)
 
-    def build_protocol_line_items_from_fields(self) -> None:
+    def build_protocol_line_items(self) -> None:
         """Build Line Items From Fields.
 
         Loop over the registered experiment fields and create LineItems, which can by used to toggle the required
@@ -224,6 +252,18 @@ class ExperimentRegistry(BCIGui):
                     'Remove': {
                         'action': self.remove_task,
                         'color': 'red',
+                        'textColor': 'white',
+                        'id': task
+                    },
+                    '▲': {
+                        'action': self.move_task_up,
+                        'color': 'grey',
+                        'textColor': 'white',
+                        'id': task
+                    },
+                    '▼': {
+                        'action': self.move_task_down,
+                        'color': 'grey',
                         'textColor': 'white',
                         'id': task
                     }
@@ -484,7 +524,6 @@ class ExperimentRegistry(BCIGui):
 
     def add_task(self) -> None:
         task = self.protocol_input.currentText()
-        print(task)
         self.protocol_tasks.append(task)
         self.refresh_protocol_panel()
 

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -1,7 +1,8 @@
 import sys
 import subprocess
 
-from bcipy.gui.main import BCIGui, app, AlertMessageType, AlertMessageResponse, ScrollableFrame, LineItems
+from PyQt6.QtWidgets import QHBoxLayout
+from bcipy.gui.main import BCIGui, app, AlertMessageType, AlertMessageResponse, ScrollableFrame, LineItems, PushButton
 from bcipy.config import BCIPY_ROOT, DEFAULT_EXPERIMENT_PATH, EXPERIMENT_FILENAME
 from bcipy.helpers.load import load_experiments, load_fields
 from bcipy.helpers.save import save_experiment_data
@@ -49,9 +50,26 @@ class ExperimentRegistry(BCIGui):
 
         # for registered fields
         self.build_scroll_area()
+        self.build_create_experiment_button()
 
         self.show_gui()
         self.update_field_list()
+
+    def build_create_experiment_button(self) -> None:
+        """Build Create Experiment Button.
+        
+        Create a button to create the experiment. This is it's own function to allow it to be inserted
+        below the scroll areas.
+        """
+        create_experiment_layout = QHBoxLayout()
+        create_experiment_layout.addStretch(1)
+        create_experiment = PushButton('Create Experiment', self.window)
+        create_experiment.clicked.connect(self.create_experiment)
+        create_experiment.setStyleSheet(
+            'background-color: green; color: white; padding: 10px;')
+        create_experiment_layout.addWidget(create_experiment)
+        create_experiment_layout.addStretch(1)
+        self.vbox.addLayout(create_experiment_layout)
 
     def build_scroll_area(self) -> None:
         """Build Scroll Area.
@@ -61,9 +79,9 @@ class ExperimentRegistry(BCIGui):
         
         protocol_line_widget = LineItems([], self.width)
         line_widget = LineItems([], self.width)
-        self.protocol_panel = ScrollableFrame(200, self.width, background_color='white', widget=protocol_line_widget, title='Task Protocol')
+        self.protocol_panel = ScrollableFrame(150, self.width, background_color='white', widget=protocol_line_widget, title='Task Protocol')
         self.add_widget(self.protocol_panel)
-        self.field_panel = ScrollableFrame(200, self.width, background_color='white', widget=line_widget, title='Registered fields *click to toggle required field*')
+        self.field_panel = ScrollableFrame(150, self.width, background_color='white', widget=line_widget, title='Registered fields *click to toggle required field*')
         self.add_widget(self.field_panel)
 
     def refresh_field_panel(self) -> None:
@@ -382,12 +400,6 @@ class ExperimentRegistry(BCIGui):
         btn_create_y = self.height - self.padding - 500
         # btn_create_y = self.height - self.padding - 100
         size = 150
-        self.add_button(
-            message='Create Experiment', position=[btn_create_x - (size / 2), btn_create_y],
-            size=[size, self.btn_height],
-            background_color='green',
-            action=self.create_experiment,
-            text_color='white')
 
         btn_field_x = (self.width / 2) + 150
         # btn_field_y = 310
@@ -587,7 +599,7 @@ def start_app() -> None:
     bcipy_gui = app(sys.argv)
     ex = ExperimentRegistry(
         title='Experiment Registry',
-        height=950,
+        height=880,
         width=700,
         background_color='black')
 

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -57,7 +57,7 @@ class ExperimentRegistry(BCIGui):
 
     def build_create_experiment_button(self) -> None:
         """Build Create Experiment Button.
-        
+
         Create a button to create the experiment. This is it's own function to allow it to be inserted
         below the scroll areas.
         """
@@ -76,12 +76,22 @@ class ExperimentRegistry(BCIGui):
 
         Appends a scrollable area at the bottom of the UI for management of registered fields via LineItems.
         """
-        
+
         protocol_line_widget = LineItems([], self.width)
         line_widget = LineItems([], self.width)
-        self.protocol_panel = ScrollableFrame(150, self.width, background_color='white', widget=protocol_line_widget, title='Task Protocol')
+        self.protocol_panel = ScrollableFrame(
+            150,
+            self.width,
+            background_color='white',
+            widget=protocol_line_widget,
+            title='Task Protocol')
         self.add_widget(self.protocol_panel)
-        self.field_panel = ScrollableFrame(150, self.width, background_color='white', widget=line_widget, title='Registered fields *click to toggle required field*')
+        self.field_panel = ScrollableFrame(
+            150,
+            self.width,
+            background_color='white',
+            widget=line_widget,
+            title='Registered fields *click to toggle required field*')
         self.add_widget(self.field_panel)
 
     def refresh_field_panel(self) -> None:
@@ -159,7 +169,8 @@ class ExperimentRegistry(BCIGui):
         task_name = self.window.sender().get_id()
         index = self.protocol_tasks.index(task_name)
         if index > 0:
-            self.protocol_tasks[index], self.protocol_tasks[index - 1] = self.protocol_tasks[index - 1], self.protocol_tasks[index]
+            self.protocol_tasks[index], self.protocol_tasks[index - 1] = \
+                self.protocol_tasks[index - 1], self.protocol_tasks[index]
             self.refresh_protocol_panel()
 
     def move_task_down(self) -> None:
@@ -173,7 +184,8 @@ class ExperimentRegistry(BCIGui):
         task_name = self.window.sender().get_id()
         index = self.protocol_tasks.index(task_name)
         if index < len(self.protocol_tasks) - 1:
-            self.protocol_tasks[index], self.protocol_tasks[index + 1] = self.protocol_tasks[index + 1], self.protocol_tasks[index]
+            self.protocol_tasks[index], self.protocol_tasks[index + 1] = \
+                self.protocol_tasks[index + 1], self.protocol_tasks[index]
             self.refresh_protocol_panel()
 
     def remove_field(self) -> None:
@@ -381,7 +393,7 @@ class ExperimentRegistry(BCIGui):
             items=self.task_registry.list(),
             background_color='white',
             text_color='black')
-        
+
         input_y += self.padding
         self.field_input = self.add_combobox(
             position=[input_x, input_y],

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -7,6 +7,7 @@ from bcipy.config import BCIPY_ROOT, DEFAULT_EXPERIMENT_PATH, EXPERIMENT_FILENAM
 from bcipy.helpers.load import load_experiments, load_fields
 from bcipy.helpers.save import save_experiment_data
 from bcipy.task.task_registry import TaskRegistry
+from bcipy.orchestrator.config import serialize_protocol
 
 
 class ExperimentRegistry(BCIGui):
@@ -41,7 +42,7 @@ class ExperimentRegistry(BCIGui):
 
         # fields is for display of registered fields
         self.fields = []
-        self.available_tasks = TaskRegistry().list()
+        self.task_registry = TaskRegistry()
         self.protocol_tasks = []
         self.registered_fields = load_fields()
         self.name = None
@@ -320,7 +321,7 @@ class ExperimentRegistry(BCIGui):
             position=[input_x, input_y],
             size=input_size,
             editable=False,
-            items=self.available_tasks,
+            items=self.task_registry.list(),
             background_color='white',
             text_color='black')
         
@@ -339,8 +340,8 @@ class ExperimentRegistry(BCIGui):
         Build all buttons necessary for the UI. Define their action on click using the named argument action.
         """
         btn_create_x = self.width - self.padding - 10
-        # btn_create_y = self.height - self.padding - 200
-        btn_create_y = self.height - self.padding - 100
+        btn_create_y = self.height - self.padding - 500
+        # btn_create_y = self.height - self.padding - 100
         size = 150
         self.add_button(
             message='Create Experiment', position=[btn_create_x - (size / 2), btn_create_y],
@@ -414,9 +415,11 @@ class ExperimentRegistry(BCIGui):
         Add a new experiment to the dict of experiments. It follows the format:
              { name: { fields : {name: '', required: bool, anonymize: bool}, summary: '' } }
         """
+        task_objects = [self.task_registry.get(task_name) for task_name in self.protocol_tasks]
         self.experiments[self.name] = {
             'fields': self.experiment_fields,
-            'summary': self.summary
+            'summary': self.summary,
+            'protocol': serialize_protocol(task_objects)
         }
 
     def save_experiments(self) -> None:

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -2,7 +2,6 @@ import sys
 import subprocess
 
 from bcipy.gui.main import BCIGui, app, AlertMessageType, AlertMessageResponse, ScrollableFrame, LineItems
-
 from bcipy.config import BCIPY_ROOT, DEFAULT_EXPERIMENT_PATH, EXPERIMENT_FILENAME
 from bcipy.helpers.load import load_experiments, load_fields
 from bcipy.helpers.save import save_experiment_data
@@ -62,9 +61,9 @@ class ExperimentRegistry(BCIGui):
         
         protocol_line_widget = LineItems([], self.width)
         line_widget = LineItems([], self.width)
-        self.protocol_panel = ScrollableFrame(100, self.width, background_color='white', widget=protocol_line_widget)
+        self.protocol_panel = ScrollableFrame(200, self.width, background_color='white', widget=protocol_line_widget, title='Task Protocol')
         self.add_widget(self.protocol_panel)
-        self.field_panel = ScrollableFrame(100, self.width, background_color='white', widget=line_widget)
+        self.field_panel = ScrollableFrame(200, self.width, background_color='white', widget=line_widget, title='Registered fields *click to toggle required field*')
         self.add_widget(self.field_panel)
 
     def refresh_field_panel(self) -> None:
@@ -323,13 +322,13 @@ class ExperimentRegistry(BCIGui):
             text_color='white',
             font_size=font_size)
         text_y += self.padding + 45
-        self.add_static_textbox(
-            text='Registered fields *click to toggle required field*',
-            position=[text_x, text_y],
-            size=[300, 50],
-            background_color='black',
-            text_color='white',
-            font_size=14)
+        # self.add_static_textbox(
+        #     text='Registered fields *click to toggle required field*',
+        #     position=[text_x, text_y],
+        #     size=[300, 50],
+        #     background_color='black',
+        #     text_color='white',
+        #     font_size=14)
 
     def build_inputs(self) -> None:
         """Build Inputs.
@@ -588,8 +587,8 @@ def start_app() -> None:
     bcipy_gui = app(sys.argv)
     ex = ExperimentRegistry(
         title='Experiment Registry',
-        height=700,
-        width=600,
+        height=950,
+        width=700,
         background_color='black')
 
     sys.exit(bcipy_gui.exec())

--- a/bcipy/gui/main.py
+++ b/bcipy/gui/main.py
@@ -971,7 +971,8 @@ class ScrollableFrame(QWidget):
                  height: int,
                  width: int,
                  background_color: str = 'black',
-                 widget: Optional[QWidget] = None):
+                 widget: Optional[QWidget] = None,
+                 title: Optional[str] = None):
         super().__init__()
 
         self.height = height
@@ -994,6 +995,15 @@ class ScrollableFrame(QWidget):
         if widget:
             self.widget = widget
             self.frame.setWidget(widget)
+
+        # If there is a title, add it to the top of the frame
+        if title:
+            title_label = QLabel(title)
+            title_label.setStyleSheet(
+                f'background-color: black; color: white;')
+            title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            title_label.setFont(font(16))
+            self.vbox.addWidget(title_label)
 
         # add the frame and set the layout
         self.vbox.addWidget(self.frame)

--- a/bcipy/gui/main.py
+++ b/bcipy/gui/main.py
@@ -1000,7 +1000,7 @@ class ScrollableFrame(QWidget):
         if title:
             title_label = QLabel(title)
             title_label.setStyleSheet(
-                f'background-color: black; color: white;')
+                'background-color: black; color: white;')
             title_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
             title_label.setFont(font(16))
             self.vbox.addWidget(title_label)

--- a/bcipy/orchestrator/config.py
+++ b/bcipy/orchestrator/config.py
@@ -7,7 +7,7 @@ from bcipy.config import TASK_SEPERATOR
 from bcipy.task.task_registry import TaskRegistry
 
 
-def parse_sequence(sequence: str) -> List[Type[Task]]:
+def parse_protocol(protocol: str) -> List[Type[Task]]:
     """
     Parses a string of actions into a list of TaskType objects.
 
@@ -15,7 +15,7 @@ def parse_sequence(sequence: str) -> List[Type[Task]]:
     to be in the format of 'Action1 -> Action2 -> ... -> ActionN'.
     Parameters
     ----------
-        action_sequence : str
+        protocol : str
             A string of actions in the format of 'Action1 -> Action2 -> ... -> ActionN'.
 
     Returns
@@ -24,10 +24,10 @@ def parse_sequence(sequence: str) -> List[Type[Task]]:
             A list of TaskType objects that represent the actions in the input string.
     """
     task_registry = TaskRegistry()
-    return [task_registry.get(item.strip()) for item in sequence.split(TASK_SEPERATOR)]
+    return [task_registry.get(item.strip()) for item in protocol.split(TASK_SEPERATOR)]
 
 
-def validate_sequence_string(action_sequence: str) -> None:
+def validate_protocol_string(protocol: str) -> None:
     """
     Validates a string of actions.
 
@@ -35,7 +35,7 @@ def validate_sequence_string(action_sequence: str) -> None:
 
     Parameters
     ----------
-        action_sequence : str
+        protocol : str
             A string of actions in the format of 'Action1 -> Action2 -> ... -> ActionN'.
 
     Raises
@@ -43,12 +43,12 @@ def validate_sequence_string(action_sequence: str) -> None:
         ValueError
             If the string of actions is invalid.
     """
-    for sequence_item in action_sequence.split(TASK_SEPERATOR):
-        if sequence_item.strip() not in TaskRegistry().list():
-            raise ValueError(f"Invalid task '{sequence_item}' name in action sequence")
+    for protocol_item in protocol.split(TASK_SEPERATOR):
+        if protocol_item.strip() not in TaskRegistry().list():
+            raise ValueError(f"Invalid task '{protocol_item}' name in protocol string.")
 
 
-def serialize_sequence(sequence: List[Type[Task]]) -> str:
+def serialize_protocol(protocol: List[Type[Task]]) -> str:
     """
     Converts a list of TaskType objects into a string of actions.
 
@@ -57,7 +57,7 @@ def serialize_sequence(sequence: List[Type[Task]]) -> str:
 
     Parameters
     ----------
-        action_sequence : str
+        protocol : str
             A string of actions in the format of 'Action1 -> Action2 -> ... -> ActionN'.
 
     Returns
@@ -66,11 +66,11 @@ def serialize_sequence(sequence: List[Type[Task]]) -> str:
             A list of TaskType objects that represent the actions in the input string.
     """
 
-    return f" {TASK_SEPERATOR} ".join([item.name for item in sequence])
+    return f" {TASK_SEPERATOR} ".join([item.name for item in protocol])
 
 
 if __name__ == '__main__':
-    actions = parse_sequence("Matrix Calibration -> Matrix Copy Phrase")
-    string = serialize_sequence(actions)
+    actions = parse_protocol("Matrix Calibration -> Matrix Copy Phrase")
+    string = serialize_protocol(actions)
     print(actions)
     print(string)

--- a/bcipy/orchestrator/tests/test_config.py
+++ b/bcipy/orchestrator/tests/test_config.py
@@ -1,5 +1,5 @@
 import unittest
-from bcipy.orchestrator.config import parse_sequence, serialize_sequence, validate_sequence_string
+from bcipy.orchestrator.config import parse_protocol, serialize_protocol, validate_protocol_string
 from bcipy.task.actions import OfflineAnalysisAction
 from bcipy.task.paradigm.rsvp.calibration.calibration import RSVPCalibrationTask
 from bcipy.task.paradigm.rsvp.copy_phrase import RSVPCopyPhraseTask
@@ -9,26 +9,26 @@ class TestTaskProtocolProcessing(unittest.TestCase):
 
     def test_parses_one_task(self) -> None:
         sequence = 'RSVP Calibration'
-        parsed = parse_sequence(sequence)
+        parsed = parse_protocol(sequence)
         assert len(parsed) == 1
         assert parsed[0] is RSVPCalibrationTask
 
     def test_parses_with_task_name(self) -> None:
         actions = OfflineAnalysisAction.name
-        parsed = parse_sequence(actions)
+        parsed = parse_protocol(actions)
         assert len(parsed) == 1
         assert parsed[0] is OfflineAnalysisAction
 
     def test_parses_multiple_tasks(self) -> None:
         actions = 'RSVP Calibration -> RSVP Copy Phrase'
-        parsed = parse_sequence(actions)
+        parsed = parse_protocol(actions)
         assert len(parsed) == 2
         assert parsed[0] is RSVPCalibrationTask
         assert parsed[1] is RSVPCopyPhraseTask
 
     def test_parses_actions_and_tasks(self) -> None:
         sequence = 'RSVP Calibration -> Offline Analysis Action -> RSVP Copy Phrase'
-        parsed = parse_sequence(sequence)
+        parsed = parse_protocol(sequence)
         assert len(parsed) == 3
         assert parsed[0] is RSVPCalibrationTask
         assert parsed[1] is OfflineAnalysisAction
@@ -36,7 +36,7 @@ class TestTaskProtocolProcessing(unittest.TestCase):
 
     def test_parses_sequence_with_extra_spaces(self) -> None:
         actions = ' RSVP Calibration ->  Offline Analysis Action    -> RSVP Copy Phrase  '
-        parsed = parse_sequence(actions)
+        parsed = parse_protocol(actions)
         assert len(parsed) == 3
         assert parsed[0] is RSVPCalibrationTask
         assert parsed[1] is OfflineAnalysisAction
@@ -45,28 +45,28 @@ class TestTaskProtocolProcessing(unittest.TestCase):
     def test_throws_exception_on_invalid_task(self) -> None:
         actions = 'RSVP Calibration -> does not exist'
         with self.assertRaises(ValueError):
-            parse_sequence(actions)
+            parse_protocol(actions)
 
     def test_throws_exception_on_invalid_string(self) -> None:
         actions = 'thisstringisbad'
         with self.assertRaises(ValueError):
-            parse_sequence(actions)
+            parse_protocol(actions)
 
     def test_validates_valid_action_string(self) -> None:
         actions = 'RSVP Calibration -> RSVP Copy Phrase'
-        validate_sequence_string(actions)
+        validate_protocol_string(actions)
 
     def test_throws_exception_on_invalid_action_string(self) -> None:
         actions = 'RSVP Calibration -> RSVP Copy Phrase -> does not exist'
         with self.assertRaises(ValueError):
-            validate_sequence_string(actions)
+            validate_protocol_string(actions)
 
     def test_serializes_one_task(self) -> None:
         actions = [RSVPCalibrationTask]
-        serialized = serialize_sequence(actions)
+        serialized = serialize_protocol(actions)
         assert serialized == RSVPCalibrationTask.name
 
     def test_serializes_multiple_tasks(self) -> None:
         sequence = [RSVPCalibrationTask, OfflineAnalysisAction, RSVPCopyPhraseTask]
-        serialized = serialize_sequence(sequence)
+        serialized = serialize_protocol(sequence)
         assert serialized == 'RSVP Calibration -> Offline Analysis Action -> RSVP Copy Phrase'


### PR DESCRIPTION
# Overview

Add ability to define task protocols in the experiment gui

## Ticket

[Pivotal Ticket](https://www.pivotaltracker.com/story/show/187701295)

## Contributions

- Add additional dropdown that displays all available tasks
- Add UI elements for reordering and removing tasks
- Add protocol saving to `experiment.json`
- Refactor formatting for create experiment button

## Test

- No testing for GUI besides manually inspecting app.

## Documentation

- Buttons in the new interface are clearly labeled and code is commented.

## Changelog

- Changelog updated
