### PR TITLE
Inquiry Preview Button Evidence Bug

### DIFF
--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -671,8 +671,7 @@ class RSVPCopyPhraseTask(Task):
         return evidence_types
 
     def compute_button_press_evidence(
-        self, proceed: bool
-    ) -> Optional[Tuple[EvidenceType, List[float]]]:
+            self, proceed: bool) -> Optional[Tuple[EvidenceType, List[float]]]:
         """If 'show_preview_inquiry' feature is enabled, compute the button
         press evidence and add it to the copy phrase task.
 
@@ -685,10 +684,7 @@ class RSVPCopyPhraseTask(Task):
             tuple of (evidence type, evidence) or None if inquiry preview is
             not enabled.
         """
-        if (
-            not self.parameters["show_preview_inquiry"] or
-            not self.current_inquiry
-        ):
+        if (not self.should_compute_button_press_evidence()):
             return None
         probs = compute_probs_after_preview(
             self.current_inquiry.stimuli[0],
@@ -698,9 +694,15 @@ class RSVPCopyPhraseTask(Task):
         )
         return (EvidenceType.BTN, probs)
 
+    def should_compute_button_press_evidence(self) -> bool:
+        """Determine if button press evidence should be computed"""
+        return self.parameters["show_preview_inquiry"] and self.parameters[
+            'preview_inquiry_progress_method'] > 0 and self.current_inquiry
+
     def compute_device_evidence(
-        self, stim_times: List[List], proceed: bool = True
-    ) -> List[Tuple[EvidenceType, List[float]]]:
+            self,
+            stim_times: List[List],
+            proceed: bool = True) -> List[Tuple[EvidenceType, List[float]]]:
         """Get inquiry data from all devices and evaluate the evidence, but
         don't yet attempt a decision.
 

--- a/bcipy/task/paradigm/rsvp/copy_phrase.py
+++ b/bcipy/task/paradigm/rsvp/copy_phrase.py
@@ -686,6 +686,7 @@ class RSVPCopyPhraseTask(Task):
         """
         if (not self.should_compute_button_press_evidence()):
             return None
+        assert self.current_inquiry, "Current inquiry is required"
         probs = compute_probs_after_preview(
             self.current_inquiry.stimuli[0],
             self.alp,
@@ -696,8 +697,8 @@ class RSVPCopyPhraseTask(Task):
 
     def should_compute_button_press_evidence(self) -> bool:
         """Determine if button press evidence should be computed"""
-        return self.parameters["show_preview_inquiry"] and self.parameters[
-            'preview_inquiry_progress_method'] > 0 and self.current_inquiry
+        return bool(self.parameters["show_preview_inquiry"] and self.parameters[
+            'preview_inquiry_progress_method'] > 0 and self.current_inquiry)
 
     def compute_device_evidence(
             self,

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -13,8 +13,8 @@ from bcipy.acquisition import LslAcquisitionClient
 from bcipy.acquisition.devices import DeviceSpec
 from bcipy.acquisition.multimodal import ContentType
 from bcipy.config import DEFAULT_ENCODING
-from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
 from bcipy.exceptions import TaskConfigurationException
+from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
 from bcipy.helpers.parameters import Parameters
 from bcipy.helpers.stimuli import InquirySchedule
 from bcipy.helpers.triggers import TriggerHandler
@@ -593,6 +593,77 @@ class TestCopyPhrase(unittest.TestCase):
         with open(Path(task.session_save_location), 'r', encoding=DEFAULT_ENCODING) as json_file:
             session = Session.from_dict(json.load(json_file))
             self.assertEqual(1, session.total_number_series)
+
+    def test_btn_evidence_without_inquiry_preview_enabled(self):
+        """Test button evidence without the inquiry preview functionality"""
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        self.parameters['show_preview_inquiry'] = False
+        task = RSVPCopyPhraseTask(
+            parameters=self.parameters,
+            file_save=self.temp_dir,
+            fake=False)
+        self.assertIsNone(task.compute_button_press_evidence(True))
+        self.assertIsNone(task.compute_button_press_evidence(False))
+
+    def test_btn_evidence_without_current_inquiry(self):
+        """Test button evidence without a current inquiry"""
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        self.parameters['show_preview_inquiry'] = True
+        task = RSVPCopyPhraseTask(
+            parameters=self.parameters,
+            file_save=self.temp_dir,
+            fake=False)
+        task.current_inquiry = None
+        self.assertIsNone(task.compute_button_press_evidence(True))
+        self.assertIsNone(task.compute_button_press_evidence(False))
+
+    @patch('bcipy.task.paradigm.rsvp.copy_phrase.compute_probs_after_preview')
+    def test_btn_evidence_with_inquiry_preview_enabled(self,
+                                                       compute_probs_mock):
+        """Test button evidence with the inquiry preview functionality"""
+        probs = [
+            0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.95, 0.05, 0.05,
+            0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05, 0.05,
+            0.05, 0.05, 0.05, 0.05, 0.95, 0.05
+        ]
+        compute_probs_mock.return_value = probs
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(
+            any(), any(), any()).thenReturn((self.daq, self.servers, self.win))
+        self.parameters['show_preview_inquiry'] = True
+        self.parameters['preview_inquiry_progress_method'] = 1
+        task = RSVPCopyPhraseTask(parameters=self.parameters,
+                                  file_save=self.temp_dir,
+                                  fake=False)
+
+        self.assertEqual(task.compute_button_press_evidence(True),
+                         (EvidenceType.BTN, probs))
+        compute_probs_mock.assert_called_with(task.current_inquiry.stimuli[0],
+                                              task.alp,
+                                              task.button_press_error_prob,
+                                              True)
+        self.assertEqual(task.compute_button_press_evidence(False),
+                         (EvidenceType.BTN, probs))
+        compute_probs_mock.assert_called_with(task.current_inquiry.stimuli[0],
+                                              task.alp,
+                                              task.button_press_error_prob,
+                                              False)
+
+    def test_btn_evidence_with_preview_only(self):
+        """Test button evidence with inquiry preview mode set to preview only."""
+        when(bcipy.task.paradigm.rsvp.copy_phrase.RSVPCopyPhraseTask).setup(any(), any(), any()).thenReturn(
+            (self.daq, self.servers, self.win))
+        self.parameters['show_preview_inquiry'] = True
+        self.parameters['preview_inquiry_progress_method'] = 0  # ButtonPressMode.NOTHING.value
+
+        task = RSVPCopyPhraseTask(
+            parameters=self.parameters,
+            file_save=self.temp_dir,
+            fake=False)
+
+        self.assertIsNone(task.compute_button_press_evidence(True))
+        self.assertIsNone(task.compute_button_press_evidence(False))
 
     def test_setup(self):
         """Test setup"""


### PR DESCRIPTION
# Overview

Ensure that button press evidence in Copy Phrase tasks is only produced when presses are meaningful (not in preview-only mode).

## Ticket

https://www.pivotaltracker.com/story/show/188514964

## Contributions

- Added unit tests to replicate the bug
- Implemented a fix
