### PR TITLE
Task return object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Task Return Object
+- Create `TaskData` dataclass to be returned from tasks
+- updates task `execute` methods to return an instance of `TaskData`
+- Allows for optional storage of a save path and task dictionary in `TaskData`
+
 # Experiment Refactor
 - Refactors the Experiment Field Collection GUI to be an action
 - Allows task protocol to be defined in the orchestrator

--- a/bcipy/task/__init__.py
+++ b/bcipy/task/__init__.py
@@ -1,12 +1,13 @@
 """
 This import statement allows users to import submodules from Task
 """
-from .main import Task
+from .main import Task, TaskData
 
 # Makes the following classes available to the task registry
 from .task_registry import TaskRegistry
 
 __all__ = [
     'Task',
-    'TaskRegistry'
+    'TaskRegistry',
+    'TaskData'
 ]

--- a/bcipy/task/actions.py
+++ b/bcipy/task/actions.py
@@ -64,13 +64,14 @@ class OfflineAnalysisAction(Task):
         subprocess.Popen(cmd, shell=True)
         return TaskData(task_save=self.data_directory)
 
-    def construct_command(self):
+    def construct_command(self) -> str:
         command = 'python -m bcipy.signal.model.offline_analysis'
         command += ' --data_folder ' + self.data_directory
         if self.parameters_path:
             command += ' --parameters_file ' + self.parameters_path
         if self.alert:
             command += ' --alert'
+        return command
 
 
 class ExperimentFieldCollectionAction(Task):

--- a/bcipy/task/actions.py
+++ b/bcipy/task/actions.py
@@ -1,8 +1,7 @@
 import subprocess
 from typing import Callable, Optional
 
-from bcipy.gui.experiments.ExperimentField import \
-    start_experiment_field_collection_gui
+from bcipy.gui.experiments.ExperimentField import start_experiment_field_collection_gui
 from bcipy.task import Task
 from bcipy.task.main import TaskData
 
@@ -11,7 +10,8 @@ class CallbackAction(Task):
     """
     Action for running a callback.
     """
-    name = 'Callback Action'
+
+    name = "Callback Action"
 
     def __init__(self, callback: Callable, *args, **kwargs) -> None:
         super().__init__()
@@ -20,9 +20,11 @@ class CallbackAction(Task):
         self.kwargs = kwargs
 
     def execute(self) -> TaskData:
-        self.logger.info(f'Executing callback action {self.callback} with args {self.args} and kwargs {self.kwargs}')
+        self.logger.info(
+            f"Executing callback action {self.callback} with args {self.args} and kwargs {self.kwargs}"
+        )
         self.callback(*self.args, **self.kwargs)
-        self.logger.info(f'Callback action {self.callback} executed')
+        self.logger.info(f"Callback action {self.callback} executed")
         return TaskData()
 
 
@@ -30,7 +32,8 @@ class CodeHookAction(Task):
     """
     Action for running generic code hooks.
     """
-    name = 'Code Hook Action'
+
+    name = "Code Hook Action"
 
     def __init__(self, code_hook: str, subprocess=True) -> None:
         super().__init__()
@@ -50,9 +53,12 @@ class OfflineAnalysisAction(Task):
     """
     Action for running offline analysis.
     """
-    name = 'Offline Analysis Action'
 
-    def __init__(self, data_directory: str, parameters_path: Optional[str] = None, alert=True) -> None:
+    name = "Offline Analysis Action"
+
+    def __init__(
+        self, data_directory: str, parameters_path: Optional[str] = None, alert=True
+    ) -> None:
         super().__init__()
         self.parameters_path = parameters_path
         self.alert = alert
@@ -62,15 +68,18 @@ class OfflineAnalysisAction(Task):
     def execute(self) -> TaskData:
         cmd = self.construct_command()
         subprocess.Popen(cmd, shell=True)
-        return TaskData(task_save=self.data_directory)
+        return TaskData(
+            save_path=self.data_directory,
+            task_dict={"data_directory": self.data_directory, "command": cmd},
+        )
 
     def construct_command(self) -> str:
-        command = 'python -m bcipy.signal.model.offline_analysis'
-        command += ' --data_folder ' + self.data_directory
+        command = "python -m bcipy.signal.model.offline_analysis"
+        command += " --data_folder " + self.data_directory
         if self.parameters_path:
-            command += ' --parameters_file ' + self.parameters_path
+            command += " --parameters_file " + self.parameters_path
         if self.alert:
-            command += ' --alert'
+            command += " --alert"
         return command
 
 
@@ -79,7 +88,7 @@ class ExperimentFieldCollectionAction(Task):
     Action for collecting experiment field data.
     """
 
-    name = 'Experiment Field Collection Action'
+    name = "Experiment Field Collection Action"
 
     def __init__(self, experiment_id: str, save_path: str) -> None:
         super().__init__()
@@ -88,8 +97,12 @@ class ExperimentFieldCollectionAction(Task):
 
     def execute(self) -> TaskData:
         self.logger.info(
-            f'Collecting experiment field data for experiment {self.experiment_id} in save folder {self.save_folder}'
+            f"Collecting experiment field data for experiment {self.experiment_id} in save folder {self.save_folder}"
         )
-        start_experiment_field_collection_gui(self.experiment_id,
-                                              self.save_folder)
-        return TaskData(task_save=self.save_folder)
+        start_experiment_field_collection_gui(self.experiment_id, self.save_folder)
+        return TaskData(
+            save_path=self.save_folder,
+            task_dict={
+                "experiment_id": self.experiment_id,
+            },
+        )

--- a/bcipy/task/base_calibration.py
+++ b/bcipy/task/base_calibration.py
@@ -239,7 +239,7 @@ class BaseCalibrationTask(Task):
         self.write_offset_trigger()
         self.cleanup()
 
-        return TaskData(task_save=self.file_save)
+        return TaskData(save_path=self.file_save, task_dict=self.session.as_dict())
 
     def exit_display(self) -> None:
         """Close the UI and cleanup."""

--- a/bcipy/task/base_calibration.py
+++ b/bcipy/task/base_calibration.py
@@ -22,7 +22,7 @@ from bcipy.helpers.task import (get_user_input, pause_calibration,
 from bcipy.helpers.triggers import (FlushFrequency, Trigger, TriggerHandler,
                                     TriggerType, convert_timing_triggers,
                                     offset_label)
-from bcipy.task import Task
+from bcipy.task import Task, TaskData
 
 
 class Inquiry(NamedTuple):
@@ -209,7 +209,7 @@ class BaseCalibrationTask(Task):
             self.logger.info('User wants to exit.')
         return should_continue
 
-    def execute(self) -> str:
+    def execute(self) -> TaskData:
         """Task run loop."""
         self.logger.info(f'Starting {self.name}!')
         self.wait()
@@ -239,7 +239,7 @@ class BaseCalibrationTask(Task):
         self.write_offset_trigger()
         self.cleanup()
 
-        return self.file_save
+        return TaskData(task_save=self.file_save)
 
     def exit_display(self) -> None:
         """Close the UI and cleanup."""

--- a/bcipy/task/main.py
+++ b/bcipy/task/main.py
@@ -11,7 +11,8 @@ class TaskData():
 
     Data structure for storing task return data.
     """
-    task_save: Optional[str] = None
+    save_path: Optional[str] = None
+    task_dict: Optional[dict] = None
 
 
 class Task(ABC):

--- a/bcipy/task/main.py
+++ b/bcipy/task/main.py
@@ -1,6 +1,17 @@
 import logging
+from dataclasses import dataclass
+from typing import Optional
 from bcipy.helpers.parameters import Parameters
 from abc import ABC, abstractmethod
+
+
+@dataclass
+class TaskData():
+    """TaskData.
+
+    Data structure for storing task return data.
+    """
+    task_save: Optional[str] = None
 
 
 class Task(ABC):
@@ -18,7 +29,7 @@ class Task(ABC):
         self.logger = logging.getLogger(__name__)
 
     @abstractmethod
-    def execute(self) -> str:
+    def execute(self) -> TaskData:
         ...
 
     def setup(self, parameters, data_save_location):

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -32,7 +32,7 @@ from bcipy.helpers.triggers import (FlushFrequency, Trigger, TriggerHandler,
 from bcipy.language.main import LanguageModel
 from bcipy.signal.model import SignalModel
 from bcipy.signal.model.inquiry_preview import compute_probs_after_preview
-from bcipy.task import Task
+from bcipy.task import Task, TaskData
 from bcipy.task.control.evidence import (EvidenceEvaluator,
                                          init_evidence_evaluator)
 from bcipy.task.data import EvidenceType, Inquiry, Session
@@ -410,7 +410,7 @@ class RSVPCopyPhraseTask(Task):
             return self.copy_phrase[len(self.spelled_text)]
         return BACKSPACE_CHAR
 
-    def execute(self) -> str:
+    def execute(self) -> TaskData:
         """Executes the task.
 
         Returns
@@ -470,7 +470,7 @@ class RSVPCopyPhraseTask(Task):
         # Wait some time before exiting so there is trailing eeg data saved
         self.wait()
 
-        return self.file_save
+        return TaskData(task_save=self.file_save)
 
     def evaluate_evidence(self) -> Decision:
         """Uses the `copy_phrase_task` parameter to evaluate the provided

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -5,11 +5,18 @@ from typing import List, NamedTuple, Optional, Tuple
 from psychopy import core, visual
 
 from bcipy.acquisition import ClientManager
-from bcipy.config import (DEFAULT_EVIDENCE_PRECISION, SESSION_DATA_FILENAME,
-                          SESSION_SUMMARY_FILENAME, TRIGGER_FILENAME,
-                          WAIT_SCREEN_MESSAGE)
-from bcipy.display import (InformationProperties, PreviewInquiryProperties,
-                           StimuliProperties)
+from bcipy.config import (
+    DEFAULT_EVIDENCE_PRECISION,
+    SESSION_DATA_FILENAME,
+    SESSION_SUMMARY_FILENAME,
+    TRIGGER_FILENAME,
+    WAIT_SCREEN_MESSAGE,
+)
+from bcipy.display import (
+    InformationProperties,
+    PreviewInquiryProperties,
+    StimuliProperties,
+)
 from bcipy.display.components.task_bar import CopyPhraseTaskBar
 from bcipy.display.paradigm.rsvp.mode.copy_phrase import CopyPhraseDisplay
 from bcipy.feedback.visual.visual_feedback import VisualFeedback
@@ -22,19 +29,28 @@ from bcipy.helpers.save import _save_session_related_data
 from bcipy.helpers.session import session_excel
 from bcipy.helpers.stimuli import InquirySchedule, StimuliOrder
 from bcipy.helpers.symbols import BACKSPACE_CHAR, alphabet
-from bcipy.helpers.task import (construct_triggers, fake_copy_phrase_decision,
-                                get_device_data_for_decision, get_user_input,
-                                relative_triggers, target_info,
-                                trial_complete_message)
-from bcipy.helpers.triggers import (FlushFrequency, Trigger, TriggerHandler,
-                                    TriggerType, convert_timing_triggers,
-                                    offset_label)
+from bcipy.helpers.task import (
+    construct_triggers,
+    fake_copy_phrase_decision,
+    get_device_data_for_decision,
+    get_user_input,
+    relative_triggers,
+    target_info,
+    trial_complete_message,
+)
+from bcipy.helpers.triggers import (
+    FlushFrequency,
+    Trigger,
+    TriggerHandler,
+    TriggerType,
+    convert_timing_triggers,
+    offset_label,
+)
 from bcipy.language.main import LanguageModel
 from bcipy.signal.model import SignalModel
 from bcipy.signal.model.inquiry_preview import compute_probs_after_preview
 from bcipy.task import Task, TaskData
-from bcipy.task.control.evidence import (EvidenceEvaluator,
-                                         init_evidence_evaluator)
+from bcipy.task.control.evidence import EvidenceEvaluator, init_evidence_evaluator
 from bcipy.task.data import EvidenceType, Inquiry, Session
 from bcipy.task.exceptions import DuplicateModelEvidence
 
@@ -51,6 +67,7 @@ class Decision(NamedTuple):
     - new_inq_schedule : the next inquiry to present if there was not a
     decision.
     """
+
     decision_made: bool
     selection: str
     spelled_text: str
@@ -86,34 +103,74 @@ class RSVPCopyPhraseTask(Task):
             path location of where to save data from the session
     """
 
-    name = 'RSVP Copy Phrase'
-    MODE = 'RSVP'
+    name = "RSVP Copy Phrase"
+    MODE = "RSVP"
 
     PARAMETERS_USED = [
-        'time_fixation', 'time_flash', 'time_prompt', 'trial_window',
-        'font', 'fixation_color', 'trigger_type',
-        'filter_high', 'filter_low', 'filter_order', 'notch_filter_frequency', 'down_sampling_rate', 'prestim_length',
-        'is_txt_stim', 'lm_backspace_prob', 'backspace_always_shown',
-        'decision_threshold', 'max_inq_len', 'max_inq_per_series', 'max_minutes', 'max_selections', 'min_inq_len',
-        'show_feedback', 'feedback_duration',
-        'show_preview_inquiry', 'preview_inquiry_isi',
-        'preview_inquiry_key_input', 'preview_inquiry_length', 'preview_inquiry_progress_method',
-        'spelled_letters_count',
-        'stim_color', 'stim_height', 'stim_jitter', 'stim_length', 'stim_number',
-        'stim_order', 'stim_pos_x', 'stim_pos_y', 'stim_space_char', 'target_color',
-        'task_buffer_length', 'task_color', 'task_height', 'task_text',
-        'info_pos_x', 'info_pos_y', 'info_color', 'info_height', 'info_text', 'info_color', 'info_height', 'info_text',
+        "time_fixation",
+        "time_flash",
+        "time_prompt",
+        "trial_window",
+        "font",
+        "fixation_color",
+        "trigger_type",
+        "filter_high",
+        "filter_low",
+        "filter_order",
+        "notch_filter_frequency",
+        "down_sampling_rate",
+        "prestim_length",
+        "is_txt_stim",
+        "lm_backspace_prob",
+        "backspace_always_shown",
+        "decision_threshold",
+        "max_inq_len",
+        "max_inq_per_series",
+        "max_minutes",
+        "max_selections",
+        "min_inq_len",
+        "show_feedback",
+        "feedback_duration",
+        "show_preview_inquiry",
+        "preview_inquiry_isi",
+        "preview_inquiry_key_input",
+        "preview_inquiry_length",
+        "preview_inquiry_progress_method",
+        "spelled_letters_count",
+        "stim_color",
+        "stim_height",
+        "stim_jitter",
+        "stim_length",
+        "stim_number",
+        "stim_order",
+        "stim_pos_x",
+        "stim_pos_y",
+        "stim_space_char",
+        "target_color",
+        "task_buffer_length",
+        "task_color",
+        "task_height",
+        "task_text",
+        "info_pos_x",
+        "info_pos_y",
+        "info_color",
+        "info_height",
+        "info_text",
+        "info_color",
+        "info_height",
+        "info_text",
     ]
 
     def __init__(
-            self,
-            win: visual.Window,
-            daq: ClientManager,
-            parameters: Parameters,
-            file_save: str,
-            signal_models: List[SignalModel],
-            language_model: LanguageModel,
-            fake: bool) -> None:
+        self,
+        win: visual.Window,
+        daq: ClientManager,
+        parameters: Parameters,
+        file_save: str,
+        signal_models: List[SignalModel],
+        language_model: LanguageModel,
+        fake: bool,
+    ) -> None:
         super(RSVPCopyPhraseTask, self).__init__()
         self.logger = logging.getLogger(__name__)
         self.window = win
@@ -122,8 +179,7 @@ class RSVPCopyPhraseTask(Task):
 
         self.validate_parameters()
 
-        self.static_clock = core.StaticPeriod(
-            screenHz=self.window.getActualFrameRate())
+        self.static_clock = core.StaticPeriod(screenHz=self.window.getActualFrameRate())
         self.experiment_clock = Clock()
         self.start_time = self.experiment_clock.getTime()
 
@@ -135,15 +191,18 @@ class RSVPCopyPhraseTask(Task):
 
         self.evidence_types = [EvidenceType.LM]
         self.evidence_types.extend(
-            [evaluator.produces for evaluator in self.evidence_evaluators])
-        if self.parameters['show_preview_inquiry']:
+            [evaluator.produces for evaluator in self.evidence_evaluators]
+        )
+        if self.parameters["show_preview_inquiry"]:
             self.evidence_types.append(EvidenceType.BTN)
 
         self.file_save = file_save
 
-        self.trigger_handler = TriggerHandler(self.file_save, TRIGGER_FILENAME, FlushFrequency.EVERY)
+        self.trigger_handler = TriggerHandler(
+            self.file_save, TRIGGER_FILENAME, FlushFrequency.EVERY
+        )
         self.session_save_location = f"{self.file_save}/{SESSION_DATA_FILENAME}"
-        self.copy_phrase = parameters['task_text']
+        self.copy_phrase = parameters["task_text"]
 
         self.fake = fake
         self.language_model = language_model
@@ -152,33 +211,41 @@ class RSVPCopyPhraseTask(Task):
 
         self.feedback = VisualFeedback(
             self.window,
-            {'feedback_font': self.parameters['font'],
-             'feedback_color': self.parameters['info_color'],
-             'feedback_pos_x': self.parameters['info_pos_x'],
-             'feedback_pos_y': self.parameters['info_pos_y'],
-             'feedback_stim_height': self.parameters['info_height'],
-             'feedback_duration': self.parameters['feedback_duration']},
-            self.experiment_clock)
+            {
+                "feedback_font": self.parameters["font"],
+                "feedback_color": self.parameters["info_color"],
+                "feedback_pos_x": self.parameters["info_pos_x"],
+                "feedback_pos_y": self.parameters["info_pos_y"],
+                "feedback_stim_height": self.parameters["info_height"],
+                "feedback_duration": self.parameters["feedback_duration"],
+            },
+            self.experiment_clock,
+        )
 
         self.setup_copyphrase()
 
         # set a preview_only parameter
         self.parameters.add_entry(
-            'preview_only',
+            "preview_only",
             {
-                'value': 'true' if self.parameters['preview_inquiry_progress_method'] == 0 else 'false',
-                'section': '',
-                'readableName': '',
-                'helpTip': '',
-                'recommended_values': '',
-                'type': 'bool'
-            }
+                "value": (
+                    "true"
+                    if self.parameters["preview_inquiry_progress_method"] == 0
+                    else "false"
+                ),
+                "section": "",
+                "readableName": "",
+                "helpTip": "",
+                "recommended_values": "",
+                "type": "bool",
+            },
         )
 
         self.rsvp = self.init_display()
 
-    def init_evidence_evaluators(self,
-                                 signal_models: List[SignalModel]) -> List[EvidenceEvaluator]:
+    def init_evidence_evaluators(
+        self, signal_models: List[SignalModel]
+    ) -> List[EvidenceEvaluator]:
         """Initializes the evidence evaluators from the provided signal models.
 
         Returns a list of evaluators for active devices. Raises an exception if
@@ -206,16 +273,16 @@ class RSVPCopyPhraseTask(Task):
     def setup_copyphrase(self) -> None:
         """Initialize/reset parameters used in the execute run loop."""
 
-        self.spelled_text = str(
-            self.copy_phrase[0:self.starting_spelled_letters()])
-        self.last_selection = ''
+        self.spelled_text = str(self.copy_phrase[0: self.starting_spelled_letters()])
+        self.last_selection = ""
         self.inq_counter = 0
         self.session = Session(
             save_location=self.file_save,
-            task='Copy Phrase',
+            task="Copy Phrase",
             mode=self.MODE,
             symbol_set=self.alp,
-            decision_threshold=self.parameters['decision_threshold'])
+            decision_threshold=self.parameters["decision_threshold"],
+        )
         self.write_session_data()
 
         self.init_copy_phrase_task()
@@ -223,10 +290,13 @@ class RSVPCopyPhraseTask(Task):
 
     def init_display(self) -> CopyPhraseDisplay:
         """Initialize the display"""
-        return _init_copy_phrase_display(self.parameters, self.window,
-                                         self.static_clock,
-                                         self.experiment_clock,
-                                         self.spelled_text)
+        return _init_copy_phrase_display(
+            self.parameters,
+            self.window,
+            self.static_clock,
+            self.experiment_clock,
+            self.spelled_text,
+        )
 
     def validate_parameters(self) -> None:
         """Validate.
@@ -240,22 +310,26 @@ class RSVPCopyPhraseTask(Task):
                 raise TaskConfigurationException(f"parameter '{param}' is required")
 
         # ensure data / query parameters are set correctly
-        buffer_len = self.parameters['task_buffer_length']
-        prestim = self.parameters['prestim_length']
-        poststim = self.parameters['trial_window'][1] - self.parameters['trial_window'][0]
+        buffer_len = self.parameters["task_buffer_length"]
+        prestim = self.parameters["prestim_length"]
+        poststim = (
+            self.parameters["trial_window"][1] - self.parameters["trial_window"][0]
+        )
         if buffer_len < prestim:
             raise TaskConfigurationException(
-                f'task_buffer_length=[{buffer_len}] must be greater than prestim_length=[{prestim}]')
+                f"task_buffer_length=[{buffer_len}] must be greater than prestim_length=[{prestim}]"
+            )
 
         if buffer_len < poststim:
             raise TaskConfigurationException(
-                f'task_buffer_length=[{buffer_len}] must be greater than trial_length=[{poststim}]')
+                f"task_buffer_length=[{buffer_len}] must be greater than trial_length=[{poststim}]"
+            )
 
     def starting_spelled_letters(self) -> int:
         """Number of letters already spelled at the start of the task."""
-        spelled_letters_count = self.parameters['spelled_letters_count']
+        spelled_letters_count = self.parameters["spelled_letters_count"]
         if spelled_letters_count > len(self.copy_phrase):
-            self.logger.info('Already spelled letters exceeds phrase length.')
+            self.logger.info("Already spelled letters exceeds phrase length.")
             spelled_letters_count = 0
         return spelled_letters_count
 
@@ -275,22 +349,24 @@ class RSVPCopyPhraseTask(Task):
         """
 
         self.copy_phrase_task = CopyPhraseWrapper(
-            self.parameters['min_inq_len'],
-            self.parameters['max_inq_per_series'],
+            self.parameters["min_inq_len"],
+            self.parameters["max_inq_per_series"],
             lmodel=self.language_model,
             alp=self.alp,
             evidence_names=self.evidence_types,
             task_list=[(str(self.copy_phrase), self.spelled_text)],
-            is_txt_stim=self.parameters['is_txt_stim'],
+            is_txt_stim=self.parameters["is_txt_stim"],
             stim_timing=[
-                self.parameters['time_fixation'], self.parameters['time_flash']
+                self.parameters["time_fixation"],
+                self.parameters["time_flash"],
             ],
-            decision_threshold=self.parameters['decision_threshold'],
-            backspace_prob=self.parameters['lm_backspace_prob'],
-            backspace_always_shown=self.parameters['backspace_always_shown'],
-            stim_length=self.parameters['stim_length'],
-            stim_jitter=self.parameters['stim_jitter'],
-            stim_order=StimuliOrder(self.parameters['stim_order']))
+            decision_threshold=self.parameters["decision_threshold"],
+            backspace_prob=self.parameters["lm_backspace_prob"],
+            backspace_always_shown=self.parameters["backspace_always_shown"],
+            stim_length=self.parameters["stim_length"],
+            stim_jitter=self.parameters["stim_jitter"],
+            stim_order=StimuliOrder(self.parameters["stim_order"]),
+        )
 
     def user_wants_to_continue(self) -> bool:
         """Check if user wants to continue or terminate.
@@ -303,10 +379,11 @@ class RSVPCopyPhraseTask(Task):
         should_continue = get_user_input(
             self.rsvp,
             WAIT_SCREEN_MESSAGE,
-            self.parameters['stim_color'],
-            first_run=self.first_run)
+            self.parameters["stim_color"],
+            first_run=self.first_run,
+        )
         if not should_continue:
-            self.logger.info('User wants to exit.')
+            self.logger.info("User wants to exit.")
         return should_continue
 
     def wait(self, seconds: Optional[float] = None) -> None:
@@ -317,11 +394,12 @@ class RSVPCopyPhraseTask(Task):
         - seconds : duration of time to wait; if missing, defaults to the
         value of the parameter `'task_buffer_length'`
         """
-        seconds = seconds or self.parameters['task_buffer_length']
+        seconds = seconds or self.parameters["task_buffer_length"]
         core.wait(seconds)
 
-    def present_inquiry(self, inquiry_schedule: InquirySchedule
-                        ) -> Tuple[List[Tuple[str, float]], bool]:
+    def present_inquiry(
+        self, inquiry_schedule: InquirySchedule
+    ) -> Tuple[List[Tuple[str, float]], bool]:
         """Present the given inquiry and return the trigger timing info.
 
         Parameters
@@ -348,12 +426,15 @@ class RSVPCopyPhraseTask(Task):
         self.wait()
 
         # Setup the new stimuli
-        self.rsvp.schedule_to(stimuli=inquiry_schedule.stimuli[0],
-                              timing=inquiry_schedule.durations[0],
-                              colors=inquiry_schedule.colors[0]
-                              if self.parameters['is_txt_stim'] else None)
+        self.rsvp.schedule_to(
+            stimuli=inquiry_schedule.stimuli[0],
+            timing=inquiry_schedule.durations[0],
+            colors=(
+                inquiry_schedule.colors[0] if self.parameters["is_txt_stim"] else None
+            ),
+        )
 
-        if self.parameters['show_preview_inquiry']:
+        if self.parameters["show_preview_inquiry"]:
             stim_times, proceed = self.rsvp.preview_inquiry()
             if proceed:
                 stim_times.extend(self.rsvp.do_inquiry())
@@ -372,40 +453,44 @@ class RSVPCopyPhraseTask(Task):
         - selection : selected stimulus to display
         - correct : whether or not the correct stim was chosen
         """
-        if self.parameters['show_feedback']:
-            self.feedback.administer(f'Selected: {selection}')
+        if self.parameters["show_feedback"]:
+            self.feedback.administer(f"Selected: {selection}")
 
     def check_stop_criteria(self) -> bool:
         """Returns True if experiment is currently within params and the task
         should continue.
         """
         if self.copy_phrase == self.spelled_text:
-            self.logger.info('Spelling complete')
+            self.logger.info("Spelling complete")
             return False
 
-        if (self.inq_counter + 1) >= self.parameters['max_inq_len']:
-            self.logger.info('Max tries exceeded: to allow for more tries'
-                             ' adjust the Maximum inquiry Length '
-                             '(max_inq_len) parameter.')
+        if (self.inq_counter + 1) >= self.parameters["max_inq_len"]:
+            self.logger.info(
+                "Max tries exceeded: to allow for more tries"
+                " adjust the Maximum inquiry Length "
+                "(max_inq_len) parameter."
+            )
             return False
 
-        if self.session.total_time_spent >= (self.parameters['max_minutes'] *
-                                             60):
-            self.logger.info('Max time exceeded. To allow for more time '
-                             'adjust the max_minutes parameter.')
+        if self.session.total_time_spent >= (self.parameters["max_minutes"] * 60):
+            self.logger.info(
+                "Max time exceeded. To allow for more time "
+                "adjust the max_minutes parameter."
+            )
             return False
 
-        if self.session.total_number_decisions >= self.parameters['max_selections']:
-            self.logger.info('Max number of selections reached '
-                             '(configured with the max_selections parameter)')
+        if self.session.total_number_decisions >= self.parameters["max_selections"]:
+            self.logger.info(
+                "Max number of selections reached "
+                "(configured with the max_selections parameter)"
+            )
             return False
 
         return True
 
     def next_target(self) -> str:
-        """Computes the next target letter based on the currently spelled_text.
-        """
-        if self.copy_phrase[0:len(self.spelled_text)] == self.spelled_text:
+        """Computes the next target letter based on the currently spelled_text."""
+        if self.copy_phrase[0: len(self.spelled_text)] == self.spelled_text:
             # if correctly spelled so far, get the next letter.
             return self.copy_phrase[len(self.spelled_text)]
         return BACKSPACE_CHAR
@@ -417,14 +502,13 @@ class RSVPCopyPhraseTask(Task):
         -------
         data save location (triggers.txt, session.json)
         """
-        self.logger.info('Starting Copy Phrase Task!')
+        self.logger.info("Starting Copy Phrase Task!")
         run = True
         self.wait()  # buffer for data processing
 
         while run and self.user_wants_to_continue() and self.current_inquiry:
             target_stimuli = self.next_target()
-            stim_times, proceed = self.present_inquiry(
-                self.current_inquiry)
+            stim_times, proceed = self.present_inquiry(self.current_inquiry)
 
             self.write_trigger_data(stim_times, target_stimuli)
             self.wait()
@@ -432,18 +516,21 @@ class RSVPCopyPhraseTask(Task):
             evidence_types = self.add_evidence(stim_times, proceed)
             decision = self.evaluate_evidence()
 
-            data = self.new_data_record(stim_times,
-                                        target_stimuli,
-                                        current_text=self.spelled_text,
-                                        decision=decision,
-                                        evidence_types=evidence_types)
-            self.update_session_data(data,
-                                     save=True,
-                                     decision_made=decision.decision_made)
+            data = self.new_data_record(
+                stim_times,
+                target_stimuli,
+                current_text=self.spelled_text,
+                decision=decision,
+                evidence_types=evidence_types,
+            )
+            self.update_session_data(
+                data, save=True, decision_made=decision.decision_made
+            )
 
             if decision.decision_made:
-                self.show_feedback(decision.selection,
-                                   (decision.selection == target_stimuli))
+                self.show_feedback(
+                    decision.selection, (decision.selection == target_stimuli)
+                )
                 self.spelled_text = decision.spelled_text
                 self.current_inquiry = self.next_inquiry()
 
@@ -457,20 +544,24 @@ class RSVPCopyPhraseTask(Task):
         self.write_offset_trigger()
 
         self.session.task_summary = TaskSummary(
-            self.session, self.parameters['show_preview_inquiry'],
-            self.parameters['preview_inquiry_progress_method'],
-            self.trigger_handler.file_path).as_dict()
+            self.session,
+            self.parameters["show_preview_inquiry"],
+            self.parameters["preview_inquiry_progress_method"],
+            self.trigger_handler.file_path,
+        ).as_dict()
         self.write_session_data()
 
         # Evidence is not recorded in the session when using fake decisions.
-        if self.parameters['summarize_session'] and self.session.has_evidence():
-            session_excel(session=self.session,
-                          excel_file=f"{self.file_save}/{SESSION_SUMMARY_FILENAME}")
+        if self.parameters["summarize_session"] and self.session.has_evidence():
+            session_excel(
+                session=self.session,
+                excel_file=f"{self.file_save}/{SESSION_SUMMARY_FILENAME}",
+            )
 
         # Wait some time before exiting so there is trailing eeg data saved
         self.wait()
 
-        return TaskData(task_save=self.file_save)
+        return TaskData(save_path=self.file_save, task_dict=self.session.as_dict())
 
     def evaluate_evidence(self) -> Decision:
         """Uses the `copy_phrase_task` parameter to evaluate the provided
@@ -481,9 +572,9 @@ class RSVPCopyPhraseTask(Task):
         - self.copy_phrase_task
         """
         if self.fake:
-            _, spelled, _ = fake_copy_phrase_decision(self.copy_phrase,
-                                                      self.next_target(),
-                                                      self.spelled_text)
+            _, spelled, _ = fake_copy_phrase_decision(
+                self.copy_phrase, self.next_target(), self.spelled_text
+            )
             # Reset the stoppage criteria by forcing the commit to a decision.
             self.copy_phrase_task.decision_maker.do_series()
             # In fake mode, only the LM is providing evidence, so the decision
@@ -491,21 +582,24 @@ class RSVPCopyPhraseTask(Task):
             self.copy_phrase_task.decision_maker.update(spelled)
 
             # In fake mode, all inquiries result in a selection.
-            return Decision(decision_made=True,
-                            selection=spelled[-1],
-                            spelled_text=spelled,
-                            new_inq_schedule=None)
+            return Decision(
+                decision_made=True,
+                selection=spelled[-1],
+                spelled_text=spelled,
+                new_inq_schedule=None,
+            )
 
         decision_made, new_sti = self.copy_phrase_task.decide()
         spelled_text = self.copy_phrase_task.decision_maker.displayed_state
-        selection = ''
+        selection = ""
         if decision_made:
             selection = self.copy_phrase_task.decision_maker.last_selection
 
         return Decision(decision_made, selection, spelled_text, new_sti)
 
-    def add_evidence(self, stim_times: List[List],
-                     proceed: bool = True) -> List[EvidenceType]:
+    def add_evidence(
+        self, stim_times: List[List], proceed: bool = True
+    ) -> List[EvidenceType]:
         """Add all evidence used to make a decision.
 
         Evaluates evidence from various sources (button press, devices,
@@ -524,9 +618,7 @@ class RSVPCopyPhraseTask(Task):
         --------
         - self.copy_phrase_task
         """
-        evidences = [
-            self.compute_button_press_evidence(proceed)
-        ]
+        evidences = [self.compute_button_press_evidence(proceed)]
         # evidence from one or more devices
         evidences.extend(self.compute_device_evidence(stim_times, proceed))
 
@@ -541,7 +633,8 @@ class RSVPCopyPhraseTask(Task):
         return evidence_types
 
     def compute_button_press_evidence(
-            self, proceed: bool) -> Optional[Tuple[EvidenceType, List[float]]]:
+        self, proceed: bool
+    ) -> Optional[Tuple[EvidenceType, List[float]]]:
         """If 'show_preview_inquiry' feature is enabled, compute the button
         press evidence and add it to the copy phrase task.
 
@@ -554,20 +647,23 @@ class RSVPCopyPhraseTask(Task):
             tuple of (evidence type, evidence) or None if inquiry preview is
             not enabled.
         """
-        if not self.parameters['show_preview_inquiry'] \
-                or not self.current_inquiry \
-                or self.parameters['preview_only']:
+        if (
+            not self.parameters["show_preview_inquiry"] or
+            not self.current_inquiry or
+            self.parameters["preview_only"]
+        ):
             return None
-        probs = compute_probs_after_preview(self.current_inquiry.stimuli[0],
-                                            self.alp,
-                                            self.button_press_error_prob,
-                                            proceed)
+        probs = compute_probs_after_preview(
+            self.current_inquiry.stimuli[0],
+            self.alp,
+            self.button_press_error_prob,
+            proceed,
+        )
         return (EvidenceType.BTN, probs)
 
     def compute_device_evidence(
-            self,
-            stim_times: List[List],
-            proceed: bool = True) -> List[Tuple[EvidenceType, List[float]]]:
+        self, stim_times: List[List], proceed: bool = True
+    ) -> List[Tuple[EvidenceType, List[float]]]:
         """Get inquiry data from all devices and evaluate the evidence, but
         don't yet attempt a decision.
 
@@ -586,13 +682,15 @@ class RSVPCopyPhraseTask(Task):
 
         # currently prestim_length is used as a buffer for filter application
         post_stim_buffer = int(self.parameters.get("task_buffer_length") / 2)
-        prestim_buffer: float = self.parameters['prestim_length']
-        trial_window: Tuple[float, float] = self.parameters['trial_window']
+        prestim_buffer: float = self.parameters["prestim_length"]
+        trial_window: Tuple[float, float] = self.parameters["trial_window"]
         window_length = trial_window[1] - trial_window[0]
         inquiry_timing = self.stims_for_decision(stim_times)
 
         # update the inquiry timing list (stim, time) based on the trial window first time value
-        inquiry_timing = [(stim, time + trial_window[0]) for stim, time in inquiry_timing]
+        inquiry_timing = [
+            (stim, time + trial_window[0]) for stim, time in inquiry_timing
+        ]
 
         # Get all data at once so we don't redundantly query devices which are
         # used in more than one signal model.
@@ -600,13 +698,15 @@ class RSVPCopyPhraseTask(Task):
             inquiry_timing=inquiry_timing,
             daq=self.daq,
             prestim=prestim_buffer,
-            poststim=post_stim_buffer + window_length)
+            poststim=post_stim_buffer + window_length,
+        )
 
         triggers = relative_triggers(inquiry_timing, prestim_buffer)
         # we assume all are nontargets at this point
-        labels = ['nontarget'] * len(triggers)
+        labels = ["nontarget"] * len(triggers)
         letters, times, filtered_labels = self.copy_phrase_task.letter_info(
-            triggers, labels)
+            triggers, labels
+        )
 
         evidences = []
         for evidence_evaluator in self.evidence_evaluators:
@@ -615,12 +715,15 @@ class RSVPCopyPhraseTask(Task):
                 symbols=letters,
                 times=times,
                 target_info=filtered_labels,
-                window_length=window_length)
+                window_length=window_length,
+            )
             evidences.append((evidence_evaluator.produces, probs))
 
         return evidences
 
-    def stims_for_decision(self, stim_times: List[Tuple[str, float]]) -> List[Tuple[str, float]]:
+    def stims_for_decision(
+        self, stim_times: List[Tuple[str, float]]
+    ) -> List[Tuple[str, float]]:
         """The stim_timings from the display may include non-letter stimuli
         such as calibration and inquiry_preview timings. This method extracts
         only the letter data used to process the data for a decision.
@@ -634,16 +737,16 @@ class RSVPCopyPhraseTask(Task):
         stim times where the stim is in the current alphabet; filters out
         'calibration', 'inquiry_preview', etc.
         """
-        return [
-            timing for timing in stim_times if timing[0] in (self.alp + ['+'])
-        ]
+        return [timing for timing in stim_times if timing[0] in (self.alp + ["+"])]
 
-    def new_data_record(self,
-                        stim_times: List[Tuple[str, float]],
-                        target_stimuli: str,
-                        current_text: str,
-                        decision: Decision,
-                        evidence_types: Optional[List[EvidenceType]] = None) -> Inquiry:
+    def new_data_record(
+        self,
+        stim_times: List[Tuple[str, float]],
+        target_stimuli: str,
+        current_text: str,
+        decision: Decision,
+        evidence_types: Optional[List[EvidenceType]] = None,
+    ) -> Inquiry:
         """Construct a new inquiry data record.
 
         Parameters
@@ -663,16 +766,19 @@ class RSVPCopyPhraseTask(Task):
         assert self.current_inquiry, "Current inquiry is required"
         evidence_types = evidence_types or []
         triggers = construct_triggers(self.stims_for_decision(stim_times))
-        data = Inquiry(stimuli=self.current_inquiry.stimuli,
-                       timing=self.current_inquiry.durations,
-                       triggers=triggers,
-                       target_info=target_info(triggers, target_stimuli,
-                                               self.parameters['is_txt_stim']),
-                       target_letter=target_stimuli,
-                       current_text=current_text,
-                       target_text=self.copy_phrase,
-                       selection=decision.selection,
-                       next_display_state=decision.spelled_text)
+        data = Inquiry(
+            stimuli=self.current_inquiry.stimuli,
+            timing=self.current_inquiry.durations,
+            triggers=triggers,
+            target_info=target_info(
+                triggers, target_stimuli, self.parameters["is_txt_stim"]
+            ),
+            target_letter=target_stimuli,
+            current_text=current_text,
+            target_text=self.copy_phrase,
+            selection=decision.selection,
+            next_display_state=decision.spelled_text,
+        )
         data.precision = self.evidence_precision
 
         if not self.fake:
@@ -697,10 +803,9 @@ class RSVPCopyPhraseTask(Task):
         # Give the system time to process
         self.wait()
 
-    def update_session_data(self,
-                            data: Inquiry,
-                            save: bool = True,
-                            decision_made: bool = False) -> None:
+    def update_session_data(
+        self, data: Inquiry, save: bool = True, decision_made: bool = False
+    ) -> None:
         """Update the current session with the latest inquiry data
 
         Parameters
@@ -713,7 +818,9 @@ class RSVPCopyPhraseTask(Task):
         - self.session
         """
         self.session.add_sequence(data)
-        self.session.total_time_spent = self.experiment_clock.getTime() - self.start_time
+        self.session.total_time_spent = (
+            self.experiment_clock.getTime() - self.start_time
+        )
         if save:
             self.write_session_data()
         if decision_made:
@@ -723,25 +830,26 @@ class RSVPCopyPhraseTask(Task):
         """Save session data to disk."""
         if self.session:
             session_file = _save_session_related_data(
-                self.session_save_location,
-                self.session.as_dict())
+                self.session_save_location, self.session.as_dict()
+            )
             session_file.close()
 
     def write_offset_trigger(self) -> None:
-        """Append the offset to the end of the triggers file.
-        """
+        """Append the offset to the end of the triggers file."""
         # To help support future refactoring or use of lsl timestamps only
         # we write only the sample offset here.
         triggers = []
         for content_type, client in self.daq.clients_by_type.items():
-            label = offset_label(content_type.name, prefix='daq_sample_offset')
+            label = offset_label(content_type.name, prefix="daq_sample_offset")
             time = client.offset(self.rsvp.first_stim_time)
             triggers.append(Trigger(label, TriggerType.SYSTEM, time))
 
         self.trigger_handler.add_triggers(triggers)
         self.trigger_handler.close()
 
-    def write_trigger_data(self, stim_times: List[Tuple[str, float]], target_stimuli: str) -> None:
+    def write_trigger_data(
+        self, stim_times: List[Tuple[str, float]], target_stimuli: str
+    ) -> None:
         """Save trigger data to disk.
 
         Parameters
@@ -755,13 +863,15 @@ class RSVPCopyPhraseTask(Task):
             offset_triggers = []
             for content_type, client in self.daq.clients_by_type.items():
                 label = offset_label(content_type.name)
-                time = client.offset(
-                    self.rsvp.first_stim_time) - self.rsvp.first_stim_time
-                offset_triggers.append(Trigger(label, TriggerType.OFFSET,
-                                               time))
+                time = (
+                    client.offset(self.rsvp.first_stim_time) - self.rsvp.first_stim_time
+                )
+                offset_triggers.append(Trigger(label, TriggerType.OFFSET, time))
             self.trigger_handler.add_triggers(offset_triggers)
 
-        triggers = convert_timing_triggers(stim_times, target_stimuli, self.trigger_type)
+        triggers = convert_timing_triggers(
+            stim_times, target_stimuli, self.trigger_type
+        )
         self.trigger_handler.add_triggers(triggers)
 
     def trigger_type(self, symbol: str, target: str, index: int) -> TriggerType:
@@ -769,11 +879,11 @@ class RSVPCopyPhraseTask(Task):
 
         Cast a given symbol to a TriggerType.
         """
-        if symbol == 'inquiry_preview':
+        if symbol == "inquiry_preview":
             return TriggerType.PREVIEW
-        if 'bcipy_key_press' in symbol:
+        if "bcipy_key_press" in symbol:
             return TriggerType.EVENT
-        if symbol == '+':
+        if symbol == "+":
             return TriggerType.FIXATION
         if target == symbol:
             return TriggerType.TARGET
@@ -801,12 +911,14 @@ class TaskSummary:
             2 = press to skip to another inquiry
     """
 
-    def __init__(self,
-                 session: Session,
-                 show_preview: bool = False,
-                 preview_mode: int = 0,
-                 trigger_path: Optional[str] = None) -> None:
-        assert preview_mode in range(3), 'Preview mode out of range'
+    def __init__(
+        self,
+        session: Session,
+        show_preview: bool = False,
+        preview_mode: int = 0,
+        trigger_path: Optional[str] = None,
+    ) -> None:
+        assert preview_mode in range(3), "Preview mode out of range"
         self.session = session
         self.show_preview = show_preview
         self.preview_mode = preview_mode
@@ -816,35 +928,30 @@ class TaskSummary:
     def as_dict(self) -> dict:
         """Computes the task summary data to append to the session."""
 
-        selections = [
-            inq for inq in self.session.all_inquiries if inq.selection
-        ]
+        selections = [inq for inq in self.session.all_inquiries if inq.selection]
         correct = [inq for inq in selections if inq.is_correct_decision]
         incorrect = [inq for inq in selections if not inq.is_correct_decision]
 
         # Note that SPACE is considered a symbol
-        correct_symbols = [
-            inq for inq in correct if inq.selection != BACKSPACE_CHAR
-        ]
+        correct_symbols = [inq for inq in correct if inq.selection != BACKSPACE_CHAR]
 
         btn_presses = self.btn_press_count()
         sel_count = len(selections)
-        switch_per_selection = (btn_presses /
-                                sel_count) if sel_count > 0 else 0
+        switch_per_selection = (btn_presses / sel_count) if sel_count > 0 else 0
         accuracy = (len(correct) / sel_count) if sel_count > 0 else 0
 
         # Note that minutes includes startup time and any breaks.
         minutes = self.session.total_time_spent / 60
         return {
-            'selections_correct': len(correct),
-            'selections_incorrect': len(incorrect),
-            'selections_correct_symbols': len(correct_symbols),
-            'switch_total': btn_presses,
-            'switch_per_selection': switch_per_selection,
-            'switch_response_time': self.switch_response_time(),
-            'typing_accuracy': accuracy,
-            'correct_rate': len(correct) / minutes if minutes else 0,
-            'copy_rate': len(correct_symbols) / minutes if minutes else 0
+            "selections_correct": len(correct),
+            "selections_incorrect": len(incorrect),
+            "selections_correct_symbols": len(correct_symbols),
+            "switch_total": btn_presses,
+            "switch_per_selection": switch_per_selection,
+            "switch_response_time": self.switch_response_time(),
+            "typing_accuracy": accuracy,
+            "correct_rate": len(correct) / minutes if minutes else 0,
+            "copy_rate": len(correct_symbols) / minutes if minutes else 0,
         }
 
     def btn_press_count(self) -> int:
@@ -874,13 +981,12 @@ class TaskSummary:
         # Confirm that the data is structured as expected.
         for preview, keypress in pairs:
             if (preview.type != TriggerType.PREVIEW) or (
-                    keypress.type != TriggerType.EVENT):
-                self.logger.info('Could not compute switch_response_time')
+                keypress.type != TriggerType.EVENT
+            ):
+                self.logger.info("Could not compute switch_response_time")
                 return None
 
-        response_times = [
-            keypress.time - preview.time for preview, keypress in pairs
-        ]
+        response_times = [keypress.time - preview.time for preview, keypress in pairs]
         count = len(response_times)
         return sum(response_times) / count if count > 0 else None
 
@@ -890,47 +996,52 @@ class TaskSummary:
             return []
         triggers, _offset = TriggerHandler.read_text_file(self.trigger_path)
         return [
-            trg for trg in triggers
+            trg
+            for trg in triggers
             if trg.type in [TriggerType.PREVIEW, TriggerType.EVENT]
         ]
 
 
 def _init_copy_phrase_display(
-        parameters: Parameters,
-        win: visual.Window,
-        static_clock: core.StaticPeriod,
-        experiment_clock: Clock,
-        starting_spelled_text) -> CopyPhraseDisplay:
+    parameters: Parameters,
+    win: visual.Window,
+    static_clock: core.StaticPeriod,
+    experiment_clock: Clock,
+    starting_spelled_text,
+) -> CopyPhraseDisplay:
     preview_inquiry = PreviewInquiryProperties(
-        preview_only=parameters['preview_only'],
-        preview_inquiry_length=parameters['preview_inquiry_length'],
-        preview_inquiry_key_input=parameters['preview_inquiry_key_input'],
-        preview_inquiry_progress_method=parameters[
-            'preview_inquiry_progress_method'],
-        preview_inquiry_isi=parameters['preview_inquiry_isi'])
-    info = InformationProperties(
-        info_color=[parameters['info_color']],
-        info_pos=[(parameters['info_pos_x'], parameters['info_pos_y'])],
-        info_height=[parameters['info_height']],
-        info_font=[parameters['font']],
-        info_text=[parameters['info_text']],
+        preview_only=parameters["preview_only"],
+        preview_inquiry_length=parameters["preview_inquiry_length"],
+        preview_inquiry_key_input=parameters["preview_inquiry_key_input"],
+        preview_inquiry_progress_method=parameters["preview_inquiry_progress_method"],
+        preview_inquiry_isi=parameters["preview_inquiry_isi"],
     )
-    stimuli = StimuliProperties(stim_font=parameters['font'],
-                                stim_pos=(parameters['stim_pos_x'],
-                                          parameters['stim_pos_y']),
-                                stim_height=parameters['stim_height'],
-                                stim_inquiry=['A'] * parameters['stim_length'],
-                                stim_colors=[parameters['stim_color']] * parameters['stim_length'],
-                                stim_timing=[10] * parameters['stim_length'],
-                                is_txt_stim=parameters['is_txt_stim'])
+    info = InformationProperties(
+        info_color=[parameters["info_color"]],
+        info_pos=[(parameters["info_pos_x"], parameters["info_pos_y"])],
+        info_height=[parameters["info_height"]],
+        info_font=[parameters["font"]],
+        info_text=[parameters["info_text"]],
+    )
+    stimuli = StimuliProperties(
+        stim_font=parameters["font"],
+        stim_pos=(parameters["stim_pos_x"], parameters["stim_pos_y"]),
+        stim_height=parameters["stim_height"],
+        stim_inquiry=["A"] * parameters["stim_length"],
+        stim_colors=[parameters["stim_color"]] * parameters["stim_length"],
+        stim_timing=[10] * parameters["stim_length"],
+        is_txt_stim=parameters["is_txt_stim"],
+    )
 
-    task_bar = CopyPhraseTaskBar(win,
-                                 task_text=parameters['task_text'],
-                                 spelled_text=starting_spelled_text,
-                                 colors=[parameters['task_color']],
-                                 font=parameters['font'],
-                                 height=parameters['task_height'],
-                                 padding=parameters['task_padding'])
+    task_bar = CopyPhraseTaskBar(
+        win,
+        task_text=parameters["task_text"],
+        spelled_text=starting_spelled_text,
+        colors=[parameters["task_color"]],
+        font=parameters["font"],
+        height=parameters["task_height"],
+        padding=parameters["task_padding"],
+    )
 
     return CopyPhraseDisplay(
         win,
@@ -940,6 +1051,7 @@ def _init_copy_phrase_display(
         task_bar,
         info,
         starting_spelled_text,
-        trigger_type=parameters['trigger_type'],
-        space_char=parameters['stim_space_char'],
-        preview_inquiry=preview_inquiry)
+        trigger_type=parameters["trigger_type"],
+        space_char=parameters["stim_space_char"],
+        preview_inquiry=preview_inquiry,
+    )

--- a/bcipy/task/start_task.py
+++ b/bcipy/task/start_task.py
@@ -3,7 +3,7 @@
 from typing import List, Optional, Type
 from psychopy import visual
 
-from bcipy.task import Task
+from bcipy.task import Task, TaskData
 from bcipy.task.paradigm.matrix.copy_phrase import MatrixCopyPhraseTask
 from bcipy.acquisition import ClientManager
 from bcipy.helpers.parameters import Parameters
@@ -65,7 +65,7 @@ def start_task(
         file_save: str,
         signal_models: Optional[List[SignalModel]] = None,
         language_model: Optional[LanguageModel] = None,
-        fake: bool = True) -> str:
+        fake: bool = True) -> TaskData:
     """Creates a Task and starts execution."""
     bcipy_task = make_task(
         display_window,

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -225,7 +225,7 @@ class TestCopyPhrase(unittest.TestCase):
         verify(self.copy_phrase_wrapper, times=1).initialize_series()
         verify(self.display, times=0).preview_inquiry()
         verify(self.display, times=0).do_inquiry()
-        self.assertEqual(self.temp_dir, result.task_save)
+        self.assertEqual(self.temp_dir, result.save_path)
 
         self.assertTrue(
             Path(task.session_save_location).is_file(),
@@ -264,7 +264,7 @@ class TestCopyPhrase(unittest.TestCase):
         verify(self.copy_phrase_wrapper, times=2).initialize_series()
         verify(self.display, times=0).preview_inquiry()
         verify(self.display, times=1).do_inquiry()
-        self.assertEqual(self.temp_dir, result.task_save)
+        self.assertEqual(self.temp_dir, result.save_path)
 
         self.assertTrue(
             Path(task.session_save_location).is_file(),
@@ -301,7 +301,7 @@ class TestCopyPhrase(unittest.TestCase):
 
         # Assertions
         verify(self.display, times=2).do_inquiry()
-        self.assertEqual(self.temp_dir, result.task_save)
+        self.assertEqual(self.temp_dir, result.save_path)
 
         self.assertTrue(
             Path(task.session_save_location).is_file(),
@@ -342,7 +342,7 @@ class TestCopyPhrase(unittest.TestCase):
 
         # Assertions
         verify(self.display, times=1).do_inquiry()
-        self.assertEqual(self.temp_dir, result.task_save)
+        self.assertEqual(self.temp_dir, result.save_path)
 
         self.assertTrue(
             Path(task.session_save_location).is_file(),
@@ -475,7 +475,7 @@ class TestCopyPhrase(unittest.TestCase):
         verify(self.display, times=1).preview_inquiry()
         verify(self.display, times=1).do_inquiry()
         verify(self.copy_phrase_wrapper, times=1).add_evidence(EvidenceType.BTN, ...)
-        self.assertEqual(self.temp_dir, result.task_save)
+        self.assertEqual(self.temp_dir, result.save_path)
 
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.init_evidence_evaluator')
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_user_input')
@@ -597,7 +597,7 @@ class TestCopyPhrase(unittest.TestCase):
         verify(copy_phrase_wrapper_mock, times=1).decide(...)
         verify(self.display, times=0).preview_inquiry()
         verify(self.display, times=1).do_inquiry()
-        self.assertEqual(self.temp_dir, result.task_save)
+        self.assertEqual(self.temp_dir, result.save_path)
 
         self.assertTrue(
             Path(task.session_save_location).is_file(),

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -225,7 +225,7 @@ class TestCopyPhrase(unittest.TestCase):
         verify(self.copy_phrase_wrapper, times=1).initialize_series()
         verify(self.display, times=0).preview_inquiry()
         verify(self.display, times=0).do_inquiry()
-        self.assertEqual(self.temp_dir, result)
+        self.assertEqual(self.temp_dir, result.task_save)
 
         self.assertTrue(
             Path(task.session_save_location).is_file(),
@@ -264,7 +264,7 @@ class TestCopyPhrase(unittest.TestCase):
         verify(self.copy_phrase_wrapper, times=2).initialize_series()
         verify(self.display, times=0).preview_inquiry()
         verify(self.display, times=1).do_inquiry()
-        self.assertEqual(self.temp_dir, result)
+        self.assertEqual(self.temp_dir, result.task_save)
 
         self.assertTrue(
             Path(task.session_save_location).is_file(),
@@ -301,7 +301,7 @@ class TestCopyPhrase(unittest.TestCase):
 
         # Assertions
         verify(self.display, times=2).do_inquiry()
-        self.assertEqual(self.temp_dir, result)
+        self.assertEqual(self.temp_dir, result.task_save)
 
         self.assertTrue(
             Path(task.session_save_location).is_file(),
@@ -342,7 +342,7 @@ class TestCopyPhrase(unittest.TestCase):
 
         # Assertions
         verify(self.display, times=1).do_inquiry()
-        self.assertEqual(self.temp_dir, result)
+        self.assertEqual(self.temp_dir, result.task_save)
 
         self.assertTrue(
             Path(task.session_save_location).is_file(),
@@ -475,7 +475,7 @@ class TestCopyPhrase(unittest.TestCase):
         verify(self.display, times=1).preview_inquiry()
         verify(self.display, times=1).do_inquiry()
         verify(self.copy_phrase_wrapper, times=1).add_evidence(EvidenceType.BTN, ...)
-        self.assertEqual(self.temp_dir, result)
+        self.assertEqual(self.temp_dir, result.task_save)
 
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.init_evidence_evaluator')
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_user_input')
@@ -597,7 +597,7 @@ class TestCopyPhrase(unittest.TestCase):
         verify(copy_phrase_wrapper_mock, times=1).decide(...)
         verify(self.display, times=0).preview_inquiry()
         verify(self.display, times=1).do_inquiry()
-        self.assertEqual(self.temp_dir, result)
+        self.assertEqual(self.temp_dir, result.task_save)
 
         self.assertTrue(
             Path(task.session_save_location).is_file(),


### PR DESCRIPTION
# Overview

- Add `TaskData` return object

## Ticket

[Pivotal Ticket](https://www.pivotaltracker.com/story/show/187766235)

## Contributions

- Adds `TaskData` dataclass
- Adds save path and task dicrionary properties
- Updates all tasks to return an instance of TaskData
- Returns session data with `TaskData` instances

## Test

- Existing tests updated to check `TaskData` properties

## Documentation

- No documentation updates required yet

## Changelog

- Changelog updated
