### PR TITLE
Surface btn error probability

### DIFF
--- a/bcipy/parameters/parameters.json
+++ b/bcipy/parameters/parameters.json
@@ -686,6 +686,14 @@
     "recommended_values": "",
     "type": "bool"
   },
+  "preview_inquiry_error_prob": {
+    "value": "0.05",
+    "section": "bci_config",
+    "readableName": "Preview Inquiry Button Error Probability",
+    "helpTip": "Specifies the probability of a button error during inquiry preview. Default: 0.05",
+    "recommended_values": "",
+    "type": "float"
+  },
   "preview_inquiry_progress_method": {
     "value": "0",
     "section": "bci_config",

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -96,7 +96,7 @@ class RSVPCopyPhraseTask(Task):
         'is_txt_stim', 'lm_backspace_prob', 'backspace_always_shown',
         'decision_threshold', 'max_inq_len', 'max_inq_per_series', 'max_minutes', 'max_selections', 'min_inq_len',
         'show_feedback', 'feedback_duration',
-        'show_preview_inquiry', 'preview_inquiry_isi',
+        'show_preview_inquiry', 'preview_inquiry_isi', 'preview_inquiry_error_prob',
         'preview_inquiry_key_input', 'preview_inquiry_length', 'preview_inquiry_progress_method',
         'spelled_letters_count',
         'stim_color', 'stim_height', 'stim_jitter', 'stim_length', 'stim_number',
@@ -129,7 +129,7 @@ class RSVPCopyPhraseTask(Task):
 
         self.alp = alphabet(self.parameters)
 
-        self.button_press_error_prob = 0.05
+        self.button_press_error_prob = parameters['preview_inquiry_error_prob']
 
         self.evidence_evaluators = self.init_evidence_evaluators(signal_models)
 

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -73,6 +73,7 @@ class TestCopyPhrase(unittest.TestCase):
             'task_color': 'white',
             'task_height': 0.1,
             'task_text': 'HELLO_WORLD',
+            "preview_inquiry_error_prob": 0.05,
             'info_pos_x': 0.0,
             'info_pos_y': -0.75,
             'time_fixation': 0.5,


### PR DESCRIPTION
# Overview

This PR surfaces an error probability value used during inquiry preview allowing user change.

## Ticket

https://www.pivotaltracker.com/story/show/187994038

## Contributions

- Add a new parameter for button error probability and require it in RSVP Copy Phrase

## Test

- `make test-all`

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? N/a

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? TODO
