### PR TITLE
Task initialization and cleanup

### DIFF
--- a/bcipy/helpers/acquisition.py
+++ b/bcipy/helpers/acquisition.py
@@ -19,13 +19,13 @@ from bcipy.helpers.save import save_device_specs
 log = logging.getLogger(__name__)
 
 
-def init_eeg_acquisition(
+def init_acquisition(
         parameters: dict,
         save_folder: str,
         server: bool = False) -> Tuple[ClientManager, List[LslDataServer]]:
     """Initialize EEG Acquisition.
 
-    Initializes a client that connects with the EEG data source and begins
+    Initializes a client that connects with ta data source and begins
     data collection.
 
     Parameters

--- a/bcipy/helpers/tests/test_acquisition.py
+++ b/bcipy/helpers/tests/test_acquisition.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock, patch
 from bcipy.acquisition.devices import DeviceSpec, DeviceStatus
 from bcipy.config import DEFAULT_PARAMETERS_PATH
 from bcipy.helpers.acquisition import (RAW_DATA_FILENAME, init_device,
-                                       init_eeg_acquisition,
+                                       init_acquisition,
                                        max_inquiry_duration, parse_stream_type,
                                        raw_data_filename, server_spec,
                                        stream_types)
@@ -36,12 +36,12 @@ class TestAcquisition(unittest.TestCase):
         shutil.rmtree(self.save)
 
     def test_init_acquisition(self):
-        """Test init_eeg_acquisition with LSL client."""
+        """Test init_acquisition with LSL client."""
 
         params = self.parameters
         params['acq_mode'] = 'EEG:passive/DSI-24'
 
-        client, servers = init_eeg_acquisition(params, self.save, server=True)
+        client, servers = init_acquisition(params, self.save, server=True)
 
         client.stop_acquisition()
         client.cleanup()

--- a/bcipy/main.py
+++ b/bcipy/main.py
@@ -1,9 +1,7 @@
 import argparse
 import logging
 import multiprocessing
-from typing import List, Optional, Type
-
-from psychopy import visual
+from typing import Type
 
 from bcipy.config import (DEFAULT_EXPERIMENT_ID, DEFAULT_PARAMETERS_PATH,
                           STATIC_AUDIO_PATH)
@@ -162,8 +160,6 @@ def execute_task(
         play_sound(f"{STATIC_AUDIO_PATH}/{parameters['alert_sound_file']}")
 
     return True
-
-
 
 
 def bcipy_main() -> None:

--- a/bcipy/main.py
+++ b/bcipy/main.py
@@ -87,9 +87,6 @@ def bci_main(
 
     log.info(sys_info)
 
-    # Collect experiment field data
-    # collect_experiment_field_data(experiment, save_folder)
-
     if execute_task(task, parameters, save_folder, alert, fake):
         if visualize:
 

--- a/bcipy/main.py
+++ b/bcipy/main.py
@@ -5,19 +5,14 @@ from typing import List, Optional, Type
 
 from psychopy import visual
 
-from bcipy.acquisition import ClientManager, LslDataServer
 from bcipy.config import (DEFAULT_EXPERIMENT_ID, DEFAULT_PARAMETERS_PATH,
                           STATIC_AUDIO_PATH)
-from bcipy.display import init_display_window
-from bcipy.helpers.acquisition import init_eeg_acquisition
 from bcipy.helpers.language_model import init_language_model
 from bcipy.helpers.load import (load_experiments, load_json_parameters,
                                 load_signal_models)
 from bcipy.helpers.save import init_save_data_structure
-from bcipy.helpers.session import collect_experiment_field_data
 from bcipy.helpers.stimuli import play_sound
 from bcipy.helpers.system_utils import configure_logger, get_system_info
-from bcipy.helpers.task import print_message
 from bcipy.helpers.validate import validate_bcipy_session, validate_experiment
 from bcipy.helpers.visualization import visualize_session_data
 from bcipy.task import TaskRegistry, Task
@@ -95,7 +90,7 @@ def bci_main(
     log.info(sys_info)
 
     # Collect experiment field data
-    collect_experiment_field_data(experiment, save_folder)
+    # collect_experiment_field_data(experiment, save_folder)
 
     if execute_task(task, parameters, save_folder, alert, fake):
         if visualize:
@@ -150,21 +145,9 @@ def execute_task(
 
         language_model = init_language_model(parameters)
 
-    # Initialize DAQ and export the device configuration
-    daq, servers = init_eeg_acquisition(
-        parameters, save_folder, server=fake)
-
-    # Initialize Display Window
-    # We have to wait until after the prompt to load the signal model before
-    # displaying the window, otherwise in fullscreen mode this throws an error
-    display = init_display_window(parameters)
-    print_message(display, f'Initializing {task}...')
-
     # Start Task
     try:
-        start_task(display,
-                   daq,
-                   task,
+        start_task(task,
                    parameters,
                    save_folder,
                    language_model=language_model,
@@ -178,41 +161,9 @@ def execute_task(
     if alert:
         play_sound(f"{STATIC_AUDIO_PATH}/{parameters['alert_sound_file']}")
 
-    return _clean_up_session(display, daq, servers)
+    return True
 
 
-def _clean_up_session(
-        display: visual.Window,
-        daq: ClientManager,
-        servers: Optional[List[LslDataServer]] = None) -> bool:
-    """Clean up session.
-
-    Closes the display window and data acquisition objects. Returns True if the session was closed successfully.
-
-    Input:
-        display (visual.Window): display window
-        daq (LslAcquisitionClient): data acquisition client
-        server (LslDataServer): data server
-    """
-    try:
-        # Stop Acquisition
-        daq.stop_acquisition()
-        daq.cleanup()
-
-        # Stop Servers
-        if servers:
-            for server in servers:
-                server.stop()
-
-        # Close the display window
-        # NOTE: There is currently a bug in psychopy when attempting to shutdown
-        # windows when using a USB-C monitor. Putting the display close last in
-        # the inquiry allows acquisition to properly shutdown.
-        display.close()
-        return True
-    except Exception as e:
-        log.exception(str(e))
-        return False
 
 
 def bcipy_main() -> None:

--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -698,7 +698,7 @@
     "type": "float"
   },
   "show_preview_inquiry": {
-    "value": "true",
+    "value": "false",
     "section": "bci_config",
     "name": "Preview Inquiry Display",
     "helpTip": "If ‘true’, the inquiry will be previewed as applicable for the Task. *Note* Not all tasks will have this enabled!",

--- a/bcipy/task/README.md
+++ b/bcipy/task/README.md
@@ -33,25 +33,3 @@ Currently, these are the supported paradigms and modes:
 > Copy Phrase: Used to copy a phrase using the Matrix paradigm (e.g. P300 Speller) on data from a P300 calibration
 
 
-
-## Start Task
--------------
-
-Start Task takes in Display [object], parameters [dict], file save [str-path] and task type [dict]. Using the
-task type, start_task() will route to the correct paradigm (RSVP, SSVEP, MATRIX) and mode (Calibration, Copy Phrase, etc.)
-
-It is called in the following way:
-
-
-```
-	from bcipy.task.start_task import start_task
-
-    start_task(
-       	display_window,
-        data_acquisition_client,
-        parameters,
-        file_save)
-
-```
-
-It will throw an error if the task isn't implemented.

--- a/bcipy/task/calibration.py
+++ b/bcipy/task/calibration.py
@@ -146,6 +146,7 @@ class BaseCalibrationTask(Task):
                 # windows when using a USB-C monitor. Putting the display close last in
                 # the inquiry allows acquisition to properly shutdown.
                 self.window.close()
+                self.initalized = False
 
             except Exception as e:
                 self.logger.exception(str(e))

--- a/bcipy/task/calibration.py
+++ b/bcipy/task/calibration.py
@@ -109,7 +109,7 @@ class BaseCalibrationTask(Task):
     def symbol_set(self) -> List[str]:
         """Symbols used in the calibration"""
         return self._symbol_set
-    
+
     def setup(self, parameters, data_save_location, fake=False) -> Tuple[ClientManager, List[LslDataServer], Window]:
         # Initialize Acquisition
         daq, servers = init_acquisition(
@@ -118,13 +118,13 @@ class BaseCalibrationTask(Task):
         # Initialize Display
         display = init_display_window(parameters)
         self.initalized = True
-    
+
         return daq, servers, display
-    
-    def validate(self) -> bool:
+
+    def validate(self) -> None:
         """Validate the task."""
         assert self.MODE != 'Undefined', 'MODE must be defined in subclass.'
-    
+
     def cleanup(self) -> None:
         """Any cleanup code to run after the last inquiry is complete."""
         self.exit_display()
@@ -296,7 +296,6 @@ class BaseCalibrationTask(Task):
 
         # Allow for some additional data to be collected for later processing
         self.wait()
-
 
     def write_trigger_data(self, timing: List[Tuple[str, float]],
                            first_run) -> None:

--- a/bcipy/task/calibration.py
+++ b/bcipy/task/calibration.py
@@ -3,13 +3,15 @@
 from abc import abstractmethod
 from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Tuple
 
-from psychopy import core, visual
+from psychopy import core
+from psychopy.visual import Window
 
 import bcipy.task.data as session_data
 from bcipy.acquisition import ClientManager
 from bcipy.config import (SESSION_DATA_FILENAME, TRIGGER_FILENAME,
                           WAIT_SCREEN_MESSAGE)
-from bcipy.display import Display
+from bcipy.helpers.acquisition import init_acquisition, LslDataServer
+from bcipy.display import init_display_window, Display
 from bcipy.helpers.clock import Clock
 from bcipy.helpers.parameters import Parameters
 from bcipy.helpers.save import _save_session_related_data
@@ -51,10 +53,9 @@ class BaseCalibrationTask(Task):
 
     PARAMETERS:
     ----------
-    win (PsychoPy Display)
-    daq (Data Acquisition Client)
     parameters (dict)
     file_save (str)
+    fake (bool)
 
     Subclasses should override the provided MODE and can specialize behavior by overriding
     the following methods:
@@ -63,19 +64,24 @@ class BaseCalibrationTask(Task):
         - trigger_type ; used for assigning trigger types to the timing data
         - session_task_data ; provide task-specific session data
         - session_inquiry_data ; provide task-specific inquiry data to the session
-        - cleanup ; perform any necessary cleanup (closing connections, etc.)
+        - cleanup ; perform any necessary cleanup (closing connections, etc.).
     """
 
     MODE = 'Undefined'
+    initalized = False
 
-    def __init__(self, win: visual.Window, daq: ClientManager,
-                 parameters: Parameters, file_save: str) -> None:
+    def __init__(self, parameters: Parameters, file_save: str, fake: bool) -> None:
         super().__init__()
+
+        self.fake = fake
+        self.validate()
+        daq, servers, win = self.setup(parameters, file_save, fake)
         self.window = win
 
         self.frame_rate = self.window.getActualFrameRate()
         self.parameters = parameters
         self.daq = daq
+        self.servers = servers
         self.static_clock = core.StaticPeriod(screenHz=self.frame_rate)
         self.experiment_clock = Clock()
         self.start_time = self.experiment_clock.getTime()
@@ -103,6 +109,46 @@ class BaseCalibrationTask(Task):
     def symbol_set(self) -> List[str]:
         """Symbols used in the calibration"""
         return self._symbol_set
+    
+    def setup(self, parameters, data_save_location, fake=False) -> Tuple[ClientManager, List[LslDataServer], Window]:
+        # Initialize Acquisition
+        daq, servers = init_acquisition(
+            parameters, data_save_location, server=fake)
+
+        # Initialize Display
+        display = init_display_window(parameters)
+        self.initalized = True
+    
+        return daq, servers, display
+    
+    def validate(self) -> bool:
+        """Validate the task."""
+        assert self.MODE != 'Undefined', 'MODE must be defined in subclass.'
+    
+    def cleanup(self) -> None:
+        """Any cleanup code to run after the last inquiry is complete."""
+        self.exit_display()
+        self.write_offset_trigger()
+        self.wait()
+        if self.initalized:
+            try:
+                # Stop Acquisition
+                self.daq.stop_acquisition()
+                self.daq.cleanup()
+
+                # Stop Servers
+                if self.servers:
+                    for server in self.servers:
+                        server.stop()
+
+                # Close the display window
+                # NOTE: There is currently a bug in psychopy when attempting to shutdown
+                # windows when using a USB-C monitor. Putting the display close last in
+                # the inquiry allows acquisition to properly shutdown.
+                self.window.close()
+
+            except Exception as e:
+                self.logger.exception(str(e))
 
     def wait(self, seconds: Optional[float] = None) -> None:
         """Pause for a time.
@@ -235,8 +281,6 @@ class BaseCalibrationTask(Task):
             self.wait()
             inq_index += 1
 
-        self.exit_display()
-        self.write_offset_trigger()
         self.cleanup()
 
         return TaskData(save_path=self.file_save, task_dict=self.session.as_dict())
@@ -252,8 +296,6 @@ class BaseCalibrationTask(Task):
         # Allow for some additional data to be collected for later processing
         self.wait()
 
-    def cleanup(self) -> None:
-        """Any cleanup code to run after the last inquiry is complete."""
 
     def write_trigger_data(self, timing: List[Tuple[str, float]],
                            first_run) -> None:

--- a/bcipy/task/paradigm/matrix/calibration.py
+++ b/bcipy/task/paradigm/matrix/calibration.py
@@ -27,10 +27,9 @@ class MatrixCalibrationTask(BaseCalibrationTask):
 
     PARAMETERS:
     ----------
-    win (PsychoPy Display Object)
-    daq (Data Acquisition Object [ClientManager]])
     parameters (Parameters Object)
     file_save (String)
+    fake (Boolean)
     """
     name = 'Matrix Calibration'
     MODE = 'Matrix'

--- a/bcipy/task/paradigm/matrix/copy_phrase.py
+++ b/bcipy/task/paradigm/matrix/copy_phrase.py
@@ -15,10 +15,6 @@ class MatrixCopyPhraseTask(RSVPCopyPhraseTask):
 
     Parameters
     ----------
-        win : object,
-            display window to present visual stimuli.
-        daq : object,
-            data acquisition object initialized for the desired protocol
         parameters : dict,
             configuration details regarding the experiment. See parameters.json
         file_save : str,

--- a/bcipy/task/paradigm/matrix/timing_verification.py
+++ b/bcipy/task/paradigm/matrix/timing_verification.py
@@ -15,10 +15,9 @@ class MatrixTimingVerificationCalibration(MatrixCalibrationTask):
         stimuli can be used with a photodiode to ensure accurate presentations.
 
     Input:
-        win (PsychoPy Display Object)
-        daq (Data Acquisition Object)
         parameters (Dictionary)
         file_save (String)
+        fake (Boolean)
 
     Output:
         file_save (String)

--- a/bcipy/task/paradigm/rsvp/calibration/calibration.py
+++ b/bcipy/task/paradigm/rsvp/calibration/calibration.py
@@ -25,10 +25,9 @@ class RSVPCalibrationTask(BaseCalibrationTask):
 
     PARAMETERS:
     ----------
-    win (PsychoPy Display)
-    daq (Data Acquisition Client)
     parameters (dict)
     file_save (str)
+    fake (bool)
     """
     name = 'RSVP Calibration'
     MODE = 'RSVP'

--- a/bcipy/task/paradigm/rsvp/calibration/timing_verification.py
+++ b/bcipy/task/paradigm/rsvp/calibration/timing_verification.py
@@ -2,9 +2,6 @@
 from itertools import cycle, islice, repeat
 from typing import Iterator, List
 
-from psychopy import visual
-
-from bcipy.acquisition import ClientManager
 from bcipy.helpers.parameters import Parameters
 from bcipy.helpers.stimuli import (PhotoDiodeStimuli, get_fixation,
                                    jittered_timing)

--- a/bcipy/task/paradigm/rsvp/calibration/timing_verification.py
+++ b/bcipy/task/paradigm/rsvp/calibration/timing_verification.py
@@ -20,22 +20,20 @@ class RSVPTimingVerificationCalibration(RSVPCalibrationTask):
         stimuli can be used with a photodiode to ensure accurate presentations.
 
     Input:
-        win (PsychoPy Window)
-        daq (ClientManager)
         parameters (Parameters)
         file_save (str)
+        fake (bool)
 
     Output:
         file_save (str)
     """
     name = 'RSVP Timing Verification'
 
-    def __init__(self, win: visual.Window, daq: ClientManager,
-                 parameters: Parameters, file_save: str) -> None:
+    def __init__(self, parameters: Parameters, file_save: str, fake: bool) -> None:
         parameters['stim_height'] = 0.8
         parameters['stim_pos_y'] = 0.0
         super(RSVPTimingVerificationCalibration,
-              self).__init__(win, daq, parameters, file_save)
+              self).__init__(parameters, file_save, fake)
 
     @property
     def symbol_set(self) -> List[str]:

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -3,6 +3,7 @@ import logging
 from typing import List, NamedTuple, Optional, Tuple
 
 from psychopy import core, visual
+from psychopy.visual import Window
 
 from bcipy.acquisition import ClientManager
 from bcipy.config import (
@@ -20,8 +21,10 @@ from bcipy.display import (
 from bcipy.display.components.task_bar import CopyPhraseTaskBar
 from bcipy.display.paradigm.rsvp.mode.copy_phrase import CopyPhraseDisplay
 from bcipy.feedback.visual.visual_feedback import VisualFeedback
+from bcipy.helpers.acquisition import init_acquisition, LslDataServer
 from bcipy.helpers.clock import Clock
 from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
+from bcipy.display import init_display_window
 from bcipy.helpers.exceptions import TaskConfigurationException
 from bcipy.helpers.list import destutter
 from bcipy.helpers.parameters import Parameters
@@ -84,10 +87,6 @@ class RSVPCopyPhraseTask(Task):
 
     Parameters
     ----------
-        win : object,
-            display window to present visual stimuli.
-        daq : object,
-            data acquisition object initialized for the desired protocol
         parameters : dict,
             configuration details regarding the experiment. See parameters.json
         file_save : str,
@@ -105,6 +104,7 @@ class RSVPCopyPhraseTask(Task):
 
     name = "RSVP Copy Phrase"
     MODE = "RSVP"
+    initalized = False
 
     PARAMETERS_USED = [
         "time_fixation",
@@ -163,8 +163,6 @@ class RSVPCopyPhraseTask(Task):
 
     def __init__(
         self,
-        win: visual.Window,
-        daq: ClientManager,
         parameters: Parameters,
         file_save: str,
         signal_models: List[SignalModel],
@@ -173,6 +171,9 @@ class RSVPCopyPhraseTask(Task):
     ) -> None:
         super(RSVPCopyPhraseTask, self).__init__()
         self.logger = logging.getLogger(__name__)
+        self.fake = fake
+        daq, servers, win = self.setup(parameters, file_save, fake)
+        self.servers = servers
         self.window = win
         self.daq = daq
         self.parameters = parameters
@@ -204,7 +205,6 @@ class RSVPCopyPhraseTask(Task):
         self.session_save_location = f"{self.file_save}/{SESSION_DATA_FILENAME}"
         self.copy_phrase = parameters["task_text"]
 
-        self.fake = fake
         self.language_model = language_model
         self.signal_model = signal_models[0] if signal_models else None
         self.evidence_precision = DEFAULT_EVIDENCE_PRECISION
@@ -243,6 +243,60 @@ class RSVPCopyPhraseTask(Task):
         )
 
         self.rsvp = self.init_display()
+
+    def setup(self, parameters, data_save_location, fake=False) -> Tuple[ClientManager, List[LslDataServer], Window]:
+        # Initialize Acquisition
+        daq, servers = init_acquisition(
+            parameters, data_save_location, server=fake)
+
+        # Initialize Display
+        display = init_display_window(parameters)
+        self.initalized = True
+    
+        return daq, servers, display
+    
+    def cleanup(self):
+        self.exit_display()
+        self.write_offset_trigger()
+        
+        if self.initalized:
+
+            self.session.task_summary = TaskSummary(
+                self.session,
+                self.parameters["show_preview_inquiry"],
+                self.parameters["preview_inquiry_progress_method"],
+                self.trigger_handler.file_path,
+            ).as_dict()
+            self.write_session_data()
+
+            # Evidence is not recorded in the session when using fake decisions.
+            if self.parameters["summarize_session"] and self.session.has_evidence():
+                session_excel(
+                    session=self.session,
+                    excel_file=f"{self.file_save}/{SESSION_SUMMARY_FILENAME}",
+                )
+
+            # Wait some time before exiting so there is trailing eeg data saved
+            self.wait()
+            try:
+                # Stop Acquisition
+                self.daq.stop_acquisition()
+                self.daq.cleanup()
+
+                # Stop Servers
+                if self.servers:
+                    for server in self.servers:
+                        server.stop()
+
+                # Close the display window
+                # NOTE: There is currently a bug in psychopy when attempting to shutdown
+                # windows when using a USB-C monitor. Putting the display close last in
+                # the inquiry allows acquisition to properly shutdown.
+                self.window.close()
+
+            except Exception as e:
+                self.logger.exception(str(e))
+
 
     def init_evidence_evaluators(
         self, signal_models: List[SignalModel]
@@ -541,26 +595,7 @@ class RSVPCopyPhraseTask(Task):
             run = self.check_stop_criteria()
             self.inq_counter += 1
 
-        self.exit_display()
-        self.write_offset_trigger()
-
-        self.session.task_summary = TaskSummary(
-            self.session,
-            self.parameters["show_preview_inquiry"],
-            self.parameters["preview_inquiry_progress_method"],
-            self.trigger_handler.file_path,
-        ).as_dict()
-        self.write_session_data()
-
-        # Evidence is not recorded in the session when using fake decisions.
-        if self.parameters["summarize_session"] and self.session.has_evidence():
-            session_excel(
-                session=self.session,
-                excel_file=f"{self.file_save}/{SESSION_SUMMARY_FILENAME}",
-            )
-
-        # Wait some time before exiting so there is trailing eeg data saved
-        self.wait()
+        self.cleanup()
 
         return TaskData(save_path=self.file_save, task_dict=self.session.as_dict())
 

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -252,16 +252,16 @@ class RSVPCopyPhraseTask(Task):
         # Initialize Display
         display = init_display_window(parameters)
         self.initalized = True
-    
+
         return daq, servers, display
-    
+
     def cleanup(self):
         self.exit_display()
         self.write_offset_trigger()
         self.save_session_data()
         # Wait some time before exiting so there is trailing eeg data saved
         self.wait()
-        
+
         if self.initalized:
 
             try:
@@ -286,11 +286,11 @@ class RSVPCopyPhraseTask(Task):
 
     def save_session_data(self) -> None:
         self.session.task_summary = TaskSummary(
-                self.session,
-                self.parameters["show_preview_inquiry"],
-                self.parameters["preview_inquiry_progress_method"],
-                self.trigger_handler.file_path,
-            ).as_dict()
+            self.session,
+            self.parameters["show_preview_inquiry"],
+            self.parameters["preview_inquiry_progress_method"],
+            self.trigger_handler.file_path,
+        ).as_dict()
         self.write_session_data()
 
         # Evidence is not recorded in the session when using fake decisions.

--- a/bcipy/task/paradigm/vep/calibration.py
+++ b/bcipy/task/paradigm/vep/calibration.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, Iterator, List, Optional
 
 from psychopy import visual  # type: ignore
 
-from bcipy.acquisition.multimodal import ClientManager
 from bcipy.display import InformationProperties, VEPStimuliProperties
 from bcipy.display.components.layout import centered
 from bcipy.display.components.task_bar import CalibrationTaskBar
@@ -28,21 +27,19 @@ class VEPCalibrationTask(BaseCalibrationTask):
 
     PARAMETERS:
     ----------
-    win (PsychoPy Display Object)
-    daq (Data Acquisition Object)
     parameters (Dictionary)
     file_save (String)
+    fake (Boolean)
     """
     name = 'VEP Calibration'
     MODE = 'VEP'
 
-    def __init__(self, win: visual.Window, daq: ClientManager,
-                 parameters: Parameters, file_save: str):
+    def __init__(self, parameters: Parameters, file_save: str, fake: bool):
         self.box_colors = [
             '#00FF80', '#FFFFB3', '#CB99FF', '#FB8072', '#80B1D3', '#FF8232'
         ]
         self.num_boxes = 6
-        super().__init__(win, daq, parameters, file_save)
+        super().__init__(parameters, file_save, fake)
 
     def init_display(self) -> VEPDisplay:
         """Initialize the display"""

--- a/bcipy/task/start.py
+++ b/bcipy/task/start.py
@@ -1,12 +1,10 @@
 """Code for constructing and executing registered tasks"""
 # mypy: disable-error-code="arg-type, misc"
 from typing import List, Optional, Type
-from psychopy import visual
 
 from bcipy.task import Task, TaskData
 from bcipy.task.paradigm.matrix.copy_phrase import MatrixCopyPhraseTask
 from bcipy.task.paradigm.rsvp.copy_phrase import RSVPCopyPhraseTask
-from bcipy.acquisition import ClientManager
 from bcipy.helpers.parameters import Parameters
 from bcipy.helpers.exceptions import BciPyCoreException
 from bcipy.signal.model import SignalModel

--- a/bcipy/task/start.py
+++ b/bcipy/task/start.py
@@ -14,8 +14,6 @@ from bcipy.language import LanguageModel
 
 
 def make_task(
-        display_window: visual.Window,
-        daq: ClientManager,
         task: Type[Task],
         parameters: Parameters,
         file_save: str,
@@ -26,8 +24,6 @@ def make_task(
 
     Parameters:
     -----------
-        display_window: psychopy Window
-        daq: ClientManager - manages one or more acquisition clients
         task: Task - instance of a Task subclass that will be initialized
         parameters: dict
         file_save: str - path to file in which to save data
@@ -39,28 +35,24 @@ def make_task(
         Task instance
     """
 
-    # NORMAL RSVP MODES
-
     from bcipy.task.calibration import BaseCalibrationTask
     if issubclass(task, BaseCalibrationTask):
-        return task(display_window, daq, parameters, file_save)
+        return task(parameters, file_save, fake)
 
     if task is RSVPCopyPhraseTask:
         return RSVPCopyPhraseTask(
-            display_window, daq, parameters, file_save, signal_models,
+            parameters, file_save, signal_models,
             language_model, fake=fake)
 
     if task is MatrixCopyPhraseTask:
         return MatrixCopyPhraseTask(
-            display_window, daq, parameters, file_save, signal_models,
+            parameters, file_save, signal_models,
             language_model, fake=fake)
 
     raise BciPyCoreException('The provided task is not available in main')
 
 
 def start_task(
-        display_window: visual.Window,
-        daq: ClientManager,
         task: Type[Task],
         parameters: Parameters,
         file_save: str,
@@ -69,8 +61,6 @@ def start_task(
         fake: bool = True) -> TaskData:
     """Creates a Task and starts execution."""
     bcipy_task = make_task(
-        display_window,
-        daq,
         task,
         parameters,
         file_save,

--- a/bcipy/task/tests/paradigm/matrix/test_matrix_calibration.py
+++ b/bcipy/task/tests/paradigm/matrix/test_matrix_calibration.py
@@ -72,7 +72,7 @@ class TestMatrixCalibration(unittest.TestCase):
         self.parameters = Parameters.from_cast_values(**parameters)
 
         self.win = mock({'size': np.array([500, 500]), 'units': 'height'})
-        self.servers = mock()
+        self.servers = [mock()]
 
         device_spec = DeviceSpec(name='Testing',
                                  channels=['a', 'b', 'c'],

--- a/bcipy/task/tests/paradigm/matrix/test_matrix_calibration.py
+++ b/bcipy/task/tests/paradigm/matrix/test_matrix_calibration.py
@@ -72,6 +72,7 @@ class TestMatrixCalibration(unittest.TestCase):
         self.parameters = Parameters.from_cast_values(**parameters)
 
         self.win = mock({'size': np.array([500, 500]), 'units': 'height'})
+        self.servers = mock()
 
         device_spec = DeviceSpec(name='Testing',
                                  channels=['a', 'b', 'c'],
@@ -98,6 +99,7 @@ class TestMatrixCalibration(unittest.TestCase):
             'transform': mock(),
             'evidence_type': 'ERP'
         })
+        self.fake = False
 
         self.display = mock(spec=MatrixDisplay)
         self.display.first_stim_time = 0.0
@@ -137,11 +139,12 @@ class TestMatrixCalibration(unittest.TestCase):
         """Test initialization"""
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
 
-        MatrixCalibrationTask(win=self.win,
-                              daq=self.daq,
-                              parameters=self.parameters,
-                              file_save=self.temp_dir)
+        MatrixCalibrationTask(parameters=self.parameters,
+                              file_save=self.temp_dir,
+                              fake=self.fake)
 
         verify(bcipy.task.paradigm.matrix.calibration,
                times=1).init_matrix_display(self.parameters, self.win, any(),
@@ -153,11 +156,11 @@ class TestMatrixCalibration(unittest.TestCase):
         """Test task execute"""
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
-
-        task = MatrixCalibrationTask(win=self.win,
-                                     daq=self.daq,
-                                     parameters=self.parameters,
-                                     file_save=self.temp_dir)
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        task = MatrixCalibrationTask(parameters=self.parameters,
+                                     file_save=self.temp_dir,
+                                     fake=self.fake)
 
         when(task).write_offset_trigger().thenReturn(None)
         when(task).write_trigger_data(any(), any()).thenReturn(None)
@@ -179,12 +182,13 @@ class TestMatrixCalibration(unittest.TestCase):
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
         parameters = {}
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
 
         with self.assertRaises(Exception):
-            MatrixCalibrationTask(win=self.win,
-                                  daq=self.daq,
-                                  parameters=parameters,
-                                  file_save=self.temp_dir)
+            MatrixCalibrationTask(parameters=parameters,
+                                  file_save=self.temp_dir,
+                                  fake=self.fake)
 
     @patch('bcipy.task.calibration.TriggerHandler')
     @patch('bcipy.task.calibration._save_session_related_data')
@@ -193,11 +197,12 @@ class TestMatrixCalibration(unittest.TestCase):
         """Test execute save stimuli positions method is called as expected."""
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
 
-        task = MatrixCalibrationTask(win=self.win,
-                                     daq=self.daq,
-                                     parameters=self.parameters,
-                                     file_save=self.temp_dir)
+        task = MatrixCalibrationTask(parameters=self.parameters,
+                                     file_save=self.temp_dir,
+                                     fake=self.fake)
 
         when(task).write_offset_trigger().thenReturn(None)
         when(task).write_trigger_data(any(), any()).thenReturn(None)
@@ -222,10 +227,11 @@ class TestMatrixCalibration(unittest.TestCase):
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
 
-        task = MatrixCalibrationTask(win=self.win,
-                                     daq=self.daq,
-                                     parameters=self.parameters,
-                                     file_save=self.temp_dir)
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        task = MatrixCalibrationTask(parameters=self.parameters,
+                                     file_save=self.temp_dir,
+                                     fake=self.fake)
 
         # non-target
         symbol = 'N'
@@ -250,10 +256,11 @@ class TestMatrixCalibration(unittest.TestCase):
         """Test trigger type fixation."""
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
-        task = MatrixCalibrationTask(win=self.win,
-                                     daq=self.daq,
-                                     parameters=self.parameters,
-                                     file_save=self.temp_dir)
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        task = MatrixCalibrationTask(parameters=self.parameters,
+                                     file_save=self.temp_dir,
+                                     fake=self.fake)
 
         # fixation
         symbol = '+'
@@ -270,11 +277,12 @@ class TestMatrixCalibration(unittest.TestCase):
         """Test trigger type prompt."""
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
 
-        task = MatrixCalibrationTask(win=self.win,
-                                     daq=self.daq,
-                                     parameters=self.parameters,
-                                     file_save=self.temp_dir)
+        task = MatrixCalibrationTask(parameters=self.parameters,
+                                     file_save=self.temp_dir,
+                                     fake=self.fake)
 
         # prompt, index = 0, otherwise it would be a target
         symbol = 'P'
@@ -292,11 +300,12 @@ class TestMatrixCalibration(unittest.TestCase):
         handler_mock = Mock()
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = handler_mock
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
 
-        task = MatrixCalibrationTask(win=self.win,
-                                     daq=self.daq,
-                                     parameters=self.parameters,
-                                     file_save=self.temp_dir)
+        task = MatrixCalibrationTask(parameters=self.parameters,
+                                     file_save=self.temp_dir,
+                                     fake=self.fake)
 
         client_by_type_resp = {ContentType.EEG: self.eeg_client_mock}
         timing_mock = mock()
@@ -325,11 +334,12 @@ class TestMatrixCalibration(unittest.TestCase):
         handler_mock = Mock()
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = handler_mock
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
 
-        task = MatrixCalibrationTask(win=self.win,
-                                     daq=self.daq,
-                                     parameters=self.parameters,
-                                     file_save=self.temp_dir)
+        task = MatrixCalibrationTask(parameters=self.parameters,
+                                     file_save=self.temp_dir,
+                                     fake=self.fake)
 
         timing_mock = mock()
         timing = [('a', 0.0)]
@@ -348,11 +358,12 @@ class TestMatrixCalibration(unittest.TestCase):
         save_session_mock.return_value = mock()
         handler_mock = Mock()
         trigger_handler_mock.return_value = handler_mock
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
 
-        task = MatrixCalibrationTask(win=self.win,
-                                     daq=self.daq,
-                                     parameters=self.parameters,
-                                     file_save=self.temp_dir)
+        task = MatrixCalibrationTask(parameters=self.parameters,
+                                     file_save=self.temp_dir,
+                                     fake=self.fake)
         client_by_type_resp = {ContentType.EEG: self.eeg_client_mock}
         when(self.daq).client_by_type(
             ContentType.EEG).thenReturn(client_by_type_resp)

--- a/bcipy/task/tests/paradigm/rsvp/calibration/test_rsvp_calibration.py
+++ b/bcipy/task/tests/paradigm/rsvp/calibration/test_rsvp_calibration.py
@@ -91,6 +91,8 @@ class TestRSVPCalibration(unittest.TestCase):
             }
         })
         self.temp_dir = ''
+        self.fake = False
+        self.servers = mock()
         self.model_metadata = mock({
             'device_spec': device_spec,
             'transform': mock(),
@@ -127,16 +129,19 @@ class TestRSVPCalibration(unittest.TestCase):
 
     @patch('bcipy.task.calibration.TriggerHandler')
     @patch('bcipy.task.calibration._save_session_related_data')
-    def test_initialize(self, save_session_mock, trigger_handler_mock):
+    @patch('bcipy.task.calibration.BaseCalibrationTask.cleanup')
+    def test_initialize(self, save_session_mock, trigger_handler_mock, cleanup_mock):
         """Test initialization"""
 
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        cleanup_mock.return_value = None
 
-        RSVPCalibrationTask(win=self.win,
-                            daq=self.daq,
-                            parameters=self.parameters,
-                            file_save=self.temp_dir)
+        RSVPCalibrationTask(parameters=self.parameters,
+                            file_save=self.temp_dir,
+                            fake=self.fake)
 
         verify(bcipy.task.paradigm.rsvp.calibration.calibration,
                times=1).init_calibration_display_task(self.parameters,
@@ -148,10 +153,11 @@ class TestRSVPCalibration(unittest.TestCase):
         """Test task execute"""
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
-        task = RSVPCalibrationTask(win=self.win,
-                                   daq=self.daq,
-                                   parameters=self.parameters,
-                                   file_save=self.temp_dir)
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        task = RSVPCalibrationTask(parameters=self.parameters,
+                                   file_save=self.temp_dir,
+                                   fake=self.fake)
 
         when(task).write_offset_trigger().thenReturn(None)
         when(task).write_trigger_data(any(), any()).thenReturn(None)
@@ -173,11 +179,12 @@ class TestRSVPCalibration(unittest.TestCase):
         parameters = {}
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         with self.assertRaises(Exception):
-            RSVPCalibrationTask(win=self.win,
-                                daq=self.daq,
-                                parameters=parameters,
-                                file_save=self.temp_dir)
+            RSVPCalibrationTask(parameters=parameters,
+                                file_save=self.temp_dir,
+                                fake=self.fake)
 
     @patch('bcipy.task.calibration.TriggerHandler')
     @patch('bcipy.task.calibration._save_session_related_data')
@@ -186,10 +193,11 @@ class TestRSVPCalibration(unittest.TestCase):
         """Test trigger type targetness."""
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
-        task = RSVPCalibrationTask(win=self.win,
-                                   daq=self.daq,
-                                   parameters=self.parameters,
-                                   file_save=self.temp_dir)
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        task = RSVPCalibrationTask(parameters=self.parameters,
+                                   file_save=self.temp_dir,
+                                   fake=self.fake)
 
         # non-target
         symbol = 'N'
@@ -214,10 +222,11 @@ class TestRSVPCalibration(unittest.TestCase):
         """Test trigger type fixation."""
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
-        task = RSVPCalibrationTask(win=self.win,
-                                   daq=self.daq,
-                                   parameters=self.parameters,
-                                   file_save=self.temp_dir)
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        task = RSVPCalibrationTask(parameters=self.parameters,
+                                   file_save=self.temp_dir,
+                                   fake=self.fake)
 
         # fixation
         symbol = '+'
@@ -232,12 +241,13 @@ class TestRSVPCalibration(unittest.TestCase):
     def test_trigger_type_prompt(self, save_session_mock,
                                  trigger_handler_mock):
         """Test trigger type prompt."""
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
-        task = RSVPCalibrationTask(win=self.win,
-                                   daq=self.daq,
-                                   parameters=self.parameters,
-                                   file_save=self.temp_dir)
+        task = RSVPCalibrationTask(parameters=self.parameters,
+                                   file_save=self.temp_dir,
+                                   fake=self.fake)
 
         # prompt, index = 0, otherwise it would be a target
         symbol = 'P'
@@ -254,10 +264,11 @@ class TestRSVPCalibration(unittest.TestCase):
         """Test trigger type preview."""
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = mock()
-        task = RSVPCalibrationTask(win=self.win,
-                                   daq=self.daq,
-                                   parameters=self.parameters,
-                                   file_save=self.temp_dir)
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        task = RSVPCalibrationTask(parameters=self.parameters,
+                                   file_save=self.temp_dir,
+                                   fake=self.fake)
 
         # preview, index > 0, otherwise it would be a prompt
         symbol = 'inquiry_preview'
@@ -274,11 +285,12 @@ class TestRSVPCalibration(unittest.TestCase):
         """Test write trigger data when it is the first run of the task."""
         handler_mock = Mock()
         save_session_mock.return_value = mock()
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         trigger_handler_mock.return_value = handler_mock
-        task = RSVPCalibrationTask(win=self.win,
-                                   daq=self.daq,
-                                   parameters=self.parameters,
-                                   file_save=self.temp_dir)
+        task = RSVPCalibrationTask(parameters=self.parameters,
+                                   file_save=self.temp_dir,
+                                   fake=self.fake)
 
         client_by_type_resp = {ContentType.EEG: self.eeg_client_mock}
         timing_mock = mock()
@@ -307,10 +319,11 @@ class TestRSVPCalibration(unittest.TestCase):
         handler_mock = Mock()
         save_session_mock.return_value = mock()
         trigger_handler_mock.return_value = handler_mock
-        task = RSVPCalibrationTask(win=self.win,
-                                   daq=self.daq,
-                                   parameters=self.parameters,
-                                   file_save=self.temp_dir)
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        task = RSVPCalibrationTask(parameters=self.parameters,
+                                   file_save=self.temp_dir,
+                                   fake=self.fake)
 
         timing_mock = mock()
         timing = [('a', 0.0)]
@@ -329,10 +342,11 @@ class TestRSVPCalibration(unittest.TestCase):
         save_session_mock.return_value = mock()
         handler_mock = Mock()
         trigger_handler_mock.return_value = handler_mock
-        task = RSVPCalibrationTask(win=self.win,
-                                   daq=self.daq,
-                                   parameters=self.parameters,
-                                   file_save=self.temp_dir)
+        when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        task = RSVPCalibrationTask(parameters=self.parameters,
+                                   file_save=self.temp_dir,
+                                   fake=self.fake)
         client_by_type_resp = {ContentType.EEG: self.eeg_client_mock}
         when(self.daq).client_by_type(
             ContentType.EEG).thenReturn(client_by_type_resp)

--- a/bcipy/task/tests/paradigm/rsvp/calibration/test_rsvp_calibration.py
+++ b/bcipy/task/tests/paradigm/rsvp/calibration/test_rsvp_calibration.py
@@ -362,8 +362,7 @@ class TestRSVPCalibration(unittest.TestCase):
         verify(self.eeg_client_mock, times=1).offset(0.0)
         verify(bcipy.task.calibration,
                times=1).offset_label('EEG', prefix='daq_sample_offset')
-        
-    
+
     @patch('bcipy.task.calibration.TriggerHandler')
     @patch('bcipy.task.calibration._save_session_related_data')
     def test_setup(self, save_session_mock, trigger_handler_mock):
@@ -380,7 +379,7 @@ class TestRSVPCalibration(unittest.TestCase):
         task = RSVPCalibrationTask(parameters=self.parameters,
                                    file_save=self.temp_dir,
                                    fake=self.fake)
-        
+
         self.assertTrue(task.initalized)
         verify(bcipy.task.calibration, times=1).init_acquisition(
             self.parameters, self.temp_dir, server=self.fake)
@@ -388,7 +387,7 @@ class TestRSVPCalibration(unittest.TestCase):
             self.parameters)
         self.assertEqual((self.daq, self.servers, self.win),
                          task.setup(self.parameters, self.temp_dir, self.fake))
-        
+
     @patch('bcipy.task.calibration.TriggerHandler')
     @patch('bcipy.task.calibration._save_session_related_data')
     def test_cleanup(self, save_session_mock, trigger_handler_mock):
@@ -398,7 +397,7 @@ class TestRSVPCalibration(unittest.TestCase):
         trigger_handler_mock.return_value = handler_mock
         when(bcipy.task.calibration.BaseCalibrationTask).setup(any(), any(), any()).thenReturn(
             (self.daq, self.servers, self.win))
-        
+
         # Mock the default cleanup
         when(bcipy.task.calibration.BaseCalibrationTask).write_offset_trigger().thenReturn(None)
         when(bcipy.task.calibration.BaseCalibrationTask).exit_display().thenReturn(None)
@@ -425,6 +424,7 @@ class TestRSVPCalibration(unittest.TestCase):
         verify(bcipy.task.calibration.BaseCalibrationTask, times=1).write_offset_trigger()
         verify(bcipy.task.calibration.BaseCalibrationTask, times=1).exit_display()
         verify(bcipy.task.calibration.BaseCalibrationTask, times=1).wait()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -130,7 +130,7 @@ class TestCopyPhrase(unittest.TestCase):
 
         when(bcipy.task.paradigm.rsvp.copy_phrase).CopyPhraseWrapper(
             ...).thenReturn(self.copy_phrase_wrapper)
-        
+
         # mock data for initial series
         series_gen = mock_inquiry_data()
         when(self.copy_phrase_wrapper).initialize_series().thenReturn(
@@ -618,7 +618,7 @@ class TestCopyPhrase(unittest.TestCase):
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
                                   fake=self.fake)
-        
+
         self.assertTrue(task.initalized)
         verify(bcipy.task.paradigm.rsvp.copy_phrase, times=1).init_acquisition(
             self.parameters, self.temp_dir, server=self.fake)
@@ -626,12 +626,12 @@ class TestCopyPhrase(unittest.TestCase):
             self.parameters)
         self.assertEqual((self.daq, self.servers, self.win),
                          task.setup(self.parameters, self.temp_dir, self.fake))
-        
+
     def test_cleanup(self):
         """Test cleanup"""
         when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
             (self.daq, self.servers, self.win))
-        
+
         # Mock the default cleanup
         when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).write_offset_trigger().thenReturn(None)
         when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).exit_display().thenReturn(None)

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -106,6 +106,7 @@ class TestCopyPhrase(unittest.TestCase):
                     ContentType.EEG: self.eeg_client_mock
                 }
             })
+        self.servers = mock()
         when(self.daq).get_client(ContentType.EEG).thenReturn(self.eeg_client_mock)
         self.temp_dir = tempfile.mkdtemp()
         self.model_metadata = mock({
@@ -129,6 +130,9 @@ class TestCopyPhrase(unittest.TestCase):
 
         when(bcipy.task.paradigm.rsvp.copy_phrase).CopyPhraseWrapper(
             ...).thenReturn(self.copy_phrase_wrapper)
+        
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         # mock data for initial series
         series_gen = mock_inquiry_data()
         when(self.copy_phrase_wrapper).initialize_series().thenReturn(
@@ -144,8 +148,6 @@ class TestCopyPhrase(unittest.TestCase):
     def test_initialize(self):
         """Test initialization"""
         RSVPCopyPhraseTask(
-            win=self.win,
-            daq=self.daq,
             parameters=self.parameters,
             file_save=self.temp_dir,
             signal_models=[self.signal_model],
@@ -154,8 +156,6 @@ class TestCopyPhrase(unittest.TestCase):
 
     def test_validate_parameters(self):
         task = RSVPCopyPhraseTask(
-            win=self.win,
-            daq=self.daq,
             parameters=self.parameters,
             file_save=self.temp_dir,
             signal_models=[self.signal_model],
@@ -169,8 +169,6 @@ class TestCopyPhrase(unittest.TestCase):
 
         with self.assertRaises(TaskConfigurationException):
             RSVPCopyPhraseTask(
-                win=self.win,
-                daq=self.daq,
                 parameters=parameters,
                 file_save=self.temp_dir,
                 signal_models=[self.signal_model],
@@ -182,8 +180,6 @@ class TestCopyPhrase(unittest.TestCase):
 
         with self.assertRaises(TaskConfigurationException):
             RSVPCopyPhraseTask(
-                win=self.win,
-                daq=self.daq,
                 parameters=self.parameters,
                 file_save=self.temp_dir,
                 signal_models=[self.signal_model],
@@ -195,8 +191,6 @@ class TestCopyPhrase(unittest.TestCase):
 
         with self.assertRaises(TaskConfigurationException):
             RSVPCopyPhraseTask(
-                win=self.win,
-                daq=self.daq,
                 parameters=self.parameters,
                 file_save=self.temp_dir,
                 signal_models=[self.signal_model],
@@ -209,9 +203,7 @@ class TestCopyPhrase(unittest.TestCase):
                                      user_input_mock):
         """User should be able to exit the task without viewing any inquiries"""
 
-        task = RSVPCopyPhraseTask(win=self.win,
-                                  daq=self.daq,
-                                  parameters=self.parameters,
+        task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
@@ -241,9 +233,7 @@ class TestCopyPhrase(unittest.TestCase):
                                               user_input_mock):
         """Test that fake data does not use the decision maker"""
 
-        task = RSVPCopyPhraseTask(win=self.win,
-                                  daq=self.daq,
-                                  parameters=self.parameters,
+        task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
@@ -280,9 +270,7 @@ class TestCopyPhrase(unittest.TestCase):
                          user_input_mock):
         """Test stoppage criteria for the max inquiry length"""
         self.parameters['max_inq_len'] = 2
-        task = RSVPCopyPhraseTask(win=self.win,
-                                  daq=self.daq,
-                                  parameters=self.parameters,
+        task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
@@ -321,9 +309,7 @@ class TestCopyPhrase(unittest.TestCase):
         self.parameters['task_text'] = 'Hello'
         self.parameters['spelled_letters_count'] = 4
 
-        task = RSVPCopyPhraseTask(win=self.win,
-                                  daq=self.daq,
-                                  parameters=self.parameters,
+        task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
@@ -358,9 +344,7 @@ class TestCopyPhrase(unittest.TestCase):
         """Spelled letters should reset if count is larger than copy phrase."""
         self.parameters['task_text'] = 'Hi'
         self.parameters['spelled_letters_count'] = 3
-        task = RSVPCopyPhraseTask(win=self.win,
-                                  daq=self.daq,
-                                  parameters=self.parameters,
+        task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
@@ -370,9 +354,7 @@ class TestCopyPhrase(unittest.TestCase):
 
     def test_stims_for_eeg(self):
         """The correct stims should be sent to get_device_data_for_decision"""
-        task = RSVPCopyPhraseTask(win=self.win,
-                                  daq=self.daq,
-                                  parameters=self.parameters,
+        task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
@@ -420,9 +402,7 @@ class TestCopyPhrase(unittest.TestCase):
                          user_input_mock):
         """Test that the task stops when the copy_phrase has been correctly spelled."""
         self.parameters['task_text'] = 'Hello'
-        task = RSVPCopyPhraseTask(win=self.win,
-                                  daq=self.daq,
-                                  parameters=self.parameters,
+        task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
@@ -449,9 +429,7 @@ class TestCopyPhrase(unittest.TestCase):
                                             user_input_mock):
         """Test that preview is displayed"""
         self.parameters['show_preview_inquiry'] = True
-        task = RSVPCopyPhraseTask(win=self.win,
-                                  daq=self.daq,
-                                  parameters=self.parameters,
+        task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
@@ -576,9 +554,7 @@ class TestCopyPhrase(unittest.TestCase):
                 'nontarget', 'nontarget'
             ]))
 
-        task = RSVPCopyPhraseTask(win=self.win,
-                                  daq=self.daq,
-                                  parameters=self.parameters,
+        task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -82,7 +82,7 @@ class TestCopyPhrase(unittest.TestCase):
             'trigger_type': 'image',
         }
         self.parameters = Parameters.from_cast_values(**parameters)
-
+        self.fake = True
         self.win = mock({'size': [500, 500], 'units': 'height'})
 
         device_spec = DeviceSpec(name='Testing',
@@ -106,7 +106,7 @@ class TestCopyPhrase(unittest.TestCase):
                     ContentType.EEG: self.eeg_client_mock
                 }
             })
-        self.servers = mock()
+        self.servers = [mock()]
         when(self.daq).get_client(ContentType.EEG).thenReturn(self.eeg_client_mock)
         self.temp_dir = tempfile.mkdtemp()
         self.model_metadata = mock({
@@ -131,8 +131,6 @@ class TestCopyPhrase(unittest.TestCase):
         when(bcipy.task.paradigm.rsvp.copy_phrase).CopyPhraseWrapper(
             ...).thenReturn(self.copy_phrase_wrapper)
         
-        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
-            (self.daq, self.servers, self.win))
         # mock data for initial series
         series_gen = mock_inquiry_data()
         when(self.copy_phrase_wrapper).initialize_series().thenReturn(
@@ -147,25 +145,31 @@ class TestCopyPhrase(unittest.TestCase):
 
     def test_initialize(self):
         """Test initialization"""
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         RSVPCopyPhraseTask(
             parameters=self.parameters,
             file_save=self.temp_dir,
             signal_models=[self.signal_model],
             language_model=self.language_model,
-            fake=True)
+            fake=self.fake)
 
     def test_validate_parameters(self):
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         task = RSVPCopyPhraseTask(
             parameters=self.parameters,
             file_save=self.temp_dir,
             signal_models=[self.signal_model],
             language_model=self.language_model,
-            fake=True)
+            fake=self.fake)
 
         task.validate_parameters()
 
     def test_validate_parameters_throws_task_exception_missing_parameter(self):
         parameters = {}
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
 
         with self.assertRaises(TaskConfigurationException):
             RSVPCopyPhraseTask(
@@ -173,10 +177,12 @@ class TestCopyPhrase(unittest.TestCase):
                 file_save=self.temp_dir,
                 signal_models=[self.signal_model],
                 language_model=self.language_model,
-                fake=True)
+                fake=self.fake)
 
     def test_validate_parameters_throws_task_exception_excess_prestim_length(self):
         self.parameters['prestim_length'] = 1000
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
 
         with self.assertRaises(TaskConfigurationException):
             RSVPCopyPhraseTask(
@@ -184,10 +190,12 @@ class TestCopyPhrase(unittest.TestCase):
                 file_save=self.temp_dir,
                 signal_models=[self.signal_model],
                 language_model=self.language_model,
-                fake=True)
+                fake=self.fake)
 
     def test_validate_parameters_throws_task_exception_excess_trial_window(self):
         self.parameters['trial_window'] = "0.0:1000.0"
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
 
         with self.assertRaises(TaskConfigurationException):
             RSVPCopyPhraseTask(
@@ -195,19 +203,20 @@ class TestCopyPhrase(unittest.TestCase):
                 file_save=self.temp_dir,
                 signal_models=[self.signal_model],
                 language_model=self.language_model,
-                fake=True)
+                fake=self.fake)
 
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_user_input')
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.trial_complete_message')
     def test_execute_without_inquiry(self, message_mock,
                                      user_input_mock):
         """User should be able to exit the task without viewing any inquiries"""
-
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
-                                  fake=True)
+                                  fake=self.fake)
 
         user_input_mock.return_value = False
 
@@ -232,12 +241,13 @@ class TestCopyPhrase(unittest.TestCase):
     def test_execute_fake_data_single_inquiry(self, process_data_mock, message_mock,
                                               user_input_mock):
         """Test that fake data does not use the decision maker"""
-
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
-                                  fake=True)
+                                  fake=self.fake)
 
         # Execute a single inquiry then `escape` to stop
         user_input_mock.side_effect = [True, False]
@@ -270,11 +280,13 @@ class TestCopyPhrase(unittest.TestCase):
                          user_input_mock):
         """Test stoppage criteria for the max inquiry length"""
         self.parameters['max_inq_len'] = 2
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
-                                  fake=True)
+                                  fake=self.fake)
 
         # Don't provide any `escape` input from the user
         user_input_mock.return_value = True
@@ -308,12 +320,13 @@ class TestCopyPhrase(unittest.TestCase):
         """Test that the task stops when the copy_phrase has been correctly spelled."""
         self.parameters['task_text'] = 'Hello'
         self.parameters['spelled_letters_count'] = 4
-
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
-                                  fake=True)
+                                  fake=self.fake)
 
         # Don't provide any `escape` input from the user
         user_input_mock.return_value = True
@@ -344,21 +357,25 @@ class TestCopyPhrase(unittest.TestCase):
         """Spelled letters should reset if count is larger than copy phrase."""
         self.parameters['task_text'] = 'Hi'
         self.parameters['spelled_letters_count'] = 3
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
-                                  fake=True)
+                                  fake=self.fake)
 
         self.assertEqual(task.starting_spelled_letters(), 0)
 
     def test_stims_for_eeg(self):
         """The correct stims should be sent to get_device_data_for_decision"""
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
-                                  fake=True)
+                                  fake=self.fake)
         timings1 = [['calibration_trigger', 2.0539278959913645],
                     ['+', 3.7769652379938634], ['Y', 4.247819707990857],
                     ['S', 4.46274590199755], ['W', 4.679621118993964],
@@ -400,13 +417,15 @@ class TestCopyPhrase(unittest.TestCase):
     @patch('bcipy.task.paradigm.rsvp.copy_phrase.get_device_data_for_decision')
     def test_next_letter(self, process_data_mock, message_mock,
                          user_input_mock):
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         """Test that the task stops when the copy_phrase has been correctly spelled."""
         self.parameters['task_text'] = 'Hello'
         task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
-                                  fake=True)
+                                  fake=self.fake)
         task.spelled_text = 'H'
         self.assertEqual(task.next_target(), 'e')
 
@@ -429,11 +448,13 @@ class TestCopyPhrase(unittest.TestCase):
                                             user_input_mock):
         """Test that preview is displayed"""
         self.parameters['show_preview_inquiry'] = True
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         task = RSVPCopyPhraseTask(parameters=self.parameters,
                                   file_save=self.temp_dir,
                                   signal_models=[self.signal_model],
                                   language_model=self.language_model,
-                                  fake=True)
+                                  fake=self.fake)
 
         # Execute a single inquiry then `escape` to stop
         user_input_mock.side_effect = [True, False]
@@ -509,7 +530,8 @@ class TestCopyPhrase(unittest.TestCase):
 
         when(bcipy.task.paradigm.rsvp.copy_phrase).CopyPhraseWrapper(
             ...).thenReturn(copy_phrase_wrapper_mock)
-
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
         # mock data for initial series
         when(copy_phrase_wrapper_mock).initialize_series().thenReturn(
             (False,
@@ -581,6 +603,64 @@ class TestCopyPhrase(unittest.TestCase):
         with open(Path(task.session_save_location), 'r', encoding=DEFAULT_ENCODING) as json_file:
             session = Session.from_dict(json.load(json_file))
             self.assertEqual(1, session.total_number_series)
+
+    def test_setup(self):
+        """Test setup"""
+
+        when(bcipy.task.paradigm.rsvp.copy_phrase).init_acquisition(any(), any(), server=self.fake).thenReturn(
+            (self.daq, self.servers))
+        when(bcipy.task.paradigm.rsvp.copy_phrase).init_display_window(self.parameters).thenReturn(
+            self.win)
+
+        self.assertFalse(RSVPCopyPhraseTask.initalized)
+        task = RSVPCopyPhraseTask(parameters=self.parameters,
+                                  file_save=self.temp_dir,
+                                  signal_models=[self.signal_model],
+                                  language_model=self.language_model,
+                                  fake=self.fake)
+        
+        self.assertTrue(task.initalized)
+        verify(bcipy.task.paradigm.rsvp.copy_phrase, times=1).init_acquisition(
+            self.parameters, self.temp_dir, server=self.fake)
+        verify(bcipy.task.paradigm.rsvp.copy_phrase, times=1).init_display_window(
+            self.parameters)
+        self.assertEqual((self.daq, self.servers, self.win),
+                         task.setup(self.parameters, self.temp_dir, self.fake))
+        
+    def test_cleanup(self):
+        """Test cleanup"""
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        
+        # Mock the default cleanup
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).write_offset_trigger().thenReturn(None)
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).exit_display().thenReturn(None)
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).save_session_data().thenReturn(None)
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).wait().thenReturn(None)
+
+        # Mock the initialized cleanup
+        when(self.daq).stop_acquisition().thenReturn(None)
+        when(self.daq).cleanup().thenReturn(None)
+        when(self.servers[0]).stop().thenReturn(None)
+        when(self.win).close().thenReturn(None)
+        task = RSVPCopyPhraseTask(parameters=self.parameters,
+                                  file_save=self.temp_dir,
+                                  signal_models=[self.signal_model],
+                                  language_model=self.language_model,
+                                  fake=self.fake)
+        # because the task is not initialized via setup, we need to set it to True here
+        task.initalized = True
+
+        task.cleanup()
+
+        verify(self.daq, times=1).stop_acquisition()
+        verify(self.daq, times=1).cleanup()
+        verify(self.servers[0], times=1).stop()
+        verify(self.win, times=1).close()
+        verify(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask, times=1).setup(any(), any(), any())
+        verify(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask, times=1).write_offset_trigger()
+        verify(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask, times=1).exit_display()
+        verify(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask, times=1).wait()
 
 
 def mock_inquiry_data():

--- a/bcipy/tests/test_bci_main.py
+++ b/bcipy/tests/test_bci_main.py
@@ -1,7 +1,7 @@
 import logging
 import unittest
 
-from mockito import (any, mock, unstub, verify, verifyNoUnwantedInteractions,
+from mockito import (mock, unstub, verify, verifyNoUnwantedInteractions,
                      verifyStubbedInvocationsAreUsed, when)
 
 from bcipy import main
@@ -285,7 +285,6 @@ class TestExecuteTask(unittest.TestCase):
             signal_models=[],
             fake=self.fake,
         )
-
 
     def test_execute_language_model_enabled(self) -> None:
         self.fake = False

--- a/bcipy/tests/test_bci_main.py
+++ b/bcipy/tests/test_bci_main.py
@@ -8,7 +8,7 @@ from bcipy import main
 from bcipy.config import (DEFAULT_EXPERIMENT_ID, DEFAULT_PARAMETERS_PATH,
                           STATIC_AUDIO_PATH)
 from bcipy.helpers.exceptions import UnregisteredExperimentException
-from bcipy.main import _clean_up_session, bci_main, execute_task
+from bcipy.main import bci_main, execute_task
 from bcipy.task.paradigm.rsvp.calibration.calibration import RSVPCalibrationTask
 from bcipy.task.paradigm.rsvp.copy_phrase import RSVPCopyPhraseTask
 
@@ -63,7 +63,6 @@ class TestBciMain(unittest.TestCase):
             self.save_location,
             version=self.system_info['bcipy_version']
         )
-        when(main).collect_experiment_field_data(self.experiment, self.save_location)
         when(main).execute_task(
             self.task,
             self.parameters,
@@ -89,7 +88,6 @@ class TestBciMain(unittest.TestCase):
         verify(main, times=1).configure_logger(
             self.save_location,
             version=self.system_info['bcipy_version'])
-        verify(main, times=1).collect_experiment_field_data(self.experiment, self.save_location)
         verify(main, times=1).execute_task(self.task, self.parameters, self.save_location, self.alert, self.fake)
 
     def test_bci_main_invalid_experiment(self) -> None:
@@ -126,7 +124,6 @@ class TestBciMain(unittest.TestCase):
             self.save_location,
             version=self.system_info['bcipy_version']
         )
-        when(main).collect_experiment_field_data(self.experiment, self.save_location)
         when(main).execute_task(
             self.task,
             self.parameters,
@@ -152,7 +149,6 @@ class TestBciMain(unittest.TestCase):
         verify(main, times=1).configure_logger(
             self.save_location,
             version=self.system_info['bcipy_version'])
-        verify(main, times=1).collect_experiment_field_data(self.experiment, self.save_location)
         verify(main, times=1).execute_task(self.task, self.parameters, self.save_location, self.alert, self.fake)
 
     def test_bci_main_visualize_disabled(self) -> None:
@@ -174,7 +170,6 @@ class TestBciMain(unittest.TestCase):
             self.save_location,
             version=self.system_info['bcipy_version']
         )
-        when(main).collect_experiment_field_data(self.experiment, self.save_location)
         when(main).execute_task(
             self.task,
             self.parameters,
@@ -199,7 +194,6 @@ class TestBciMain(unittest.TestCase):
         verify(main, times=1).configure_logger(
             self.save_location,
             version=self.system_info['bcipy_version'])
-        verify(main, times=1).collect_experiment_field_data(self.experiment, self.save_location)
         verify(main, times=1).execute_task(self.task, self.parameters, self.save_location, self.alert, self.fake)
 
     def test_bci_main_fake(self) -> None:
@@ -223,7 +217,6 @@ class TestBciMain(unittest.TestCase):
             self.save_location,
             version=self.system_info['bcipy_version']
         )
-        when(main).collect_experiment_field_data(self.experiment, self.save_location)
         when(main).execute_task(
             self.task,
             self.parameters,
@@ -249,57 +242,7 @@ class TestBciMain(unittest.TestCase):
         verify(main, times=1).configure_logger(
             self.save_location,
             version=self.system_info['bcipy_version'])
-        verify(main, times=1).collect_experiment_field_data(self.experiment, self.save_location)
         verify(main, times=1).execute_task(self.task, self.parameters, self.save_location, self.alert, fake)
-
-
-class TestCleanUpSession(unittest.TestCase):
-
-    def tearDown(self) -> None:
-        unstub()
-
-    def test_clean_up_no_server(self) -> None:
-        daq = mock()
-        display = mock()
-        servers = []
-
-        # mock the required daq calls
-        when(daq).stop_acquisition()
-        when(daq).cleanup()
-
-        # mock the required display call
-        when(display).close()
-
-        response = _clean_up_session(display, daq, servers)
-        self.assertTrue(response)
-
-        verify(daq, times=1).stop_acquisition()
-        verify(daq, times=1).cleanup()
-        verify(display, times=1).close()
-
-    def test_clean_up_with_server(self) -> None:
-        daq = mock()
-        display = mock()
-        server = mock()
-        servers = [server]
-
-        # mock the required daq calls
-        when(daq).stop_acquisition()
-        when(daq).cleanup()
-
-        # mock the required display call
-        when(display).close()
-
-        # mock the required server call
-        when(server).stop()
-
-        response = _clean_up_session(display, daq, servers)
-        self.assertTrue(response)
-
-        verify(daq, times=1).stop_acquisition()
-        verify(daq, times=1).cleanup()
-        verify(display, times=1).close()
-        verify(server, times=1).stop()
 
 
 class TestExecuteTask(unittest.TestCase):
@@ -316,26 +259,14 @@ class TestExecuteTask(unittest.TestCase):
         self.task = RSVPCalibrationTask
         self.fake = True
         self.display_mock = mock()
-        self.daq = mock()
-        self.eeg_client = mock()
-        when(self.daq).get_client('EEG').thenReturn(self.eeg_client)
         self.server = [mock()]
 
     def tearDown(self) -> None:
         unstub()
 
     def test_execute_task_fake_data(self) -> None:
-        response = (self.daq, self.server)
-        when(main).init_eeg_acquisition(
-            self.parameters,
-            self.save_folder,
-            server=self.fake
-        ).thenReturn(response)
-        when(main).init_display_window(self.parameters).thenReturn(self.display_mock)
-        when(main).print_message(self.display_mock, any())
+
         when(main).start_task(
-            self.display_mock,
-            self.daq,
             self.task,
             self.parameters,
             self.save_folder,
@@ -343,19 +274,10 @@ class TestExecuteTask(unittest.TestCase):
             signal_models=[],
             fake=self.fake,
         )
-        when(main)._clean_up_session(self.display_mock, self.daq, self.server)
 
         execute_task(self.task, self.parameters, self.save_folder, self.alert, self.fake)
 
-        verify(main, times=1).init_eeg_acquisition(
-            self.parameters,
-            self.save_folder,
-            server=self.fake)
-        verify(main, times=1).init_display_window(self.parameters)
-        verify(main, times=1).print_message(self.display_mock, any())
         verify(main, times=1).start_task(
-            self.display_mock,
-            self.daq,
             self.task,
             self.parameters,
             self.save_folder,
@@ -363,100 +285,7 @@ class TestExecuteTask(unittest.TestCase):
             signal_models=[],
             fake=self.fake,
         )
-        verify(main, times=1)._clean_up_session(self.display_mock, self.daq, self.server)
 
-    def test_execute_task_real_data(self) -> None:
-        self.fake = False
-        response = (self.daq, self.server)
-        when(main).init_eeg_acquisition(
-            self.parameters,
-            self.save_folder,
-            server=self.fake
-        ).thenReturn(response)
-        when(main).init_display_window(self.parameters).thenReturn(self.display_mock)
-        when(main).print_message(self.display_mock, any())
-        when(main).start_task(
-            self.display_mock,
-            self.daq,
-            self.task,
-            self.parameters,
-            self.save_folder,
-            language_model=None,
-            signal_models=[],
-            fake=self.fake,
-        )
-        when(main)._clean_up_session(self.display_mock, self.daq, self.server)
-
-        execute_task(self.task, self.parameters, self.save_folder, self.alert, self.fake)
-
-        verify(main, times=1).init_eeg_acquisition(
-            self.parameters,
-            self.save_folder,
-            server=self.fake)
-        verify(main, times=1).init_display_window(self.parameters)
-        verify(main, times=1).print_message(self.display_mock, any())
-        verify(main, times=1).start_task(
-            self.display_mock,
-            self.daq,
-            self.task,
-            self.parameters,
-            self.save_folder,
-            language_model=None,
-            signal_models=[],
-            fake=self.fake,
-        )
-        verify(main, times=1)._clean_up_session(self.display_mock, self.daq, self.server)
-
-    def test_execute_task_non_calibration_real_data(self) -> None:
-        self.fake = False
-        model_path = "data/mycalib/"
-        self.parameters['signal_model_path'] = model_path
-        self.task = RSVPCopyPhraseTask
-        signal_model = mock()
-        language_model = mock()
-        file_name = 'test'
-        load_model_response = [signal_model]
-        eeg_response = (self.daq, self.server)
-        when(main).init_eeg_acquisition(
-            self.parameters,
-            self.save_folder,
-            server=self.fake).thenReturn(eeg_response)
-        when(main).init_display_window(self.parameters).thenReturn(self.display_mock)
-        when(main).print_message(self.display_mock, any())
-        when(main).load_signal_models(directory=model_path).thenReturn(load_model_response)
-        when(main).init_language_model(self.parameters).thenReturn(language_model)
-        when(main).start_task(
-            self.display_mock,
-            self.daq,
-            self.task,
-            self.parameters,
-            self.save_folder,
-            language_model=language_model,
-            signal_models=[signal_model],
-            fake=self.fake,
-        )
-        when(main)._clean_up_session(self.display_mock, self.daq, self.server)
-
-        execute_task(self.task, self.parameters, self.save_folder, self.alert, self.fake)
-
-        verify(main, times=1).init_eeg_acquisition(
-            self.parameters,
-            self.save_folder,
-            server=self.fake)
-        verify(main, times=1).init_display_window(self.parameters)
-        verify(main, times=1).print_message(self.display_mock, any())
-        verify(main, times=1).start_task(
-            self.display_mock,
-            self.daq,
-            self.task,
-            self.parameters,
-            self.save_folder,
-            language_model=language_model,
-            signal_models=[signal_model],
-            fake=self.fake,
-        )
-        verify(main, times=1).load_signal_models(directory=model_path)
-        verify(main, times=1)._clean_up_session(self.display_mock, self.daq, self.server)
 
     def test_execute_language_model_enabled(self) -> None:
         self.fake = False
@@ -464,23 +293,13 @@ class TestExecuteTask(unittest.TestCase):
 
         # mock the signal and language models
         signal_model = mock()
-        file_name = 'test'
         language_model = mock()
         load_model_response = [signal_model]
 
         # mock the behavior of execute task
-        eeg_response = (self.daq, self.server)
-        when(main).init_eeg_acquisition(
-            self.parameters,
-            self.save_folder,
-            server=self.fake).thenReturn(eeg_response)
         when(main).init_language_model(self.parameters).thenReturn(language_model)
-        when(main).init_display_window(self.parameters).thenReturn(self.display_mock)
-        when(main).print_message(self.display_mock, any())
         when(main).load_signal_models(directory='').thenReturn(load_model_response)
         when(main).start_task(
-            self.display_mock,
-            self.daq,
             self.task,
             self.parameters,
             self.save_folder,
@@ -488,19 +307,10 @@ class TestExecuteTask(unittest.TestCase):
             signal_models=[signal_model],
             fake=self.fake,
         )
-        when(main)._clean_up_session(self.display_mock, self.daq, self.server)
 
         execute_task(self.task, self.parameters, self.save_folder, self.alert, self.fake)
 
-        verify(main, times=1).init_eeg_acquisition(
-            self.parameters,
-            self.save_folder,
-            server=self.fake)
-        verify(main, times=1).init_display_window(self.parameters)
-        verify(main, times=1).print_message(self.display_mock, any())
         verify(main, times=1).start_task(
-            self.display_mock,
-            self.daq,
             self.task,
             self.parameters,
             self.save_folder,
@@ -510,21 +320,10 @@ class TestExecuteTask(unittest.TestCase):
         )
         verify(main, times=1).load_signal_models(directory='')
         verify(main, times=1).init_language_model(self.parameters)
-        verify(main, times=1)._clean_up_session(self.display_mock, self.daq, self.server)
 
     def test_execute_with_alert_enabled(self):
         expected_alert_path = f"{STATIC_AUDIO_PATH}/{self.parameters['alert_sound_file']}"
-        response = (self.daq, self.server)
-        when(main).init_eeg_acquisition(
-            self.parameters,
-            self.save_folder,
-            server=self.fake,
-        ).thenReturn(response)
-        when(main).init_display_window(self.parameters).thenReturn(self.display_mock)
-        when(main).print_message(self.display_mock, any())
         when(main).start_task(
-            self.display_mock,
-            self.daq,
             self.task,
             self.parameters,
             self.save_folder,
@@ -532,20 +331,11 @@ class TestExecuteTask(unittest.TestCase):
             signal_models=[],
             fake=self.fake,
         )
-        when(main)._clean_up_session(self.display_mock, self.daq, self.server)
         when(main).play_sound(expected_alert_path)
 
         execute_task(self.task, self.parameters, self.save_folder, True, self.fake)
 
-        verify(main, times=1).init_eeg_acquisition(
-            self.parameters,
-            self.save_folder,
-            server=self.fake)
-        verify(main, times=1).init_display_window(self.parameters)
-        verify(main, times=1).print_message(self.display_mock, any())
         verify(main, times=1).start_task(
-            self.display_mock,
-            self.daq,
             self.task,
             self.parameters,
             self.save_folder,
@@ -553,7 +343,6 @@ class TestExecuteTask(unittest.TestCase):
             signal_models=[],
             fake=self.fake,
         )
-        verify(main, times=1)._clean_up_session(self.display_mock, self.daq, self.server)
         verify(main, times=1).play_sound(expected_alert_path)
 
 


### PR DESCRIPTION
# Overview

Update the codebase to move initialization and cleanup to the Task itself to support use with orchestration.

## Ticket

https://www.pivotaltracker.com/story/show/187701313
https://www.pivotaltracker.com/story/show/187701285

## Contributions

- Refactor bci_main to pass parameters, save data, and models only
     - We may want to move model loading to this as well 
- Add cleanup and setup methods to Tasks
- Refactor naming for clarity (init_acquistion vs. init_eeg_acquisition) 
- Update unittests as needed
- Change default preview inquiry parameter to false 

## Test

- `make test-all`
- With fake data on, I ran all available tasks and ensured expected behaviour. 

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Updated docstrings, some README updates would be helpful with full orchestrator integration. 

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? Not yet!
