### PR TITLE
Matrix Inquiry Preview

### DIFF
--- a/bcipy/display/components/button_press_handler.py
+++ b/bcipy/display/components/button_press_handler.py
@@ -4,7 +4,6 @@ from typing import List, Optional, Type
 
 from psychopy import core, event
 
-from bcipy.display.main import ButtonPressMode
 from bcipy.helpers.clock import Clock
 from bcipy.helpers.task import get_key_press
 
@@ -107,13 +106,3 @@ class PreviewOnlyButtonPressHandler(ButtonPressHandler):
     def accept_result(self) -> bool:
         """Should the result of a button press be affirmative"""
         return True
-
-
-def get_button_handler_class(
-        mode: ButtonPressMode) -> Type[ButtonPressHandler]:
-    """Get the appropriate handler constructor for the given button press mode."""
-    return {
-        ButtonPressMode.NOTHING: PreviewOnlyButtonPressHandler,
-        ButtonPressMode.ACCEPT: AcceptButtonPressHandler,
-        ButtonPressMode.REJECT: RejectButtonPressHandler
-    }.get(mode)

--- a/bcipy/display/components/button_press_handler.py
+++ b/bcipy/display/components/button_press_handler.py
@@ -1,0 +1,119 @@
+"""Handles button press interactions"""
+from abc import ABC, abstractmethod
+from typing import List, Optional, Type
+
+from psychopy import core, event
+
+from bcipy.display.main import ButtonPressMode
+from bcipy.helpers.clock import Clock
+from bcipy.helpers.task import get_key_press
+
+
+class ButtonPressHandler(ABC):
+    """Handles button press events."""
+
+    def __init__(self,
+                 max_wait: float,
+                 key_input: str,
+                 clock: Optional[Clock] = None,
+                 timer: Type[Clock] = core.CountdownTimer):
+        """
+        Parameters
+        ----------
+            wait_length - maximum number of seconds to wait for a key press
+            key_input - key that we are listening for.
+            clock - clock used to associate the key event with a timestamp
+        """
+        self.max_wait = max_wait
+        self.key_input = key_input
+        self.clock = clock or Clock()
+        self.response: Optional[List] = None
+
+        self._timer = None
+        self.make_timer = timer
+
+    @property
+    def response_label(self) -> Optional[str]:
+        """Label for the latest button press"""
+        return self.response[0] if self.response else None
+
+    @property
+    def response_timestamp(self) -> Optional[float]:
+        """Timestamp for the latest button response"""
+        return self.response[1] if self.response else None
+
+    def _reset(self) -> None:
+        """Reset any existing events and timers."""
+        self._timer = self.make_timer(self.max_wait)
+        self.response = None
+        event.clearEvents(eventType='keyboard')
+        self._timer.reset()
+
+    def await_response(self):
+        """Wait for a button response for a maximum number of seconds. Wait
+        period could end early if the class determines that some other
+        criteria have been met (such as an acceptable response)."""
+
+        self._reset()
+        while self._should_keep_waiting() and self._within_wait_period():
+            self._check_key_press()
+
+    def has_response(self) -> bool:
+        """Whether a response has been provided"""
+        return self.response is not None
+
+    def _check_key_press(self) -> None:
+        """Check for any key press events and set the latest as the response."""
+        self.response = get_key_press(
+            key_list=[self.key_input],
+            clock=self.clock,
+        )
+
+    def _within_wait_period(self) -> bool:
+        """Check that we are within the allotted time for a response."""
+        return self._timer and self._timer.getTime() > 0
+
+    def _should_keep_waiting(self) -> bool:
+        """Check that we should keep waiting for responses."""
+        return not self.has_response()
+
+    @abstractmethod
+    def accept_result(self) -> bool:
+        """Should the result of a button press be affirmative"""
+
+
+class AcceptButtonPressHandler(ButtonPressHandler):
+    """ButtonPressHandler where a matching button press indicates an affirmative result."""
+
+    def accept_result(self) -> bool:
+        """Should the result of a button press be affirmative"""
+        return self.has_response()
+
+
+class RejectButtonPressHandler(ButtonPressHandler):
+    """ButtonPressHandler where a matching button press indicates a rejection."""
+
+    def accept_result(self) -> bool:
+        """Should the result of a button press be affirmative"""
+        return not self.has_response()
+
+
+class PreviewOnlyButtonPressHandler(ButtonPressHandler):
+    """ButtonPressHandler that waits for the entire span of the configured max_wait."""
+
+    def _should_keep_waiting(self) -> bool:
+        return True
+
+    def accept_result(self) -> bool:
+        """Should the result of a button press be affirmative"""
+        return True
+
+
+def get_button_handler_class(
+        mode: ButtonPressMode) -> Type[ButtonPressHandler]:
+    """Get the appropriate handler constructor for the given button press mode."""
+    return {
+        ButtonPressMode.NOTHING: PreviewOnlyButtonPressHandler,
+        ButtonPressMode.ACCEPT: AcceptButtonPressHandler,
+        ButtonPressMode.REJECT: RejectButtonPressHandler
+    }.get(mode)

--- a/bcipy/display/components/button_press_handler.py
+++ b/bcipy/display/components/button_press_handler.py
@@ -2,7 +2,8 @@
 from abc import ABC, abstractmethod
 from typing import List, Optional, Type
 
-from psychopy import core, event
+from psychopy import event
+from psychopy.core import CountdownTimer
 
 from bcipy.helpers.clock import Clock
 from bcipy.helpers.task import get_key_press
@@ -15,7 +16,7 @@ class ButtonPressHandler(ABC):
                  max_wait: float,
                  key_input: str,
                  clock: Optional[Clock] = None,
-                 timer: Type[Clock] = core.CountdownTimer):
+                 timer: Type[CountdownTimer] = CountdownTimer):
         """
         Parameters
         ----------
@@ -28,7 +29,7 @@ class ButtonPressHandler(ABC):
         self.clock = clock or Clock()
         self.response: Optional[List] = None
 
-        self._timer = None
+        self._timer: Optional[CountdownTimer] = None
         self.make_timer = timer
 
     @property
@@ -48,7 +49,7 @@ class ButtonPressHandler(ABC):
         event.clearEvents(eventType='keyboard')
         self._timer.reset()
 
-    def await_response(self):
+    def await_response(self) -> None:
         """Wait for a button response for a maximum number of seconds. Wait
         period could end early if the class determines that some other
         criteria have been met (such as an acceptable response)."""
@@ -70,7 +71,7 @@ class ButtonPressHandler(ABC):
 
     def _within_wait_period(self) -> bool:
         """Check that we are within the allotted time for a response."""
-        return self._timer and self._timer.getTime() > 0
+        return (self._timer is not None) and (self._timer.getTime() > 0)
 
     def _should_keep_waiting(self) -> bool:
         """Check that we should keep waiting for responses."""

--- a/bcipy/display/demo/matrix/demo_calibration_matrix.py
+++ b/bcipy/display/demo/matrix/demo_calibration_matrix.py
@@ -5,6 +5,7 @@ from psychopy import core
 from bcipy.display import (InformationProperties, StimuliProperties,
                            init_display_window)
 from bcipy.display.components.task_bar import CalibrationTaskBar
+from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.matrix.display import MatrixDisplay
 
 info = InformationProperties(
@@ -34,11 +35,17 @@ win = init_display_window(window_parameters)
 win.recordFrameIntervals = False
 
 task_bar = CalibrationTaskBar(win, inquiry_count=4, current_index=0, font='Arial')
+preview_config = PreviewParams(show_preview_inquiry=True,
+                               preview_inquiry_length=2,
+                               preview_inquiry_key_input='return',
+                               preview_inquiry_progress_method=2,
+                               preview_inquiry_isi=1)
 matrix_display = MatrixDisplay(win,
                                experiment_clock,
                                stim_properties,
                                task_bar=task_bar,
-                               info=info)
+                               info=info,
+                               preview_config=preview_config)
 
 time_target = 1
 time_fixation = 0.5

--- a/bcipy/display/demo/matrix/demo_copyphrase_matrix.py
+++ b/bcipy/display/demo/matrix/demo_copyphrase_matrix.py
@@ -8,6 +8,7 @@ from psychopy import core
 from bcipy.display import (InformationProperties, StimuliProperties,
                            init_display_window)
 from bcipy.display.components.task_bar import CopyPhraseTaskBar
+from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.matrix.display import MatrixDisplay
 
 font = "Overpass Mono"
@@ -72,13 +73,18 @@ task_bar = CopyPhraseTaskBar(win,
                              spelled_text='COPY_PHA',
                              colors=['white', 'green'],
                              font=font)
-
+preview_config = PreviewParams(show_preview_inquiry=True,
+                               preview_inquiry_length=2,
+                               preview_inquiry_key_input='return',
+                               preview_inquiry_progress_method=0,
+                               preview_inquiry_isi=1)
 display = MatrixDisplay(win,
                         experiment_clock,
                         stim_properties,
                         task_bar,
                         info,
-                        should_prompt_target=False)
+                        should_prompt_target=False,
+                        preview_config=preview_config)
 
 counter = 0
 

--- a/bcipy/display/demo/rsvp/demo_calibration_rsvp.py
+++ b/bcipy/display/demo/rsvp/demo_calibration_rsvp.py
@@ -1,9 +1,11 @@
 from psychopy import core
 
+from bcipy.display import (InformationProperties, StimuliProperties,
+                           init_display_window)
+from bcipy.display.components.task_bar import CalibrationTaskBar
+from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.rsvp.mode.calibration import CalibrationDisplay
 from bcipy.helpers.clock import Clock
-from bcipy.display import InformationProperties, StimuliProperties, init_display_window
-from bcipy.display.components.task_bar import CalibrationTaskBar
 
 info = InformationProperties(
     info_color=['White'],
@@ -44,7 +46,7 @@ window_parameters = {
     'full_screen': False,
     'window_height': 500,
     'window_width': 500,
-    'stim_screen': 1,
+    'stim_screen': 0,
     'background_color': 'black'
 }
 win = init_display_window(window_parameters)
@@ -70,13 +72,20 @@ task_bar = CalibrationTaskBar(win,
                               inquiry_count=100,
                               current_index=0,
                               font='Arial')
+
+preview_config = PreviewParams(show_preview_inquiry=True,
+                               preview_inquiry_length=2,
+                               preview_inquiry_key_input='return',
+                               preview_inquiry_progress_method=0,
+                               preview_inquiry_isi=1)
 rsvp = CalibrationDisplay(
     win,
     clock,
     experiment_clock,
     stimuli,
     task_bar,
-    info)
+    info,
+    preview_config=preview_config)
 
 
 for idx_o in range(len(task_text)):

--- a/bcipy/display/demo/rsvp/demo_copyphrase_rsvp.py
+++ b/bcipy/display/demo/rsvp/demo_copyphrase_rsvp.py
@@ -4,24 +4,23 @@
 
 from psychopy import core
 
-from bcipy.display import (
-    init_display_window,
-    InformationProperties,
-    PreviewInquiryProperties,
-    StimuliProperties)
+from bcipy.display import (InformationProperties, StimuliProperties,
+                           init_display_window)
 from bcipy.display.components.task_bar import CopyPhraseTaskBar
+from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.rsvp.mode.copy_phrase import CopyPhraseDisplay
 from bcipy.helpers.clock import Clock
 
 # Initialize Stimulus
 is_txt_stim = True
-show_preview_inquiry = True
+
 
 # Inquiry preview
-preview_inquiry_length = 5
-preview_inquiry_key_input = 'space'
-preview_inquiry_progress_method = 1  # press to accept ==1 wait to accept ==2
-preview_inquiry_isi = 3
+preview_config = PreviewParams(show_preview_inquiry=True,
+                               preview_inquiry_length=5,
+                               preview_inquiry_key_input='space',
+                               preview_inquiry_progress_method=1,
+                               preview_inquiry_isi=3)
 
 info = InformationProperties(
     info_color=['White'],
@@ -50,7 +49,7 @@ window_parameters = {
     'full_screen': False,
     'window_height': 500,
     'window_width': 500,
-    'stim_screen': 1,
+    'stim_screen': 0,
     'background_color': 'black'
 }
 
@@ -86,12 +85,7 @@ print(frameRate)
 clock = core.StaticPeriod(screenHz=frameRate)
 experiment_clock = Clock()
 task_bar = CopyPhraseTaskBar(win, task_text='COPY_PHRASE', font='Menlo')
-preview_inquiry = PreviewInquiryProperties(
-    preview_only=True,
-    preview_inquiry_length=preview_inquiry_length,
-    preview_inquiry_key_input=preview_inquiry_key_input,
-    preview_inquiry_progress_method=preview_inquiry_progress_method,
-    preview_inquiry_isi=preview_inquiry_isi)
+
 rsvp = CopyPhraseDisplay(
     win,
     clock,
@@ -99,11 +93,11 @@ rsvp = CopyPhraseDisplay(
     stimuli,
     task_bar,
     info,
-    preview_inquiry=preview_inquiry)
+    preview_config=preview_config)
 
 counter = 0
 
-for idx_o in range(len(spelled_text)):
+for idx_o, _symbol in enumerate(spelled_text):
 
     rsvp.update_task_bar(text=spelled_text[idx_o])
     rsvp.draw_static()
@@ -119,16 +113,8 @@ for idx_o in range(len(spelled_text)):
 
         core.wait(inter_stim_buffer)
 
-        if show_preview_inquiry:
-            inquiry_timing, proceed = rsvp.preview_inquiry()
-            print(inquiry_timing)
-            if proceed:
-                inquiry_timing.extend(rsvp.do_inquiry())
-            else:
-                print('Rejected inquiry! Handle here')
-                inquiry_timing = rsvp.do_inquiry()
-        else:
-            inquiry_timing = rsvp.do_inquiry()
+        inquiry_timing = rsvp.do_inquiry()
+        print(inquiry_timing)
 
         core.wait(inter_stim_buffer)
         counter += 1

--- a/bcipy/display/main.py
+++ b/bcipy/display/main.py
@@ -301,11 +301,12 @@ class PreviewParams(NamedTuple):
 def get_button_handler_class(
         mode: ButtonPressMode) -> Type[ButtonPressHandler]:
     """Get the appropriate handler constructor for the given button press mode."""
-    return {
+    mapping = {
         ButtonPressMode.NOTHING: PreviewOnlyButtonPressHandler,
         ButtonPressMode.ACCEPT: AcceptButtonPressHandler,
         ButtonPressMode.REJECT: RejectButtonPressHandler
-    }.get(mode)
+    }
+    return mapping[mode]
 
 
 def init_preview_button_handler(params: PreviewParams,

--- a/bcipy/display/main.py
+++ b/bcipy/display/main.py
@@ -238,12 +238,14 @@ class InformationProperties:
                 opacity=1, depth=-6.0))
         return self.text_stim
 
+
 class ButtonPressMode(Enum):
     """Represents the possible meanings for a button press (when using an Inquiry Preview.)"""
     NOTHING = 0
     ACCEPT = 1
     REJECT = 2
-    
+
+
 class PreviewInquiryProperties:
     """"Preview Inquiry Properties.
     An encapsulation of properties relevant to preview_inquiry() operation.
@@ -274,10 +276,11 @@ class PreviewInquiryProperties:
         self.preview_only = preview_only
         self.preview_inquiry_isi = preview_inquiry_isi
 
+
 class PreviewParams(NamedTuple):
     """Parameters relevant for the Inquiry Preview functionality"""
     show_preview_inquiry: bool
-    preview_inquiry_length:float
+    preview_inquiry_length: float
     preview_inquiry_key_input: str
     preview_inquiry_progress_method: int
     preview_inquiry_isi: float
@@ -285,7 +288,7 @@ class PreviewParams(NamedTuple):
     @property
     def button_press_mode(self):
         return ButtonPressMode(self.preview_inquiry_progress_method)
-    
+
 
 class VEPStimuliProperties(StimuliProperties):
 

--- a/bcipy/display/main.py
+++ b/bcipy/display/main.py
@@ -1,7 +1,8 @@
 # mypy: disable-error-code="assignment,empty-body"
 from abc import ABC, abstractmethod
+from enum import Enum
 from logging import Logger
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, List, NamedTuple, Optional, Tuple, Union
 
 from psychopy import visual
 
@@ -237,7 +238,12 @@ class InformationProperties:
                 opacity=1, depth=-6.0))
         return self.text_stim
 
-
+class ButtonPressMode(Enum):
+    """Represents the possible meanings for a button press (when using an Inquiry Preview.)"""
+    NOTHING = 0
+    ACCEPT = 1
+    REJECT = 2
+    
 class PreviewInquiryProperties:
     """"Preview Inquiry Properties.
     An encapsulation of properties relevant to preview_inquiry() operation.
@@ -268,6 +274,18 @@ class PreviewInquiryProperties:
         self.preview_only = preview_only
         self.preview_inquiry_isi = preview_inquiry_isi
 
+class PreviewParams(NamedTuple):
+    """Parameters relevant for the Inquiry Preview functionality"""
+    show_preview_inquiry: bool
+    preview_inquiry_length:float
+    preview_inquiry_key_input: str
+    preview_inquiry_progress_method: int
+    preview_inquiry_isi: float
+
+    @property
+    def button_press_mode(self):
+        return ButtonPressMode(self.preview_inquiry_progress_method)
+    
 
 class VEPStimuliProperties(StimuliProperties):
 

--- a/bcipy/display/paradigm/matrix/display.py
+++ b/bcipy/display/paradigm/matrix/display.py
@@ -8,7 +8,10 @@ import bcipy.display.components.layout as layout
 from bcipy.config import MATRIX_IMAGE_FILENAME
 from bcipy.display import (BCIPY_LOGO_PATH, Display, InformationProperties,
                            StimuliProperties)
+from bcipy.display.components.button_press_handler import (
+    ButtonPressHandler, get_button_handler_class)
 from bcipy.display.components.task_bar import TaskBar
+from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.matrix.layout import symbol_positions
 from bcipy.helpers.stimuli import resize_image
 from bcipy.helpers.symbols import alphabet
@@ -48,7 +51,8 @@ class MatrixDisplay(Display):
                  trigger_type: str = 'text',
                  symbol_set: Optional[List[str]] = None,
                  should_prompt_target: bool = True,
-                 sort_order: Optional[Callable] = None):
+                 sort_order: Optional[Callable] = None,
+                 preview_config: Optional[PreviewParams] = None):
         """Initialize Matrix display parameters and objects.
 
         PARAMETERS:
@@ -73,6 +77,7 @@ class MatrixDisplay(Display):
             the first symbol of each inquiry. For example: [target, fixation, *stim].
         sort_order - optional function to define the position index for each
             symbol. Using a custom function it is possible to skip a position.
+        preview_config - optional configuration for previewing inquiries
         """
         self.window = window
 
@@ -114,6 +119,9 @@ class MatrixDisplay(Display):
         self.stim_registry = self.build_grid()
         self.should_prompt_target = should_prompt_target
 
+        self.preview_params = preview_config
+        self._preview_button_handler = self.init_preview_button_handler()
+
         self.logger.info(
             f"Symbol positions ({display_container.units} units):\n{self.stim_positions}"
         )
@@ -127,6 +135,11 @@ class MatrixDisplay(Display):
             sym: tuple(stim.pos)
             for sym, stim in self.stim_registry.items()
         }
+
+    @property
+    def preview_enabled(self) -> bool:
+        """Should the inquiry preview be enabled."""
+        return self.preview_params and self.preview_params.show_preview_inquiry
 
     def capture_grid_screenshot(self, file_path: str) -> None:
         """Capture Grid Screenshot.
@@ -171,12 +184,13 @@ class MatrixDisplay(Display):
             for sti in zip(self.stimuli_inquiry, self.stimuli_timing, self.stimuli_colors)
         ]
 
-    def add_timing(self, stimuli: str):
+    def add_timing(self, stimuli: str, stamp: Optional[float] = None):
         """Add a new timing entry using the stimuli as a label.
 
         Useful as a callback function to register a marker at the time it is
         first displayed."""
-        self._timing.append((stimuli, self.experiment_clock.getTime()))
+        stamp = stamp or self.experiment_clock.getTime()
+        self._timing.append((stimuli, stamp))
 
     def reset_timing(self):
         """Reset the trigger timing."""
@@ -196,7 +210,12 @@ class MatrixDisplay(Display):
         else:
             [fixation, *stim] = symbol_durations
 
-        self.animate_scp(fixation, stim)
+        should_proceed = True
+        if self.preview_enabled:
+            should_proceed = self.preview_inquiry(stim)
+
+        if should_proceed:
+            self.animate_scp(fixation, stim)
 
         return self._timing
 
@@ -217,7 +236,7 @@ class MatrixDisplay(Display):
     def draw_grid(self,
                   opacity: float = 1,
                   color: Optional[str] = 'white',
-                  highlight: Optional[str] = None,
+                  highlight: Optional[List[str]] = None,
                   highlight_color: Optional[str] = None):
         """Draw the grid.
 
@@ -225,16 +244,16 @@ class MatrixDisplay(Display):
         ----------
             opacity - opacity for each item in the matrix
             color - optional color for each item in the matrix
-            highlight - optional stim label for the item to be highlighted
+            highlight - optional list of stim labels to be highlighted
                 (rendered using the highlight_opacity).
             highlight_color - optional color to use for rendering the
               highlighted stim.
         """
         for symbol, stim in self.stim_registry.items():
-            stim.setOpacity(self.highlight_opacity if highlight ==
-                            symbol else opacity)
+            should_highlight = highlight and (symbol in highlight)
+            stim.setOpacity(self.highlight_opacity if should_highlight else opacity)
             stim.setColor(highlight_color if highlight_color and
-                          highlight == symbol else color)
+                          should_highlight else color)
             stim.draw()
 
     def prompt_target(self, target: SymbolDuration) -> float:
@@ -249,14 +268,57 @@ class MatrixDisplay(Display):
         self.window.callOnFlip(self.add_timing, target.symbol)
         self.draw(grid_opacity=self.start_opacity,
                   duration=target.duration,
-                  highlight=target.symbol,
+                  highlight=[target.symbol],
                   highlight_color=target.color)
+
+    def init_preview_button_handler(self) -> Optional[ButtonPressHandler]:
+        """"Returns a button press handler for inquiry preview."""
+        if not self.preview_enabled:
+            return None
+
+        params = self.preview_params
+        make_handler = get_button_handler_class(params.button_press_mode)
+        return make_handler(max_wait=params.preview_inquiry_length,
+                            key_input=params.preview_inquiry_key_input,
+                            clock=self.experiment_clock)
+
+    def preview_inquiry(self, stimuli: List[SymbolDuration]) -> bool:
+        """"Preview the inquiry and handle any button presses.
+        Parameters
+        ----------
+            stimuli - list of stimuli to highlight (will be flashed in next inquiry)
+
+        Returns
+        -------
+            boolean indicating whether the participant would like to proceed
+                with the inquiry (True) or reject the inquiry (False) and
+                go on to the next one.
+        """
+        assert self.preview_enabled, "Preview feature not enabled."
+
+        handler = self._preview_button_handler
+        self.window.callOnFlip(self.add_timing, 'inquiry_preview')
+
+        self.draw_preview(stimuli)
+        handler.await_response()
+
+        if handler.has_response():
+            self.add_timing(handler.response_label, handler.response_timestamp)
+
+        self.draw(grid_opacity=self.start_opacity, duration=self.preview_params.preview_inquiry_isi)
+        return handler.accept_result()
+
+    def draw_preview(self, stimuli: List[SymbolDuration]) -> None:
+        """Draw the inquiry preview by highlighting all of the symbols in the
+        list."""
+        self.draw(grid_opacity=self.start_opacity,
+                  highlight=[stim.symbol for stim in stimuli])
 
     def draw(self,
              grid_opacity: float,
              grid_color: Optional[str] = None,
              duration: Optional[float] = None,
-             highlight: Optional[str] = None,
+             highlight: Optional[List[str]] = None,
              highlight_color: Optional[str] = None):
         """Draw all screen elements and flip the window.
 
@@ -265,7 +327,7 @@ class MatrixDisplay(Display):
             grid_opacity - opacity value to use on all grid symbols
             grid_color - optional color to use for all grid symbols
             duration - optional seconds to wait after flipping the window.
-            highlight - optional symbol to highlight in the grid.
+            highlight - optional list of symbols to highlight in the grid.
             highlight_color - optional color to use for rendering the
               highlighted stim.
         """
@@ -299,7 +361,7 @@ class MatrixDisplay(Display):
             self.window.callOnFlip(self.add_timing, stim.symbol)
             self.draw(grid_opacity=self.start_opacity,
                       duration=stim.duration,
-                      highlight=stim.symbol,
+                      highlight=[stim.symbol],
                       highlight_color=stim.color)
         self.draw(self.start_opacity)
 

--- a/bcipy/display/paradigm/matrix/display.py
+++ b/bcipy/display/paradigm/matrix/display.py
@@ -120,6 +120,7 @@ class MatrixDisplay(Display):
         self.preview_params = preview_config
         self.preview_button_handler = init_preview_button_handler(
             preview_config, experiment_clock) if self.preview_enabled else None
+        self.preview_accepted = True
 
         self.logger.info(
             f"Symbol positions ({display_container.units} units):\n{self.stim_positions}"
@@ -198,6 +199,7 @@ class MatrixDisplay(Display):
 
     def do_inquiry(self) -> List[Tuple[str, float]]:
         """Animates an inquiry of stimuli and returns a list of stimuli trigger timing."""
+        self.preview_accepted = True
         self.reset_timing()
         symbol_durations = self.symbol_durations()
 
@@ -210,11 +212,10 @@ class MatrixDisplay(Display):
         else:
             [fixation, *stim] = symbol_durations
 
-        should_proceed = True
         if self.preview_enabled:
-            should_proceed = self.preview_inquiry(stim)
+            self.preview_accepted = self.preview_inquiry(stim)
 
-        if should_proceed:
+        if self.preview_accepted:
             self.animate_scp(fixation, stim)
 
         return self._timing

--- a/bcipy/display/paradigm/rsvp/mode/calibration.py
+++ b/bcipy/display/paradigm/rsvp/mode/calibration.py
@@ -13,7 +13,7 @@ class CalibrationDisplay(RSVPDisplay):
                  task_bar,
                  info,
                  trigger_type='image',
-                 preview_inquiry=None,
+                 preview_config=None,
                  space_char=SPACE_CHAR,
                  full_screen=False):
 
@@ -24,6 +24,14 @@ class CalibrationDisplay(RSVPDisplay):
                          task_bar,
                          info,
                          trigger_type=trigger_type,
-                         preview_inquiry=preview_inquiry,
+                         preview_config=preview_config,
                          space_char=space_char,
                          full_screen=full_screen)
+
+    @property
+    def preview_index(self) -> int:
+        """Index within an inquiry at which the inquiry preview should be displayed.
+
+        For calibration, we should display it after the target prompt (index = 1).
+        """
+        return 1

--- a/bcipy/display/paradigm/rsvp/mode/copy_phrase.py
+++ b/bcipy/display/paradigm/rsvp/mode/copy_phrase.py
@@ -1,7 +1,8 @@
 from psychopy import visual
-from bcipy.display.paradigm.rsvp.display import RSVPDisplay, BCIPY_LOGO_PATH
-from bcipy.helpers.symbols import SPACE_CHAR
+
+from bcipy.display.paradigm.rsvp.display import BCIPY_LOGO_PATH, RSVPDisplay
 from bcipy.helpers.stimuli import resize_image
+from bcipy.helpers.symbols import SPACE_CHAR
 
 """Note:
 
@@ -33,7 +34,7 @@ class CopyPhraseDisplay(RSVPDisplay):
             starting_spelled_text='',
             trigger_type='image',
             space_char=SPACE_CHAR,
-            preview_inquiry=None,
+            preview_config=None,
             full_screen=False):
         """ Initializes Copy Phrase Task Objects """
         self.starting_spelled_text = starting_spelled_text
@@ -46,8 +47,17 @@ class CopyPhraseDisplay(RSVPDisplay):
                          info,
                          trigger_type=trigger_type,
                          space_char=space_char,
-                         preview_inquiry=preview_inquiry,
+                         preview_config=preview_config,
                          full_screen=full_screen)
+
+    @property
+    def preview_index(self) -> int:
+        """Index within an inquiry at which the inquiry preview should be displayed.
+
+        For copy phrase there is no target prompt so it should display before
+        the fixation.
+        """
+        return 0
 
     def wait_screen(self, message: str, message_color: str) -> None:
         """Wait Screen.

--- a/bcipy/display/tests/components/test_button_press_handler.py
+++ b/bcipy/display/tests/components/test_button_press_handler.py
@@ -1,0 +1,205 @@
+"""Tests for button press handlers."""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from bcipy.display.components.button_press_handler import (
+    AcceptButtonPressHandler, PreviewOnlyButtonPressHandler,
+    RejectButtonPressHandler, get_button_handler_class)
+from bcipy.display.main import ButtonPressMode
+
+
+class TestButtonPressModule(unittest.TestCase):
+    """Test the module functions"""
+
+    def test_get_handler_class(self):
+        """Test get handler class"""
+        self.assertEqual(PreviewOnlyButtonPressHandler,
+                         get_button_handler_class(ButtonPressMode.NOTHING))
+        self.assertEqual(AcceptButtonPressHandler,
+                         get_button_handler_class(ButtonPressMode.ACCEPT))
+        self.assertEqual(RejectButtonPressHandler,
+                         get_button_handler_class(ButtonPressMode.REJECT))
+
+
+class TestPreviewOnlyButtonPressHandler(unittest.TestCase):
+    """Test the PreviewOnlyButtonPressHandler"""
+
+    @patch('bcipy.display.components.button_press_handler.get_key_press')
+    def test_preview_only(self, get_key_press_mock):
+        """Test preview only"""
+        mock_timer_class = Mock()
+        mock_timer = Mock()
+        mock_timer_class.return_value = mock_timer
+
+        # Timer counts down
+        mock_timer.reset.return_value = None
+        mock_timer.getTime.side_effect = [2.0, 1.0, 0.0]
+        get_key_press_mock.return_value = None
+
+        handler = PreviewOnlyButtonPressHandler(max_wait=2,
+                                                key_input='space',
+                                                timer=mock_timer_class)
+        handler.await_response()
+
+        mock_timer_class.assert_called_once()
+        mock_timer.reset.assert_called_once()
+        self.assertEqual(3, mock_timer.getTime.call_count)
+        self.assertEqual(2, get_key_press_mock.call_count)
+
+        self.assertTrue(handler.accept_result())
+        self.assertFalse(handler.has_response())
+
+    @patch('bcipy.display.components.button_press_handler.get_key_press')
+    def test_preview_only_with_keypress(self, get_key_press_mock):
+        """Test preview only with a keypress"""
+        mock_timer_class = Mock()
+        mock_timer = Mock()
+        mock_timer_class.return_value = mock_timer
+
+        # Timer counts down
+        mock_timer.reset.return_value = None
+        mock_timer.getTime.side_effect = [2.0, 1.0, 0.0]
+        get_key_press_mock.side_effect = [None, ['bcipy_key_press_space', 1.5]]
+
+        handler = PreviewOnlyButtonPressHandler(max_wait=2,
+                                                key_input='space',
+                                                timer=mock_timer_class)
+        handler.await_response()
+
+        mock_timer_class.assert_called_once()
+        mock_timer.reset.assert_called_once()
+        self.assertEqual(3, mock_timer.getTime.call_count)
+        self.assertEqual(2, get_key_press_mock.call_count)
+
+        self.assertTrue(handler.accept_result())
+        self.assertTrue(handler.has_response())
+
+    @patch('bcipy.display.components.button_press_handler.get_key_press')
+    def test_preview_only_with_keypress_in_middle(self, get_key_press_mock):
+        """Test preview only with a keypress in the middle of the wait period"""
+        mock_timer_class = Mock()
+        mock_timer = Mock()
+        mock_timer_class.return_value = mock_timer
+
+        # Timer counts down
+        mock_timer.reset.return_value = None
+        mock_timer.getTime.side_effect = [3.0, 2.0, 1.0, 0.0]
+        get_key_press_mock.side_effect = [
+            None, ['bcipy_key_press_space', 1.5], None
+        ]
+
+        handler = PreviewOnlyButtonPressHandler(max_wait=3,
+                                                key_input='space',
+                                                timer=mock_timer_class)
+        handler.await_response()
+
+        self.assertEqual(4, mock_timer.getTime.call_count)
+        self.assertEqual(3, get_key_press_mock.call_count)
+
+        self.assertTrue(handler.accept_result())
+        self.assertFalse(handler.has_response())
+
+
+class TestAcceptButtonPressHandler(unittest.TestCase):
+    """Test for Press To Accept behavior"""
+
+    @patch('bcipy.display.components.button_press_handler.get_key_press')
+    def test_press_to_accept_with_no_presses(self, get_key_press_mock):
+        """Test press to accept with no button presses."""
+        mock_timer_class = Mock()
+        mock_timer = Mock()
+        mock_timer_class.return_value = mock_timer
+
+        # Timer counts down
+        mock_timer.reset.return_value = None
+        mock_timer.getTime.side_effect = [2.0, 1.0, 0.0]
+        get_key_press_mock.return_value = None
+
+        handler = AcceptButtonPressHandler(max_wait=2,
+                                           key_input='space',
+                                           timer=mock_timer_class)
+        handler.await_response()
+
+        self.assertEqual(3, mock_timer.getTime.call_count)
+        self.assertEqual(2, get_key_press_mock.call_count)
+
+        self.assertFalse(handler.accept_result())
+        self.assertFalse(handler.has_response())
+
+    @patch('bcipy.display.components.button_press_handler.get_key_press')
+    def test_press_to_accept_with_keypress(self, get_key_press_mock):
+        """Test press to accept with a keypress"""
+        mock_timer_class = Mock()
+        mock_timer = Mock()
+        mock_timer_class.return_value = mock_timer
+
+        # Timer counts down
+        mock_timer.reset.return_value = None
+        mock_timer.getTime.side_effect = [3.0, 2.0, 1.0, 0.0]
+        get_key_press_mock.side_effect = [None, ['bcipy_key_press_space', 1.5]]
+
+        handler = AcceptButtonPressHandler(max_wait=2,
+                                           key_input='space',
+                                           timer=mock_timer_class)
+        handler.await_response()
+
+        self.assertEqual(2, mock_timer.getTime.call_count)
+        self.assertEqual(2, get_key_press_mock.call_count)
+
+        self.assertTrue(handler.accept_result())
+        self.assertTrue(handler.has_response())
+        self.assertEqual('bcipy_key_press_space', handler.response_label)
+        self.assertEqual(1.5, handler.response_timestamp)
+
+
+class TestRejectButtonPressHandler(unittest.TestCase):
+    """Test for Press To Reject behavior"""
+
+    @patch('bcipy.display.components.button_press_handler.get_key_press')
+    def test_press_to_reject_with_no_presses(self, get_key_press_mock):
+        """Test press to reject with no button presses."""
+        mock_timer_class = Mock()
+        mock_timer = Mock()
+        mock_timer_class.return_value = mock_timer
+
+        # Timer counts down
+        mock_timer.reset.return_value = None
+        mock_timer.getTime.side_effect = [2.0, 1.0, 0.0]
+        get_key_press_mock.return_value = None
+
+        handler = RejectButtonPressHandler(max_wait=2,
+                                           key_input='space',
+                                           timer=mock_timer_class)
+        handler.await_response()
+
+        self.assertEqual(3, mock_timer.getTime.call_count)
+        self.assertEqual(2, get_key_press_mock.call_count)
+
+        self.assertTrue(handler.accept_result())
+        self.assertFalse(handler.has_response())
+
+    @patch('bcipy.display.components.button_press_handler.get_key_press')
+    def test_press_to_reject_with_keypress(self, get_key_press_mock):
+        """Test press to accept with a keypress"""
+        mock_timer_class = Mock()
+        mock_timer = Mock()
+        mock_timer_class.return_value = mock_timer
+
+        # Timer counts down
+        mock_timer.reset.return_value = None
+        mock_timer.getTime.side_effect = [3.0, 2.0, 1.0, 0.0]
+        get_key_press_mock.side_effect = [None, ['bcipy_key_press_space', 1.5]]
+
+        handler = RejectButtonPressHandler(max_wait=2,
+                                           key_input='space',
+                                           timer=mock_timer_class)
+        handler.await_response()
+
+        self.assertEqual(2, mock_timer.getTime.call_count)
+        self.assertEqual(2, get_key_press_mock.call_count)
+
+        self.assertFalse(handler.accept_result())
+        self.assertTrue(handler.has_response())
+        self.assertEqual('bcipy_key_press_space', handler.response_label)
+        self.assertEqual(1.5, handler.response_timestamp)

--- a/bcipy/display/tests/components/test_button_press_handler.py
+++ b/bcipy/display/tests/components/test_button_press_handler.py
@@ -5,21 +5,7 @@ from unittest.mock import Mock, patch
 
 from bcipy.display.components.button_press_handler import (
     AcceptButtonPressHandler, PreviewOnlyButtonPressHandler,
-    RejectButtonPressHandler, get_button_handler_class)
-from bcipy.display.main import ButtonPressMode
-
-
-class TestButtonPressModule(unittest.TestCase):
-    """Test the module functions"""
-
-    def test_get_handler_class(self):
-        """Test get handler class"""
-        self.assertEqual(PreviewOnlyButtonPressHandler,
-                         get_button_handler_class(ButtonPressMode.NOTHING))
-        self.assertEqual(AcceptButtonPressHandler,
-                         get_button_handler_class(ButtonPressMode.ACCEPT))
-        self.assertEqual(RejectButtonPressHandler,
-                         get_button_handler_class(ButtonPressMode.REJECT))
+    RejectButtonPressHandler)
 
 
 class TestPreviewOnlyButtonPressHandler(unittest.TestCase):

--- a/bcipy/display/tests/paradigm/matrix/test_matrix_display.py
+++ b/bcipy/display/tests/paradigm/matrix/test_matrix_display.py
@@ -7,18 +7,18 @@ from mockito import (any, mock, unstub, verify, verifyNoUnwantedInteractions,
 
 from bcipy.display import InformationProperties, StimuliProperties
 from bcipy.display.components.task_bar import TaskBar
+from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.matrix.display import MatrixDisplay, SymbolDuration
 
 # Define some reusable elements to test Matrix Display with
 LEN_STIM = 10
-TEST_STIM = StimuliProperties(
-    stim_font='Arial',
-    stim_pos=(-0.6, 0.4),
-    stim_height=0.1,
-    stim_inquiry=['A'],
-    stim_colors=[],
-    stim_timing=[0.1],
-    is_txt_stim=True)
+TEST_STIM = StimuliProperties(stim_font='Arial',
+                              stim_pos=(-0.6, 0.4),
+                              stim_height=0.1,
+                              stim_inquiry=['A'],
+                              stim_colors=[],
+                              stim_timing=[0.1],
+                              is_txt_stim=True)
 
 TEST_INFO = InformationProperties(
     info_color=['White'],
@@ -39,7 +39,8 @@ class TestMatrixDisplay(unittest.TestCase):
         self.window = mock({"units": "norm", "size": (2.0, 2.0)})
         self.experiment_clock = mock()
         self.static_clock = mock()
-        self.text_stim_mock = mock({'pos': (0, 0)}, spec=psychopy.visual.TextStim)
+        self.text_stim_mock = mock({'pos': (0, 0)},
+                                   spec=psychopy.visual.TextStim)
         when(self.text_stim_mock).setOpacity(...).thenReturn()
         when(self.text_stim_mock).setColor(...).thenReturn()
         when(self.text_stim_mock).draw(...).thenReturn()
@@ -99,13 +100,17 @@ class TestMatrixDisplay(unittest.TestCase):
         unstub()
 
     def test_information_properties_set_correctly(self):
-        self.assertEqual(self.matrix.info_text, self.info.build_info_text(self.window))
+        self.assertEqual(self.matrix.info_text,
+                         self.info.build_info_text(self.window))
 
     def test_schedule_to(self):
         # Test schedule_to method correctly sets stim inquiry, timing, and colors to given parameters.
-        self.matrix.schedule_to(self.stimuli.stim_inquiry, self.stimuli.stim_timing, self.stimuli.stim_colors)
+        self.matrix.schedule_to(self.stimuli.stim_inquiry,
+                                self.stimuli.stim_timing,
+                                self.stimuli.stim_colors)
 
-        self.assertEqual(self.matrix.stimuli_inquiry, self.stimuli.stim_inquiry)
+        self.assertEqual(self.matrix.stimuli_inquiry,
+                         self.stimuli.stim_inquiry)
         self.assertEqual(self.matrix.stimuli_timing, self.stimuli.stim_timing)
 
     def test_do_inquiry(self):
@@ -129,16 +134,91 @@ class TestMatrixDisplay(unittest.TestCase):
         verify(self.matrix, times=1).prompt_target(target)
         verify(self.matrix, times=1).animate_scp(fixation, stim_durations)
 
+    def test_do_inquiry_with_preview_accepted(self):
+        """Verify that the symbols are animated following an inquiry preview
+        in which the user accepts the input."""
+        preview_config = PreviewParams(show_preview_inquiry=True,
+                                       preview_inquiry_length=2,
+                                       preview_inquiry_key_input='return',
+                                       preview_inquiry_progress_method=2,
+                                       preview_inquiry_isi=1)
+        matrix = MatrixDisplay(window=self.window,
+                               experiment_clock=self.experiment_clock,
+                               stimuli=self.stimuli,
+                               task_bar=self.task_bar_mock,
+                               info=self.info,
+                               preview_config=preview_config)
+        when(matrix)._trigger_pulse().thenReturn()
+
+        stimuli = ['X', '+', 'A', 'B', 'C']
+        timing = [0.5, 1.0, 0.2, 0.2, 0.2]
+
+        target = SymbolDuration('X', 0.5)
+        fixation = SymbolDuration('+', 1.0)
+        stim_durations = [
+            SymbolDuration(*sti)
+            for sti in [('A', 0.2), ('B', 0.2), ('C', 0.2)]
+        ]
+
+        when(matrix).prompt_target(any()).thenReturn(0.0)
+        when(matrix).animate_scp(any(), any()).thenReturn([])
+        when(matrix).preview_inquiry(any()).thenReturn(True)
+
+        matrix.schedule_to(stimuli, timing, [])
+        matrix.do_inquiry()
+
+        verify(matrix, times=1)._trigger_pulse()
+        verify(matrix, times=1).prompt_target(target)
+        verify(matrix, times=1).preview_inquiry(stim_durations)
+        verify(matrix, times=1).animate_scp(fixation, stim_durations)
+
+    def test_do_inquiry_with_preview_rejected(self):
+        """Test that if an inquiry preview is rejected the inquiry does not
+        animate."""
+        preview_config = PreviewParams(show_preview_inquiry=True,
+                                       preview_inquiry_length=2,
+                                       preview_inquiry_key_input='return',
+                                       preview_inquiry_progress_method=2,
+                                       preview_inquiry_isi=1)
+        matrix = MatrixDisplay(window=self.window,
+                               experiment_clock=self.experiment_clock,
+                               stimuli=self.stimuli,
+                               task_bar=self.task_bar_mock,
+                               info=self.info,
+                               preview_config=preview_config)
+        when(matrix)._trigger_pulse().thenReturn()
+
+        stimuli = ['X', '+', 'A', 'B', 'C']
+        timing = [0.5, 1.0, 0.2, 0.2, 0.2]
+
+        target = SymbolDuration('X', 0.5)
+        fixation = SymbolDuration('+', 1.0)
+        stim_durations = [
+            SymbolDuration(*sti)
+            for sti in [('A', 0.2), ('B', 0.2), ('C', 0.2)]
+        ]
+
+        when(matrix).prompt_target(any()).thenReturn(0.0)
+        when(matrix).preview_inquiry(any()).thenReturn(False)
+        when(matrix).animate_scp(any(), any()).thenReturn([])
+
+        matrix.schedule_to(stimuli, timing, [])
+        matrix.do_inquiry()
+
+        verify(matrix, times=1)._trigger_pulse()
+        verify(matrix, times=1).prompt_target(target)
+        verify(matrix, times=1).preview_inquiry(stim_durations)
+        verify(matrix, times=0).animate_scp(fixation, stim_durations)
+
     def test_build_grid(self):
         # mock the text stims and increment_position
-        when(psychopy.visual).TextStim(
-            win=self.window,
-            height=any(),
-            text=any(),
-            color=any(),
-            pos=any(),
-            opacity=any()
-        ).thenReturn(self.text_stim_mock)
+        when(psychopy.visual).TextStim(win=self.window,
+                                       height=any(),
+                                       text=any(),
+                                       color=any(),
+                                       pos=any(),
+                                       opacity=any()).thenReturn(
+                                           self.text_stim_mock)
 
         sym_length = len(self.matrix.symbol_set)
         grid = self.matrix.build_grid()
@@ -152,13 +232,12 @@ class TestMatrixDisplay(unittest.TestCase):
 
     def test_animate_scp(self):
         # mock the text stims and window
-        when(psychopy.visual).TextStim(
-            win=self.window,
-            height=any(),
-            text=any(),
-            pos=any(),
-            opacity=any()
-        ).thenReturn(self.text_stim_mock)
+        when(psychopy.visual).TextStim(win=self.window,
+                                       height=any(),
+                                       text=any(),
+                                       pos=any(),
+                                       opacity=any()).thenReturn(
+                                           self.text_stim_mock)
         when(self.matrix.window).callOnFlip(any(), any(), any()).thenReturn()
         when(self.matrix.window).callOnFlip(any(), any()).thenReturn()
         # mock the drawing of text stims

--- a/bcipy/display/tests/paradigm/rsvp/test_rsvp_display.py
+++ b/bcipy/display/tests/paradigm/rsvp/test_rsvp_display.py
@@ -1,25 +1,25 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import psychopy
-from mockito import (any, mock, unstub, verifyNoUnwantedInteractions,
+from mockito import (mock, unstub, verify, verifyNoUnwantedInteractions,
                      verifyStubbedInvocationsAreUsed, when)
 
-from bcipy.display import (InformationProperties, PreviewInquiryProperties,
-                           StimuliProperties)
+from bcipy.display import InformationProperties, StimuliProperties
+from bcipy.display.components.button_press_handler import ButtonPressHandler
 from bcipy.display.components.task_bar import TaskBar
+from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.rsvp import RSVPDisplay
 
 # Define some reusable elements to test RSVPDisplay with
 LEN_STIM = 10
-TEST_STIM = StimuliProperties(
-    stim_font='Arial',
-    stim_pos=(0, 0),
-    stim_height=0.6,
-    stim_inquiry=['A', '+'] * LEN_STIM,
-    stim_colors=['white'] * LEN_STIM,
-    stim_timing=[3] * LEN_STIM,
-    is_txt_stim=True)
+TEST_STIM = StimuliProperties(stim_font='Arial',
+                              stim_pos=(0, 0),
+                              stim_height=0.6,
+                              stim_inquiry=['A', '+'] * LEN_STIM,
+                              stim_colors=['white'] * LEN_STIM,
+                              stim_timing=[3] * LEN_STIM,
+                              is_txt_stim=True)
 TEST_INFO = InformationProperties(
     info_color=['White'],
     info_pos=[(-.5, -.75)],
@@ -45,13 +45,9 @@ class TestRSVPDisplay(unittest.TestCase):
         self.task_bar_mock = mock(TaskBar)
         task_bar_mock.returnValue(self.task_bar_mock)
         when(psychopy.visual).TextStim(...).thenReturn(self.text_stim_mock)
-        self.rsvp = RSVPDisplay(
-            self.window,
-            self.static_clock,
-            self.experiment_clock,
-            self.stimuli,
-            self.task_bar_mock,
-            self.info)
+        self.rsvp = RSVPDisplay(self.window, self.static_clock,
+                                self.experiment_clock, self.stimuli,
+                                self.task_bar_mock, self.info)
 
     def tearDown(self):
         verifyNoUnwantedInteractions()
@@ -63,7 +59,8 @@ class TestRSVPDisplay(unittest.TestCase):
 
     def test_information_properties_set_correctly(self):
         self.assertEqual(self.rsvp.info, self.info)
-        self.assertEqual(self.rsvp.info_text, self.info.build_info_text(self.window))
+        self.assertEqual(self.rsvp.info_text,
+                         self.info.build_info_text(self.window))
 
     def test_stimuli_properties_set_correctly(self):
         """Stimuli properties are set on the instance to allow easy resetting of this properties during a task."""
@@ -78,218 +75,232 @@ class TestRSVPDisplay(unittest.TestCase):
 
 
 class TestRSVPDisplayInquiryPreview(unittest.TestCase):
+
+    @patch('bcipy.display.paradigm.rsvp.display.init_preview_button_handler')
     @patch('bcipy.display.paradigm.rsvp.display.TaskBar')
-    def setUp(self, task_bar_mock):
+    def setUp(self, task_bar_mock, init_preview_button_handler_mock):
         """Set up needed items for test."""
         self.info = TEST_INFO
         self.stimuli = TEST_STIM
-        self.preview_inquiry_length = 0.1
-        self.preview_inquiry_isi = 0.1
-        self.preview_inquiry_progress_method = 1  # preview only = 0; press to accept == 1; press to skip == 2
-        self.preview_inquiry_key_input = 'space'
-        self.preview_inquiry = PreviewInquiryProperties(
-            preview_on=False,
-            preview_only=False,
-            preview_inquiry_length=self.preview_inquiry_length,
-            preview_inquiry_isi=self.preview_inquiry_isi,
-            preview_inquiry_progress_method=self.preview_inquiry_progress_method,
-            preview_inquiry_key_input=self.preview_inquiry_key_input
-        )
+
         self.window = mock({"units": "norm", "size": (2.0, 2.0)})
         self.experiment_clock = mock()
         self.static_clock = mock()
         self.text_stim_mock = mock()
         self.rect_stim_mock = mock()
         self.task_bar_mock = mock(TaskBar)
-        task_bar_mock.returnValue(self.task_bar_mock)
+        task_bar_mock.return_value(self.task_bar_mock)
         when(psychopy.visual).TextStim(...).thenReturn(self.text_stim_mock)
-        self.rsvp = RSVPDisplay(
-            self.window,
-            self.static_clock,
-            self.experiment_clock,
-            self.stimuli,
-            self.task_bar_mock,
-            self.info,
-            preview_inquiry=self.preview_inquiry)
+
+        self.rsvp = None
 
     def tearDown(self):
         verifyNoUnwantedInteractions()
         verifyStubbedInvocationsAreUsed()
         unstub()
 
-    def test_preview_inquiry_properties_set_correctly(self):
-        self.assertEqual(self.rsvp._preview_inquiry, self.preview_inquiry)
-        # In our test case, preview_inquiry_progress_method is 1 and should map to press_to_accept
-        self.assertEqual(self.rsvp._preview_inquiry.press_to_accept, True)
+    def init_display(self, preview_config) -> None:
+        """Initializes a new display with the given config; """
+        self.rsvp = RSVPDisplay(self.window,
+                                self.static_clock,
+                                self.experiment_clock,
+                                self.stimuli,
+                                self.task_bar_mock,
+                                self.info,
+                                preview_config=preview_config)
+
+        # skip the gui components
+        when(self.rsvp).draw_static().thenReturn()
+        when(self.rsvp).draw_preview().thenReturn()
+        when(self.rsvp.window).flip().thenReturn()
+        when(psychopy.core).wait(
+            preview_config.preview_inquiry_isi).thenReturn()
+
+    def test_preview_enabled_default(self):
+        """Test preview_enabled when preview_config is None."""
+        rsvp = RSVPDisplay(self.window,
+                           self.static_clock,
+                           self.experiment_clock,
+                           self.stimuli,
+                           self.task_bar_mock,
+                           self.info,
+                           preview_config=None)
+        self.assertFalse(rsvp.preview_enabled)
+
+    def test_preview_enabled_is_false(self):
+        """Test inquiry preview disabled when params specify not to
+        show_preview_inquiry."""
+        preview_config = PreviewParams(show_preview_inquiry=False,
+                                       preview_inquiry_length=2,
+                                       preview_inquiry_key_input='space',
+                                       preview_inquiry_progress_method=1,
+                                       preview_inquiry_isi=1)
+        rsvp = RSVPDisplay(self.window,
+                           self.static_clock,
+                           self.experiment_clock,
+                           self.stimuli,
+                           self.task_bar_mock,
+                           self.info,
+                           preview_config=preview_config)
+        self.assertFalse(rsvp.preview_enabled)
+
+    def test_preview_enabled_is_true(self):
+        """Test inquiry preview disabled when params specify to
+        show_preview_inquiry."""
+        preview_config = PreviewParams(show_preview_inquiry=True,
+                                       preview_inquiry_length=2,
+                                       preview_inquiry_key_input='space',
+                                       preview_inquiry_progress_method=1,
+                                       preview_inquiry_isi=1)
+        rsvp = RSVPDisplay(self.window,
+                           self.static_clock,
+                           self.experiment_clock,
+                           self.stimuli,
+                           self.task_bar_mock,
+                           self.info,
+                           preview_config=preview_config)
+        self.assertTrue(rsvp.preview_enabled)
+
+    @patch('bcipy.display.paradigm.rsvp.display.init_preview_button_handler')
+    def test_preview_inquiry_evoked_press_to_accept_pressed(
+            self, init_preview_button_handler_mock):
+        """Test preview with a press to accept configuration."""
+
+        button_press_handler_mock = Mock(ButtonPressHandler)
+        init_preview_button_handler_mock.return_value = button_press_handler_mock
+
+        preview_config = PreviewParams(show_preview_inquiry=True,
+                                       preview_inquiry_length=0.01,
+                                       preview_inquiry_key_input='space',
+                                       preview_inquiry_progress_method=1,
+                                       preview_inquiry_isi=0.01)
+        self.init_display(preview_config)
+
+        button_press_handler_mock.has_response.return_value = True
+        button_press_handler_mock.accept_result.return_value = True
+        button_press_handler_mock.response_label = 'bcipy_key_press_space'
+        button_press_handler_mock.response_timestamp = 1.0
+
+        timing = []
+        proceed = self.rsvp.preview_inquiry(timing)
+
+        init_preview_button_handler_mock.assert_called_once_with(
+            preview_config, self.experiment_clock)
+        button_press_handler_mock.await_response.assert_called_once()
+
+        verify(self.rsvp, times=1).draw_preview()
+        self.assertTrue(proceed)
         self.assertEqual(
-            self.rsvp._preview_inquiry.preview_inquiry_length,
-            self.preview_inquiry.preview_inquiry_length)
-        self.assertEqual(
-            self.rsvp._preview_inquiry.preview_inquiry_key_input,
-            self.preview_inquiry.preview_inquiry_key_input)
-        self.assertEqual(
-            self.rsvp._preview_inquiry.preview_inquiry_isi,
-            self.preview_inquiry.preview_inquiry_isi)
+            2, len(timing),
+            "time stamps for the preview and the button press should be present"
+        )
+        label, stamp = timing[-1]
+        self.assertEqual('bcipy_key_press_space', label)
+        self.assertEqual(1.0, stamp)
 
-    def test_preview_inquiry_generate_inquiry_preview_fixation(self):
-        text = ' '.join(self.rsvp.stimuli_inquiry).split('+ ')[1]
-        stim_mock = mock()
-        when(self.rsvp)._create_stimulus(
-            any(),
-            stimulus=text,
-            units='height',
-            stimuli_position=self.rsvp.stimuli_pos,
-            mode='textbox',
-            align_text='left',
-            wrap_width=any()
-        ).thenReturn(stim_mock)
+    @patch('bcipy.display.paradigm.rsvp.display.init_preview_button_handler')
+    def test_preview_inquiry_evoked_press_to_skip_pressed(
+            self, init_preview_button_handler_mock):
+        """Test preview with a press to reject/skip configuration."""
+        button_press_handler_mock = Mock(ButtonPressHandler)
+        init_preview_button_handler_mock.return_value = button_press_handler_mock
 
-        response = self.rsvp._generate_inquiry_preview()
-        self.assertEqual(response, stim_mock)
+        preview_config = PreviewParams(show_preview_inquiry=True,
+                                       preview_inquiry_length=0.01,
+                                       preview_inquiry_key_input='space',
+                                       preview_inquiry_progress_method=2,
+                                       preview_inquiry_isi=0.01)
+        self.init_display(preview_config)
 
-    @patch('bcipy.display.paradigm.rsvp.display.get_key_press')
-    def test_preview_inquiry_evoked_press_to_accept_pressed(self, get_key_press_mock):
-        stim_mock = mock()
-        # mock the stimulus generation
-        when(self.rsvp)._generate_inquiry_preview().thenReturn(stim_mock)
-        when(stim_mock).draw().thenReturn()
-        when(self.rsvp).draw_static().thenReturn()
-        when(self.rsvp.window).flip().thenReturn()
-        when(self.rsvp)._trigger_pulse().thenReturn()
+        button_press_handler_mock.has_response.return_value = True
+        button_press_handler_mock.accept_result.return_value = False
+        button_press_handler_mock.response_label = 'bcipy_key_press_space'
+        button_press_handler_mock.response_timestamp = 1.0
 
-        # skip the core wait for testing
-        when(psychopy.core).wait(self.preview_inquiry.preview_inquiry_isi).thenReturn()
-        key_timestamp = 1000
-        get_key_press_mock.return_value = [
-            f'bcipy_key_press_{self.preview_inquiry_key_input}', key_timestamp
-        ]
-        response = self.rsvp.preview_inquiry()
-        # we expect the trigger callback to return none, the key press to return the time and key press message,
-        #  The second item should be True as it is press to accept and a response was returned
-        expected = ([None, [f'bcipy_key_press_{self.preview_inquiry_key_input}', key_timestamp]], True)
-        self.assertEqual(response, expected)
+        timing = []
+        proceed = self.rsvp.preview_inquiry(timing)
 
-    @patch('bcipy.display.paradigm.rsvp.display.get_key_press')
-    def test_preview_inquiry_evoked_press_to_skip_pressed(self, get_key_press_mock):
-        # set the progress method to press to skip
-        self.rsvp._preview_inquiry.press_to_accept = False
-        stim_mock = mock()
-        # mock the stimulus generation
-        when(self.rsvp)._generate_inquiry_preview().thenReturn(stim_mock)
-        when(stim_mock).draw().thenReturn()
-        when(self.rsvp).draw_static().thenReturn()
-        when(self.rsvp.window).flip().thenReturn()
-        when(self.rsvp)._trigger_pulse().thenReturn()
+        verify(self.rsvp, times=1).draw_preview()
+        self.assertFalse(proceed)
+        self.assertEqual(2, len(timing))
+        label, stamp = timing[-1]
+        self.assertEqual('bcipy_key_press_space', label)
+        self.assertEqual(1.0, stamp)
 
-        # skip the core wait for testing
-        when(psychopy.core).wait(self.preview_inquiry.preview_inquiry_isi).thenReturn()
-        key_timestamp = 1000
-        get_key_press_mock.return_value = [
-            f'bcipy_key_press_{self.preview_inquiry_key_input}', key_timestamp
-        ]
-        response = self.rsvp.preview_inquiry()
-        # we expect the trigger callback to return none, the key press to return the time and key press message,
-        #  The second item should be False as it is press to skip and a response was returned
-        expected = ([None, [f'bcipy_key_press_{self.preview_inquiry_key_input}', key_timestamp]], False)
-        self.assertEqual(response, expected)
+    @patch('bcipy.display.paradigm.rsvp.display.init_preview_button_handler')
+    def test_preview_inquiry_evoked_press_to_accept_not_pressed(
+            self, init_preview_button_handler_mock):
+        """Test preview with a press to accept with no button press."""
+        button_press_handler_mock = Mock(ButtonPressHandler)
+        init_preview_button_handler_mock.return_value = button_press_handler_mock
 
-    @patch('bcipy.display.paradigm.rsvp.display.get_key_press')
-    def test_preview_inquiry_evoked_press_to_accept_not_pressed(self, get_key_press_mock):
-        stim_mock = mock()
-        # mock the stimulus generation
-        when(self.rsvp)._generate_inquiry_preview().thenReturn(stim_mock)
-        when(stim_mock).draw().thenReturn()
-        when(self.rsvp).draw_static().thenReturn()
-        when(self.rsvp.window).flip().thenReturn()
-        when(self.rsvp)._trigger_pulse().thenReturn()
+        preview_config = PreviewParams(show_preview_inquiry=True,
+                                       preview_inquiry_length=0.01,
+                                       preview_inquiry_key_input='space',
+                                       preview_inquiry_progress_method=1,
+                                       preview_inquiry_isi=0.01)
+        self.init_display(preview_config)
 
-        # skip the core wait for testing
-        when(psychopy.core).wait(self.preview_inquiry.preview_inquiry_isi).thenReturn()
-        get_key_press_mock.return_value = None
-        response = self.rsvp.preview_inquiry()
-        # we expect the trigger callback to return none, the key press to return the time and key press message,
-        #  The second item should be False as it is press to accept and a response was returned
-        expected = ([None], False)
-        self.assertEqual(response, expected)
+        button_press_handler_mock.has_response.return_value = False
+        button_press_handler_mock.accept_result.return_value = False
 
-    @patch('bcipy.display.paradigm.rsvp.display.get_key_press')
-    def test_preview_inquiry_evoked_press_to_skip_not_pressed(self, get_key_press_mock):
-        # set the progress method to press to skip
-        self.rsvp._preview_inquiry.press_to_accept = False
-        stim_mock = mock()
-        # mock the stimulus generation
-        when(self.rsvp)._generate_inquiry_preview().thenReturn(stim_mock)
-        when(stim_mock).draw().thenReturn()
-        when(self.rsvp).draw_static().thenReturn()
-        when(self.rsvp.window).flip().thenReturn()
-        when(self.rsvp)._trigger_pulse().thenReturn()
+        timing = []
+        proceed = self.rsvp.preview_inquiry(timing)
+        verify(self.rsvp, times=1).draw_preview()
 
-        # skip the core wait for testing
-        when(psychopy.core).wait(self.preview_inquiry.preview_inquiry_isi).thenReturn()
-        get_key_press_mock.return_value = None
-        response = self.rsvp.preview_inquiry()
-        # we expect the trigger callback to return none, the key press to return the time and key press message,
-        #  The second item should be True as it is press to skip and a response was not returned
-        expected = ([None], True)
-        self.assertEqual(response, expected)
+        self.assertFalse(proceed)
+        self.assertEqual(1, len(timing),
+                         "Only the timing for the preview should be present.")
 
-    @patch('bcipy.display.paradigm.rsvp.display.get_key_press')
-    def test_preview_inquiry_preview_only_response_registered(self, get_key_press_mock):
-        # set the progress method to press to skip
-        self.rsvp._preview_inquiry.press_to_accept = False
-        self.rsvp._preview_inquiry.preview_only = True
-        stim_mock = mock()
-        # mock the stimulus generation
-        when(self.rsvp)._generate_inquiry_preview().thenReturn(stim_mock)
-        when(stim_mock).draw().thenReturn()
-        when(self.rsvp).draw_static().thenReturn()
-        when(self.rsvp.window).flip().thenReturn()
-        when(self.rsvp)._trigger_pulse().thenReturn()
+    @patch('bcipy.display.paradigm.rsvp.display.init_preview_button_handler')
+    def test_preview_inquiry_evoked_press_to_skip_not_pressed(
+            self, init_preview_button_handler_mock):
+        """Test preview with a press to reject/skip configuration when the
+        button was not pressed."""
+        button_press_handler_mock = Mock(ButtonPressHandler)
+        init_preview_button_handler_mock.return_value = button_press_handler_mock
 
-        # skip the core wait for testing
-        when(psychopy.core).wait(self.preview_inquiry.preview_inquiry_isi).thenReturn()
-        # we return a key press value here to demonstrate, even if a response is returned by this method, it will not
-        #  be used in the preview_inquiry response from our display.
-        key_timestamp = 1000
-        get_key_press_mock.return_value = [
-            f'bcipy_key_press_{self.preview_inquiry_key_input}', key_timestamp
-        ]
-        response = self.rsvp.preview_inquiry()
-        # we expect the trigger callback to return none, no key press response even if returned,
-        #  The second item should be True as it is preview only
-        expected = ([None], True)
-        self.assertEqual(response, expected)
+        preview_config = PreviewParams(show_preview_inquiry=True,
+                                       preview_inquiry_length=0.01,
+                                       preview_inquiry_key_input='space',
+                                       preview_inquiry_progress_method=2,
+                                       preview_inquiry_isi=0.01)
+        self.init_display(preview_config)
 
-    @patch('bcipy.display.paradigm.rsvp.display.get_key_press')
-    def test_preview_inquiry_preview_only_no_response(self, get_key_press_mock):
-        # set the progress method to press to skip
-        self.rsvp._preview_inquiry.press_to_accept = False
-        self.rsvp._preview_inquiry.preview_only = True
-        stim_mock = mock()
-        # mock the stimulus generation
-        when(self.rsvp)._generate_inquiry_preview().thenReturn(stim_mock)
-        when(stim_mock).draw().thenReturn()
-        when(self.rsvp).draw_static().thenReturn()
-        when(self.rsvp.window).flip().thenReturn()
-        when(self.rsvp)._trigger_pulse().thenReturn()
+        button_press_handler_mock.has_response.return_value = False
+        button_press_handler_mock.accept_result.return_value = True
 
-        # skip the core wait for testing
-        when(psychopy.core).wait(self.preview_inquiry.preview_inquiry_isi).thenReturn()
+        timing = []
+        proceed = self.rsvp.preview_inquiry(timing)
 
-        get_key_press_mock.return_value = None
-        response = self.rsvp.preview_inquiry()
-        # we expect the trigger callback to return none, no key press response,
-        #  The second item should be True as it is preview only
-        expected = ([None], True)
-        self.assertEqual(response, expected)
+        verify(self.rsvp, times=1).draw_preview()
 
-    def test_error_thrown_when_calling_preview_inquiry_without_properties_set(self):
-        # If not defined using the kwarg preview_inquiry, this value is set to None
-        self.rsvp._preview_inquiry = None
+        self.assertTrue(proceed)
+        self.assertEqual(1, len(timing),
+                         "Only the timing for the preview should be present.")
 
-        # Assert when set to None, calling the method will result in an exception
-        with self.assertRaises(Exception):
-            self.rsvp.preview_inquiry()
+    @patch('bcipy.display.paradigm.rsvp.display.init_preview_button_handler')
+    def test_preview_inquiry_preview_only_response_registered(
+            self, init_preview_button_handler_mock):
+        """Test preview with preview only."""
+        button_press_handler_mock = Mock(ButtonPressHandler)
+        init_preview_button_handler_mock.return_value = button_press_handler_mock
+
+        preview_config = PreviewParams(show_preview_inquiry=True,
+                                       preview_inquiry_length=0.01,
+                                       preview_inquiry_key_input='space',
+                                       preview_inquiry_progress_method=0,
+                                       preview_inquiry_isi=0.01)
+        self.init_display(preview_config)
+
+        button_press_handler_mock.has_response.return_value = False
+        button_press_handler_mock.accept_result.return_value = True
+
+        timing = []
+        proceed = self.rsvp.preview_inquiry(timing)
+
+        verify(self.rsvp, times=1).draw_preview()
+        self.assertTrue(proceed)
 
 
 if __name__ == '__main__':

--- a/bcipy/display/tests/test_main.py
+++ b/bcipy/display/tests/test_main.py
@@ -1,8 +1,13 @@
 import unittest
 
-from mockito import any, mock, when, unstub
 import psychopy
+from mockito import any, mock, unstub, when
+
 from bcipy.display import init_display_window
+from bcipy.display.components.button_press_handler import (
+    AcceptButtonPressHandler, PreviewOnlyButtonPressHandler,
+    RejectButtonPressHandler)
+from bcipy.display.main import ButtonPressMode, get_button_handler_class
 
 
 class TestInitializeDisplayWindow(unittest.TestCase):
@@ -42,6 +47,19 @@ class TestInitializeDisplayWindow(unittest.TestCase):
         """Test display window is created."""
         self.assertIsInstance(self.display_window, type(self.window))
         self.assertEqual(self.display_window, self.window)
+
+
+class TestButtonPressFunctions(unittest.TestCase):
+    """Test the module functions"""
+
+    def test_get_handler_class(self):
+        """Test get handler class"""
+        self.assertEqual(PreviewOnlyButtonPressHandler,
+                         get_button_handler_class(ButtonPressMode.NOTHING))
+        self.assertEqual(AcceptButtonPressHandler,
+                         get_button_handler_class(ButtonPressMode.ACCEPT))
+        self.assertEqual(RejectButtonPressHandler,
+                         get_button_handler_class(ButtonPressMode.REJECT))
 
 
 if __name__ == '__main__':

--- a/bcipy/task/base_calibration.py
+++ b/bcipy/task/base_calibration.py
@@ -167,6 +167,8 @@ class BaseCalibrationTask(Task):
         """
         if index == 0:
             return TriggerType.PROMPT
+        if symbol == 'inquiry_preview':
+            return TriggerType.PREVIEW
         if symbol == DEFAULT_TEXT_FIXATION:
             return TriggerType.FIXATION
         if target == symbol:

--- a/bcipy/task/paradigm/matrix/calibration.py
+++ b/bcipy/task/paradigm/matrix/calibration.py
@@ -4,6 +4,7 @@ from psychopy import core, visual
 
 from bcipy.display import InformationProperties, StimuliProperties
 from bcipy.display.components.task_bar import CalibrationTaskBar
+from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.matrix.display import MatrixDisplay
 from bcipy.helpers.clock import Clock
 from bcipy.helpers.parameters import Parameters
@@ -104,4 +105,5 @@ def init_matrix_display(parameters: Parameters, window: visual.Window,
                          width_pct=parameters['matrix_width'],
                          height_pct=1 - (2 * task_bar.height_pct),
                          trigger_type=parameters['trigger_type'],
-                         symbol_set=symbol_set)
+                         symbol_set=symbol_set,
+                         preview_config=parameters.instantiate(PreviewParams))

--- a/bcipy/task/paradigm/matrix/copy_phrase.py
+++ b/bcipy/task/paradigm/matrix/copy_phrase.py
@@ -2,6 +2,7 @@
 
 from bcipy.display import InformationProperties, StimuliProperties
 from bcipy.display.components.task_bar import CopyPhraseTaskBar
+from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.matrix.display import MatrixDisplay
 from bcipy.task.paradigm.rsvp.copy_phrase import RSVPCopyPhraseTask
 
@@ -80,4 +81,5 @@ def init_display(
         width_pct=parameters['matrix_width'],
         height_pct=1 - (2 * task_bar.height_pct),
         trigger_type=parameters['trigger_type'],
-        should_prompt_target=False)
+        should_prompt_target=False,
+        preview_config=parameters.instantiate(PreviewParams))

--- a/bcipy/task/paradigm/rsvp/calibration/calibration.py
+++ b/bcipy/task/paradigm/rsvp/calibration/calibration.py
@@ -1,8 +1,8 @@
 from psychopy import core, visual
 
-from bcipy.display import (Display, InformationProperties,
-                           PreviewInquiryProperties, StimuliProperties)
+from bcipy.display import Display, InformationProperties, StimuliProperties
 from bcipy.display.components.task_bar import CalibrationTaskBar
+from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.rsvp.mode.calibration import CalibrationDisplay
 from bcipy.helpers.clock import Clock
 from bcipy.helpers.parameters import Parameters
@@ -79,22 +79,13 @@ def init_calibration_display_task(
                                   height=parameters['task_height'],
                                   padding=parameters['task_padding'])
 
-    preview_inquiry = PreviewInquiryProperties(
-        preview_on=parameters['show_preview_inquiry'],
-        preview_only=True,
-        preview_inquiry_length=parameters['preview_inquiry_length'],
-        preview_inquiry_progress_method=parameters[
-            'preview_inquiry_progress_method'],
-        preview_inquiry_key_input=parameters['preview_inquiry_key_input'],
-        preview_inquiry_isi=parameters['preview_inquiry_isi'])
-
     return CalibrationDisplay(window,
                               static_clock,
                               experiment_clock,
                               stimuli,
                               task_bar,
                               info,
-                              preview_inquiry=preview_inquiry,
+                              preview_config=parameters.instantiate(PreviewParams),
                               trigger_type=parameters['trigger_type'],
                               space_char=parameters['stim_space_char'],
                               full_screen=parameters['full_screen'])

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -11,6 +11,7 @@ from bcipy.config import (DEFAULT_EVIDENCE_PRECISION, SESSION_DATA_FILENAME,
 from bcipy.display import (InformationProperties, PreviewInquiryProperties,
                            StimuliProperties)
 from bcipy.display.components.task_bar import CopyPhraseTaskBar
+from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.rsvp.mode.copy_phrase import CopyPhraseDisplay
 from bcipy.feedback.visual.visual_feedback import VisualFeedback
 from bcipy.helpers.clock import Clock
@@ -371,14 +372,8 @@ class RSVPCopyPhraseTask(Task):
                               colors=inquiry_schedule.colors[0]
                               if self.parameters['is_txt_stim'] else None)
 
-        if self.parameters['show_preview_inquiry']:
-            stim_times, proceed = self.rsvp.preview_inquiry()
-            if proceed:
-                stim_times.extend(self.rsvp.do_inquiry())
-        else:
-            stim_times = self.rsvp.do_inquiry()
-            proceed = True
-
+        stim_times = self.rsvp.do_inquiry()
+        proceed = not self.rsvp.preview_enabled or self.rsvp.preview_accepted
         return stim_times, proceed
 
     def show_feedback(self, selection: str, correct: bool = True) -> None:
@@ -977,4 +972,4 @@ def _init_copy_phrase_display(
         starting_spelled_text,
         trigger_type=parameters['trigger_type'],
         space_char=parameters['stim_space_char'],
-        preview_inquiry=preview_inquiry)
+        preview_config=parameters.instantiate(PreviewParams))

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -264,7 +264,6 @@ class TestCopyPhrase(unittest.TestCase):
 
         # Assertions
         verify(self.copy_phrase_wrapper, times=2).initialize_series()
-        verify(self.display, times=0).preview_inquiry()
         verify(self.display, times=1).do_inquiry()
         self.assertEqual(self.temp_dir, result)
 
@@ -474,7 +473,6 @@ class TestCopyPhrase(unittest.TestCase):
 
         # Assertions
         verify(self.copy_phrase_wrapper, times=2).initialize_series()
-        verify(self.display, times=1).preview_inquiry()
         verify(self.display, times=1).do_inquiry()
         verify(self.copy_phrase_wrapper, times=1).add_evidence(EvidenceType.BTN, ...)
         self.assertEqual(self.temp_dir, result)


### PR DESCRIPTION
# Overview

Added Inquiry Preview functionality for Matrix Calibration and Matrix Copy Phrase. Fixed a bug in RSVP Copy Phrase when using Inquiry Preview.

## Ticket

https://www.pivotaltracker.com/story/show/188181571

## Contributions

- Added ButtonPressHandler classes for managing button press interactions. There is a different handler for each mode (press to accept, press to reject, preview only).
- Updated display demos.
- Added Inquiry Preview functionality to Matrix display.
- Initialized Matrix Calibration and Copy Phrase tasks with preview parameters.
- Refactored rsvp calibration to use button press handler classes.

## Test

- Added unit tests for ButtonPressHandlers.
- Added unit tests for Inquiry Preview functionality in RSVP and Matrix displays.