### PR TITLE
BIDS DSI-24, ET Data, and 1020 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Contributions
 
 - BIDS
-  - Bundling support and refactor of `convert` module. See `demo_convert.py` #362
+  - Bundling support and refactor of `convert` module. See `demo_convert.py` #362 Add support for 1020 channels and eye tracker data #369
 - Library Refactor
   - Refactor `helpers` into `io` and `core` #362
 - Dependencies

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ This a list of the major modules and their functionality. Each module will conta
 - `feedback`: feedback mechanisms for sound and visual stimuli.
 - `gui`: end-user interface into registered bci tasks and parameter editing. See BCInterface.py.
 - `helpers`: helpful functions needed for interactions between modules and general utility.
-- `io`: load, save, and convert data files. Ex. BrainVision, EDF, MNE, CSV, JSON, etc.
+- `io`: load, save, and convert data files. Ex. BIDS, BrainVision, EDF, MNE, CSV, JSON, etc.
 - `language`: gives probabilities of next symbols during typing.
 - `main`: executor of experiments. Main entry point into the application
 - `parameters`: location of json parameters. This includes parameters.json (main experiment / app configuration) and device.json (device registry and configuration).

--- a/bcipy/core/demo/demo_report.py
+++ b/bcipy/core/demo/demo_report.py
@@ -31,7 +31,10 @@ if __name__ == "__main__":
     # if no path is provided, prompt for one using a GUI
     path = args.path
     if not path:
-        path = load_experimental_data()
+        path = load_experimental_data(
+            message="Select the folder containing the raw_data.csv, parameters.json and triggers.txt",
+            strict=True
+        )
 
     trial_window = (0, 1.0)
 

--- a/bcipy/core/demo/demo_session_tools.py
+++ b/bcipy/core/demo/demo_session_tools.py
@@ -39,7 +39,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     path = args.path
     if not path:
-        path = ask_directory()
+        path = ask_directory(strict=True)
 
     if args.db or args.csv or args.charts:
         session = read_session(Path(path, SESSION_DATA_FILENAME))

--- a/bcipy/core/raw_data.py
+++ b/bcipy/core/raw_data.py
@@ -406,7 +406,7 @@ def sample_data(rows: int = 1000,
 
 def get_1020_channels() -> List[str]:
     """Returns the standard 10-20 channel names.
-    
+
     Note: The 10-20 system is a standard for EEG electrode placement. The following is not a complete list of all
     possible channels, but the most common ones used in BCI research. This excludes the reference and ground channels.
 
@@ -422,7 +422,7 @@ def get_1020_channels() -> List[str]:
 
 def get_1020_channel_map(channels_name: List[str]) -> List[int]:
     """Returns a list of 1s and 0s indicating if the channel name is in the 10-20 system.
-    
+
     Parameters
     ----------
     channels_name : list of channel names

--- a/bcipy/core/raw_data.py
+++ b/bcipy/core/raw_data.py
@@ -402,3 +402,17 @@ def sample_data(rows: int = 1000,
         data.append([timestamp] + channel_data + [trg])
 
     return data
+
+
+def get_1020_channels():
+    """Returns the standard 10-20 channel names"""
+    return [
+        'Fp1', 'Fp2', 'F7', 'F3', 'Fz', 'F4', 'F8', 'T3', 'C3', 'Cz', 'C4',
+        'T4', 'T5', 'P3', 'Pz', 'P4', 'T6', 'O1', 'O2'
+    ]
+
+
+def get_1020_channel_map(channels_name):
+    """Returns the standard 10-20 channel names"""
+    valid_channels = get_1020_channels()
+    return [1 if name in valid_channels else 0 for name in channels_name]

--- a/bcipy/core/raw_data.py
+++ b/bcipy/core/raw_data.py
@@ -404,15 +404,32 @@ def sample_data(rows: int = 1000,
     return data
 
 
-def get_1020_channels():
-    """Returns the standard 10-20 channel names"""
+def get_1020_channels() -> List[str]:
+    """Returns the standard 10-20 channel names.
+    
+    Note: The 10-20 system is a standard for EEG electrode placement. The following is not a complete list of all
+    possible channels, but the most common ones used in BCI research. This excludes the reference and ground channels.
+
+    Returns
+    -------
+    list of channel names
+    """
     return [
         'Fp1', 'Fp2', 'F7', 'F3', 'Fz', 'F4', 'F8', 'T3', 'C3', 'Cz', 'C4',
         'T4', 'T5', 'P3', 'Pz', 'P4', 'T6', 'O1', 'O2'
     ]
 
 
-def get_1020_channel_map(channels_name):
-    """Returns the standard 10-20 channel names"""
+def get_1020_channel_map(channels_name: List[str]) -> List[int]:
+    """Returns a list of 1s and 0s indicating if the channel name is in the 10-20 system.
+    
+    Parameters
+    ----------
+    channels_name : list of channel names
+
+    Returns
+    -------
+    list of 1s and 0s indicating if the channel name is in the 10-20 system
+    """
     valid_channels = get_1020_channels()
     return [1 if name in valid_channels else 0 for name in channels_name]

--- a/bcipy/core/tests/test_raw_data.py
+++ b/bcipy/core/tests/test_raw_data.py
@@ -12,7 +12,8 @@ from mockito import any, mock, when, verify, unstub
 
 from bcipy.exceptions import BciPyCoreException
 from bcipy.core.raw_data import (RawData, RawDataReader, RawDataWriter,
-                                 load, sample_data, settings, write)
+                                 load, sample_data, settings, write,
+                                 get_1020_channel_map, get_1020_channels)
 
 
 class TestRawData(unittest.TestCase):
@@ -375,6 +376,26 @@ class TestRawData(unittest.TestCase):
         self.assertEqual(expected_fs, fs)
         self.assertEqual(expected_channels, channels)
         verify(RawData, times=1).by_channel(transform)
+
+
+class Test1020(unittest.TestCase):
+    """Tests for 10-20 channel mapping functions."""
+
+    def test_get_1020_channels(self):
+        """Tests that the 10-20 channel map is correctly generated."""
+        channels = get_1020_channels()
+        self.assertEqual(19, len(channels))
+        self.assertTrue(isinstance(channels[0], str))
+
+    def test_get_1020_channel_map(self):
+        """Tests that the 10-20 channel map is correctly generated."""
+        # all but the last channel are valid 10-20 channels
+        channels = ['Fp1', 'Fp2', 'F3', 'F4', 'C3', 'C4', 'P3', 'P4', 'O1', 'invalid']
+        channel_map = get_1020_channel_map(channels)
+        self.assertEqual(10, len(channel_map))
+        self.assertEqual(0, channel_map[-1])
+        for i in range(len(channels) - 1):
+            self.assertEqual(1, channel_map[i])
 
 
 if __name__ == '__main__':

--- a/bcipy/gui/file_dialog.py
+++ b/bcipy/gui/file_dialog.py
@@ -64,7 +64,7 @@ def ask_filename(
         file_types: str = DEFAULT_FILE_TYPES,
         directory: str = "",
         prompt: str = "Select File",
-        strict=False) -> Union[str, BciPyCoreException]:
+        strict: bool = False) -> Union[str, BciPyCoreException]:
     """Prompt for a file using a GUI.
 
     Parameters
@@ -94,14 +94,14 @@ def ask_filename(
         app.quit()
 
         return filename
-    
+
     if strict:
         raise BciPyCoreException('No file selected.')
-    
+
     return ''
 
 
-def ask_directory(prompt: str = "Select Directory", strict=False) -> Union[str, BciPyCoreException]:
+def ask_directory(prompt: str = "Select Directory", strict: bool = False) -> Union[str, BciPyCoreException]:
     """Prompt for a directory using a GUI.
 
     Parameters
@@ -131,5 +131,5 @@ def ask_directory(prompt: str = "Select Directory", strict=False) -> Union[str, 
 
     if strict:
         raise BciPyCoreException('No directory selected.')
-    
+
     return ''

--- a/bcipy/gui/file_dialog.py
+++ b/bcipy/gui/file_dialog.py
@@ -90,7 +90,7 @@ def ask_filename(
         app.quit()
 
         return filename
-    
+
     raise BciPyCoreException('No file selected.')
 
 
@@ -119,5 +119,5 @@ def ask_directory(prompt: str = "Select Directory") -> Union[str, BciPyCoreExcep
         app.quit()
 
         return name
-    
+
     raise BciPyCoreException('No directory selected.')

--- a/bcipy/gui/file_dialog.py
+++ b/bcipy/gui/file_dialog.py
@@ -63,7 +63,8 @@ class FileDialog(QWidget):
 def ask_filename(
         file_types: str = DEFAULT_FILE_TYPES,
         directory: str = "",
-        prompt: str = "Select File") -> Union[str, BciPyCoreException]:
+        prompt: str = "Select File",
+        strict=False) -> Union[str, BciPyCoreException]:
     """Prompt for a file using a GUI.
 
     Parameters
@@ -71,6 +72,9 @@ def ask_filename(
     - file_types : optional file type filters; Examples: 'Text files (*.txt)'
     or 'Image files (*.jpg *.gif)' or '*.csv;;*.pkl'
     - directory : optional directory
+    - prompt : optional prompt message to display to users
+    - strict : optional flag to raise an exception if the user cancels the dialog. Default is False.
+        If False, an empty string is returned.
 
     Returns
     -------
@@ -90,16 +94,21 @@ def ask_filename(
         app.quit()
 
         return filename
+    
+    if strict:
+        raise BciPyCoreException('No file selected.')
+    
+    return ''
 
-    raise BciPyCoreException('No file selected.')
 
-
-def ask_directory(prompt: str = "Select Directory") -> Union[str, BciPyCoreException]:
+def ask_directory(prompt: str = "Select Directory", strict=False) -> Union[str, BciPyCoreException]:
     """Prompt for a directory using a GUI.
 
     Parameters
     ----------
     prompt : optional prompt message to display to users
+    strict : optional flag to raise an exception if the user cancels the dialog. Default is False.
+        If False, an empty string is returned.
 
     Returns
     -------
@@ -120,4 +129,7 @@ def ask_directory(prompt: str = "Select Directory") -> Union[str, BciPyCoreExcep
 
         return name
 
-    raise BciPyCoreException('No directory selected.')
+    if strict:
+        raise BciPyCoreException('No directory selected.')
+    
+    return ''

--- a/bcipy/gui/file_dialog.py
+++ b/bcipy/gui/file_dialog.py
@@ -1,11 +1,13 @@
 # pylint: disable=no-name-in-module,missing-docstring,too-few-public-methods
 import sys
 from pathlib import Path
+from typing import Union
 
 from PyQt6 import QtGui
 from PyQt6.QtWidgets import QApplication, QFileDialog, QWidget
 
 from bcipy.preferences import preferences
+from bcipy.exceptions import BciPyCoreException
 
 DEFAULT_FILE_TYPES = "All Files (*)"
 
@@ -61,8 +63,8 @@ class FileDialog(QWidget):
 def ask_filename(
         file_types: str = DEFAULT_FILE_TYPES,
         directory: str = "",
-        prompt: str = "Select File") -> str:
-    """Prompt for a file.
+        prompt: str = "Select File") -> Union[str, BciPyCoreException]:
+    """Prompt for a file using a GUI.
 
     Parameters
     ----------
@@ -72,7 +74,7 @@ def ask_filename(
 
     Returns
     -------
-    path to file or None if the user cancelled the dialog.
+    path to file or raises an exception if the user cancels the dialog.
     """
     app = QApplication(sys.argv)
     dialog = FileDialog()
@@ -84,18 +86,24 @@ def ask_filename(
     if filename and path.is_file():
         preferences.last_directory = str(path.parent)
 
-    # Alternatively, we could use `app.closeAllWindows()`
-    app.quit()
+        # Alternatively, we could use `app.closeAllWindows()`
+        app.quit()
 
-    return filename
+        return filename
+    
+    raise BciPyCoreException('No file selected.')
 
 
-def ask_directory(prompt: str = "Select Directory") -> str:
-    """Prompt for a directory.
+def ask_directory(prompt: str = "Select Directory") -> Union[str, BciPyCoreException]:
+    """Prompt for a directory using a GUI.
+
+    Parameters
+    ----------
+    prompt : optional prompt message to display to users
 
     Returns
     -------
-    path to directory or None if the user cancelled the dialog.
+    path to directory or raises an exception if the user cancels the dialog.
     """
     app = QApplication(sys.argv)
 
@@ -107,7 +115,9 @@ def ask_directory(prompt: str = "Select Directory") -> str:
     if name and Path(name).is_dir():
         preferences.last_directory = name
 
-    # Alternatively, we could use `app.closeAllWindows()`
-    app.quit()
+        # Alternatively, we could use `app.closeAllWindows()`
+        app.quit()
 
-    return name
+        return name
+    
+    raise BciPyCoreException('No directory selected.')

--- a/bcipy/helpers/demo/demo_visualization.py
+++ b/bcipy/helpers/demo/demo_visualization.py
@@ -42,7 +42,10 @@ if __name__ == '__main__':
 
     path = args.path
     if not path:
-        path = load_experimental_data()
+        path = load_experimental_data(
+            message="Select the folder containing the raw_data.csv, parameters.json and triggers.txt",
+            strict=True
+        )
 
     parameters = load_json_parameters(f'{path}/{DEFAULT_PARAMETERS_FILENAME}',
                                       value_cast=True)

--- a/bcipy/helpers/offset.py
+++ b/bcipy/helpers/offset.py
@@ -340,7 +340,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     data_path = args.data_path
     if not data_path:
-        data_path = ask_directory()
+        data_path = ask_directory(prompt="Please select a BciPy time test directory..", strict=True)
 
     # grab the stim length from the data directory parameters
     stim_length = load_json_parameters(f'{data_path}/{DEFAULT_PARAMETERS_FILENAME}', value_cast=True)['stim_length']

--- a/bcipy/io/README.md
+++ b/bcipy/io/README.md
@@ -2,6 +2,6 @@
 
 The BciPy IO module contains functionality for loading and saving data in various formats. This includes the ability to convert data to BIDS format, load and save raw data, and load and save triggers.
 
-- `convert`: functionality for converting the bcipy raw data output to other formats (currently, EDF)
-- `load`: methods for loading most BciPy data. For loading of triggers, see triggers.py
-- `save`: methods for saving BciPy data in supported formats. For saving of triggers, see triggers.py
+- `convert`: functionality for converting the bcipy raw data output to other formats (currently, BrainVision and EDF), and for converting the raw data to BIDS format.
+- `load`: methods for loading most BciPy data formats, including raw data and triggers.
+- `save`: methods for saving BciPy data in supported formats.

--- a/bcipy/io/convert.py
+++ b/bcipy/io/convert.py
@@ -190,16 +190,16 @@ def convert_eyetracking_to_bids(
     # check that the raw data path exists
     if not os.path.exists(raw_data_path):
         raise FileNotFoundError(f"Raw eye tracking data path={raw_data_path} does not exist")
-    
+
     if not os.path.exists(output_dir):
         raise FileNotFoundError(f"Output directory={output_dir} does not exist")
-    
+
     found_files = glob.glob(f"{raw_data_path}/eyetracker*.csv")
     if len(found_files) == 0:
         raise FileNotFoundError(f"No raw eye tracking data found in directory={raw_data_path}")
     if len(found_files) > 1:
         raise ValueError(f"Multiple raw eye tracking data files found in directory={raw_data_path}")
-    
+
     eye_tracking_file = found_files[0]
     logger.info(f"Found raw eye tracking data file={eye_tracking_file}")
 
@@ -218,6 +218,7 @@ def convert_eyetracking_to_bids(
     data.to_csv(output_path, sep='\t', index=False)
     logger.info(f"Eye tracking data saved to {output_path}")
     return output_path
+
 
 def compress(tar_file_name: str, members: List[str]) -> None:
     """
@@ -370,7 +371,7 @@ def convert_to_mne(
         transform: Optional[Composition] = None,
         montage: str = 'standard_1020',
         volts: bool = False,
-        remove_system_channels: bool = True) -> RawArray:
+        remove_system_channels: bool = False) -> RawArray:
     """Convert to MNE.
 
     Returns BciPy RawData as an MNE RawArray. This assumes all channel names

--- a/bcipy/io/convert.py
+++ b/bcipy/io/convert.py
@@ -4,6 +4,7 @@ import logging
 import os
 import tarfile
 from typing import List, Optional, Tuple
+import glob
 
 import mne
 from enum import Enum
@@ -15,10 +16,9 @@ from bcipy.acquisition.devices import preconfigured_device
 from bcipy.config import (DEFAULT_PARAMETERS_FILENAME, RAW_DATA_FILENAME,
                           TRIGGER_FILENAME, SESSION_LOG_FILENAME)
 from bcipy.io.load import load_json_parameters, load_raw_data
-from bcipy.core.raw_data import RawData
+from bcipy.core.raw_data import RawData, get_1020_channel_map
 from bcipy.core.triggers import trigger_decoder
 from bcipy.signal.process import Composition
-# from bcipy.signal.process import get_default_transform
 
 logger = logging.getLogger(SESSION_LOG_FILENAME)
 
@@ -52,7 +52,8 @@ def convert_to_bids(
         output_dir: str,
         task_name: Optional[str] = None,
         line_frequency: float = 60,
-        format: ConvertFormat = ConvertFormat.BV) -> str:
+        format: ConvertFormat = ConvertFormat.BV,
+        label_duration: float = 0.5) -> str:
     """Convert to BIDS.
 
     Convert the raw data to the Brain Imaging Data Structure (BIDS) format.
@@ -65,13 +66,19 @@ def convert_to_bids(
     ----------
     data_dir - path to the directory containing the raw data, triggers, and parameters
     participant_id - the participant ID
+    session_id - the session ID
+    run_id - the run ID
     output_dir - the directory to save the BIDS formatted data
+    task_name - the name of the task
+    line_frequency - the line frequency of the data (50 or 60 Hz)
+    format - the format to convert the data to (BrainVision, EDF, FIF, or EEGLAB)
+    label_duration - the duration of the trigger labels in seconds. Default is 0.5 seconds.
 
     Returns
     -------
     The path to the BIDS formatted data
     """
-    # validate the inputs
+    # validate the inputs before proceeding
     if not os.path.exists(data_dir):
         raise FileNotFoundError(f"Data directory={data_dir} does not exist")
     if not os.path.exists(output_dir):
@@ -87,18 +94,12 @@ def convert_to_bids(
     # create file paths for raw data, triggers, and parameters
     raw_data_file = os.path.join(data_dir, f'{RAW_DATA_FILENAME}.csv')
     trigger_file = os.path.join(data_dir, TRIGGER_FILENAME)
-    parameters_file = os.path.join(data_dir, DEFAULT_PARAMETERS_FILENAME)
 
-    # load the raw data
+    # load the raw data and specifications for the device used to collect the data
     raw_data = load_raw_data(raw_data_file)
+    channel_map = get_1020_channel_map(raw_data.channels)
     device_spec = preconfigured_device(raw_data.daq_type)
     volts = True if device_spec.channel_specs[0].units == 'volts' else False
-
-    # load the parameters
-    # parameters = load_json_parameters(parameters_file, value_cast=True)
-    trial_window = (0.0, 0.5)
-
-    window_length = trial_window[1] - trial_window[0]
 
     # load the triggers without removing any triggers other than system triggers (default)
     trigger_targetness, trigger_timing, trigger_labels = trigger_decoder(
@@ -108,20 +109,24 @@ def convert_to_bids(
     )
 
     # convert the raw data to MNE format
-    breakpoint()
-    mne_data = convert_to_mne(raw_data, volts=volts, remove_system_channels=True)
+    mne_data = convert_to_mne(raw_data, volts=volts, channel_map=channel_map)
+
+    # add the trigger annotations to the MNE data
     targetness_annotations = mne.Annotations(
         onset=trigger_timing,
-        duration=[window_length] * len(trigger_timing),
+        duration=[label_duration] * len(trigger_timing),
         description=trigger_targetness,
     )
     label_annotations = mne.Annotations(
         onset=trigger_timing,
-        duration=[window_length] * len(trigger_timing),
+        duration=[label_duration] * len(trigger_timing),
         description=trigger_labels,
     )
     mne_data.set_annotations(targetness_annotations + label_annotations)
-    mne_data.info["line_freq"] = line_frequency  # set the line frequency to 60 Hz
+    # add the line frequency to the MNE data
+    mne_data.info["line_freq"] = line_frequency
+
+    # create the BIDS path for the data
     bids_path = BIDSPath(
         subject=participant_id,
         session=session_id,
@@ -139,8 +144,77 @@ def convert_to_bids(
         allow_preload=True,
         overwrite=True)
 
-    return bids_path.root
+    return bids_path.directory
 
+
+def convert_eyetracking_to_bids(
+        raw_data_path,
+        output_dir,
+        participant_id,
+        session_id,
+        run_id,
+        task_name) -> str:
+    """Converts the raw eye tracking data to BIDS format.
+
+    There is currently no standard for eye tracking data in BIDS. This function will write the raw eye tracking data
+    to a tsv file in a BIDS-style format.
+
+    Parameters
+    ----------
+    raw_data_path : str
+        Path to the raw eye tracking data
+    output_dir : str
+        Path to the output directory.
+        This should be where other BIDS formatted data is stored for the participant, session, and run.
+    participant_id : str
+        Participant ID, e.g. 'S01'
+    session_id : str
+        Session ID, e.g. '01'
+    run_id : str
+        Run ID, e.g. '01'
+    task_name : str
+        Task name. Example: 'RSVPCalibration'
+
+    Returns
+    -------
+    str
+        Path to the BIDS formatted eye tracking data
+    """
+    # use glob to find raw eye tracking data in the provided directory.
+    # It will be a csv file with eyetracker in the name.
+    # If there are multiple files, an error will be raised.
+
+    # check that the raw data path exists
+    if not os.path.exists(raw_data_path):
+        raise FileNotFoundError(f"Raw eye tracking data path={raw_data_path} does not exist")
+    
+    if not os.path.exists(output_dir):
+        raise FileNotFoundError(f"Output directory={output_dir} does not exist")
+    
+    found_files = glob.glob(f"{raw_data_path}/eyetracker*.csv")
+    if len(found_files) == 0:
+        raise FileNotFoundError(f"No raw eye tracking data found in directory={raw_data_path}")
+    if len(found_files) > 1:
+        raise ValueError(f"Multiple raw eye tracking data files found in directory={raw_data_path}")
+    
+    eye_tracking_file = found_files[0]
+    logger.info(f"Found raw eye tracking data file={eye_tracking_file}")
+
+    # make the et subdirectory
+    et_dir = os.path.join(output_dir, 'et')
+    os.makedirs(et_dir, exist_ok=True)
+
+    # load the raw eye tracking data
+    raw_data = load_raw_data(eye_tracking_file)
+    # get the data as a pandas DataFrame
+    data = raw_data.dataframe
+
+    # write the dataframe as a tsv file to the output directory
+    output_filename = f'sub-{participant_id}_ses-{session_id}_task-{task_name}-run-{run_id}_eyetracking.tsv'
+    output_path = os.path.join(et_dir, output_filename)
+    data.to_csv(output_path, sep='\t', index=False)
+    logger.info(f"Eye tracking data saved to {output_path}")
+    return output_path
 
 def compress(tar_file_name: str, members: List[str]) -> None:
     """
@@ -293,7 +367,7 @@ def convert_to_mne(
         transform: Optional[Composition] = None,
         montage: str = 'standard_1020',
         volts: bool = False,
-        remove_system_channels: bool = False) -> RawArray:
+        remove_system_channels: bool = True) -> RawArray:
     """Convert to MNE.
 
     Returns BciPy RawData as an MNE RawArray. This assumes all channel names
@@ -334,6 +408,7 @@ def convert_to_mne(
 
     # if no channel types provided, assume all channels are eeg
     if not channel_types:
+        logger.warning("No channel types provided. Assuming all channels are EEG.")
         channel_types = ['eeg'] * len(channels)
 
     # check that number of channel types matches number of channels in the case custom channel types are provided

--- a/bcipy/io/convert.py
+++ b/bcipy/io/convert.py
@@ -95,13 +95,8 @@ def convert_to_bids(
     volts = True if device_spec.channel_specs[0].units == 'volts' else False
 
     # load the parameters
-    parameters = load_json_parameters(parameters_file, value_cast=True)
-    trial_window = parameters.get("trial_window", (0.0, 0.5))
-
-    if task_name is None:
-        task_name = parameters.get("task")
-        if task_name is None:
-            raise ValueError("Task name must be provided or specified in the parameters")
+    # parameters = load_json_parameters(parameters_file, value_cast=True)
+    trial_window = (0.0, 0.5)
 
     window_length = trial_window[1] - trial_window[0]
 
@@ -113,6 +108,7 @@ def convert_to_bids(
     )
 
     # convert the raw data to MNE format
+    breakpoint()
     mne_data = convert_to_mne(raw_data, volts=volts, remove_system_channels=True)
     targetness_annotations = mne.Annotations(
         onset=trigger_timing,

--- a/bcipy/io/convert.py
+++ b/bcipy/io/convert.py
@@ -13,9 +13,9 @@ from mne_bids import BIDSPath, write_raw_bids
 from tqdm import tqdm
 
 from bcipy.acquisition.devices import preconfigured_device
-from bcipy.config import (DEFAULT_PARAMETERS_FILENAME, RAW_DATA_FILENAME,
+from bcipy.config import (RAW_DATA_FILENAME,
                           TRIGGER_FILENAME, SESSION_LOG_FILENAME)
-from bcipy.io.load import load_json_parameters, load_raw_data
+from bcipy.io.load import load_raw_data
 from bcipy.core.raw_data import RawData, get_1020_channel_map
 from bcipy.core.triggers import trigger_decoder
 from bcipy.signal.process import Composition
@@ -213,7 +213,7 @@ def convert_eyetracking_to_bids(
     os.makedirs(et_dir, exist_ok=True)
 
     # write the dataframe as a tsv file to the output directory
-    output_filename = f'sub-{participant_id}_ses-{session_id}_task-{task_name}-run-{run_id}_eyetracking.tsv'
+    output_filename = f'sub-{participant_id}_ses-{session_id}_task-{task_name}_run-{run_id}_eyetracking.tsv'
     output_path = os.path.join(et_dir, output_filename)
     data.to_csv(output_path, sep='\t', index=False)
     logger.info(f"Eye tracking data saved to {output_path}")
@@ -371,7 +371,7 @@ def convert_to_mne(
         transform: Optional[Composition] = None,
         montage: str = 'standard_1020',
         volts: bool = False,
-        remove_system_channels: bool = False) -> RawArray:
+        remove_system_channels: bool = True) -> RawArray:
     """Convert to MNE.
 
     Returns BciPy RawData as an MNE RawArray. This assumes all channel names

--- a/bcipy/io/demo/demo_convert.py
+++ b/bcipy/io/demo/demo_convert.py
@@ -143,7 +143,7 @@ if __name__ == '__main__':
 
     path = args.directory
     if not path:
-        path = ask_directory("Select the directory with data to be converted")
+        path = ask_directory("Select the directory with data to be converted", strict=True)
 
     # convert a study to BIDS format
     convert_experiment_to_bids(

--- a/bcipy/io/demo/demo_convert.py
+++ b/bcipy/io/demo/demo_convert.py
@@ -11,12 +11,13 @@ from bcipy.gui.file_dialog import ask_directory
 from bcipy.io.load import BciPySessionTaskData
 
 EXCLUDED_TASKS = ['Report', 'Offline', 'Intertask', 'BAD']
-# Note: We can share the eye tracking data as-is but we need 
+# Note: We can share the eye tracking data as-is but we need
 # sub1/eeg/.tsv sub1/eyetracker/.tsv
+
 
 def load_bcipy_data(directory: str, experiment_id: str) -> List[BciPySessionTaskData]:
     """Load the data from the given directory.
-    
+
     The expected directory structure is:
 
     directory/
@@ -31,7 +32,7 @@ def load_bcipy_data(directory: str, experiment_id: str) -> List[BciPySessionTask
     data = Path(directory)
     experiment_data = []
     for participant in data.iterdir():
-        
+
         # Skip files
         if not participant.is_dir():
             continue

--- a/bcipy/io/load.py
+++ b/bcipy/io/load.py
@@ -155,8 +155,8 @@ def load_json_parameters(path: str, value_cast: bool = False) -> Parameters:
     return Parameters(source=path, cast_values=value_cast)
 
 
-def load_experimental_data() -> str:
-    filename = ask_directory()  # show dialog box and return the path
+def load_experimental_data(message='', strict=False) -> str:
+    filename = ask_directory(prompt=message, strict=strict)  # show dialog box and return the path
     log.info("Loaded Experimental Data From: %s" % filename)
     return filename
 

--- a/bcipy/io/load.py
+++ b/bcipy/io/load.py
@@ -324,6 +324,7 @@ class BciPySessionTaskData:
             user_id: str,
             experiment_id: str,
             date_time: Optional[str] = None,
+            date: Optional[str] = None,
             task_name: Optional[str] = None,
             session_id: int = 1,
             run: int = 1) -> None:
@@ -332,16 +333,19 @@ class BciPySessionTaskData:
         self.experiment_id = experiment_id.replace('_', '')
         self.session_id = f'0{str(session_id)}' if session_id < 10 else str(session_id)
         self.date_time = date_time
+        self.date = date
         self.run = f'0{str(run)}' if run < 10 else str(run)
         self.path = path
         self.task_name = task_name
         self.info = {
-            'user_id': user_id,
+            'user_id': self.user_id,
             'experiment_id': self.experiment_id,
             'task_name': self.task_name,
+            'session_id': self.session_id,
+            'run': self.run,
+            'date': self.date,
             'date_time': self.date_time,
-            'run': run,
-            'path': path
+            'path': self.path
         }
 
     def __str__(self):
@@ -542,7 +546,8 @@ class BciPyCollection:
                     BciPySessionTaskData(
                         path=task_path,
                         user_id=user_id,
-                        date_time=date,
+                        date_time=date_time,
+                        date=date,
                         experiment_id=experiment_id,
                         run=run,
                         task_name=task.split(date)[0].strip('_')

--- a/bcipy/io/load.py
+++ b/bcipy/io/load.py
@@ -10,7 +10,6 @@ from typing import List, Optional, Union
 
 from bcipy.config import (DEFAULT_ENCODING, DEFAULT_EXPERIMENT_PATH,
                           DEFAULT_FIELD_PATH, DEFAULT_PARAMETERS_PATH,
-                          DEFAULT_PARAMETERS_FILENAME,
                           EXPERIMENT_FILENAME, FIELD_FILENAME,
                           SIGNAL_MODEL_FILE_SUFFIX, SESSION_LOG_FILENAME)
 from bcipy.gui.file_dialog import ask_directory, ask_filename
@@ -542,6 +541,7 @@ class BciPyCollection:
                 date = task_path.parts[-4]
                 experiment_id = task_path.parts[-3]
                 date_time = task_path.parts[-2]
+                task_name = task.split(date)[0].strip('_')
                 self.session_task_data.append(
                     BciPySessionTaskData(
                         path=task_path,
@@ -550,7 +550,7 @@ class BciPyCollection:
                         date=date,
                         experiment_id=experiment_id,
                         run=run,
-                        task_name=task.split(date)[0].strip('_')
+                        task_name=task_name
                     )
                 )
                 run += 1

--- a/bcipy/io/load.py
+++ b/bcipy/io/load.py
@@ -307,10 +307,10 @@ def fast_scandir(directory_name: str, return_path: bool = True) -> List[str]:
 class BciPySessionTaskData:
     """Session Task Data.
 
-    This class is used to represent a single task data session. It is used to store the
+    This class is used to represent a single task session. It is used to store the
     path to the task data, as well as the parameters and other information about the task.
 
-    /<local_path>/<user_id>/<date>/<experiment_id>/<date_time>/
+    /<path>/
         protocol.json
         <task_date_time>/
             parameters.json
@@ -323,28 +323,26 @@ class BciPySessionTaskData:
             path: str,
             user_id: str,
             experiment_id: str,
-            session_id: Optional[str] = None,
+            date_time: Optional[str] = None,
             task_name: Optional[str] = None,
+            session_id: int = 1,
             run: int = 1) -> None:
 
         self.user_id = user_id
         self.experiment_id = experiment_id.replace('_', '')
-        self.session_id = session_id
-        self.run = str(run)
+        self.session_id = f'0{str(session_id)}' if session_id < 10 else str(session_id)
+        self.date_time = date_time
+        self.run = f'0{str(run)}' if run < 10 else str(run)
         self.path = path
         self.task_name = task_name
         self.info = {
             'user_id': user_id,
             'experiment_id': self.experiment_id,
             'task_name': self.task_name,
+            'date_time': self.date_time,
             'run': run,
             'path': path
         }
-
-    def get_parameters(self) -> Parameters:
-        return load_json_parameters(
-            f'{self.path}/{DEFAULT_PARAMETERS_FILENAME}',
-            value_cast=True)
 
     def __str__(self):
         return f'BciPySessionTaskData: {self.info=}'
@@ -544,11 +542,10 @@ class BciPyCollection:
                     BciPySessionTaskData(
                         path=task_path,
                         user_id=user_id,
-                        date=date,
+                        date_time=date,
                         experiment_id=experiment_id,
-                        date_time=date_time,
                         run=run,
-                        task=task
+                        task_name=task.split(date)[0].strip('_')
                     )
                 )
                 run += 1

--- a/bcipy/io/load.py
+++ b/bcipy/io/load.py
@@ -322,29 +322,20 @@ class BciPySessionTaskData:
             self,
             path: str,
             user_id: str,
-            date: str,
             experiment_id: str,
-            date_time: str,
-            task: str,
+            session_id: Optional[str] = None,
+            task_name: Optional[str] = None,
             run: int = 1) -> None:
 
         self.user_id = user_id
-        self.date = date
         self.experiment_id = experiment_id.replace('_', '')
-        self.date_time = date_time.replace("_", "").replace("-", "")
-        self.session_id = f'{self.experiment_id}{self.date_time}'
-        self.date_time = date_time
-        self.task = task
+        self.session_id = session_id
         self.run = str(run)
         self.path = path
-        self.parameters = self.get_parameters()
-        self.task_name = self.parameters.get('task', 'unknown').replace(' ', '')
+        self.task_name = task_name
         self.info = {
             'user_id': user_id,
-            'date': date,
             'experiment_id': self.experiment_id,
-            'date_time': self.date_time,
-            'task': task,
             'task_name': self.task_name,
             'run': run,
             'path': path
@@ -578,7 +569,7 @@ def load_bcipy_data(
     Walks a data directory and returns a list of data paths for the given experiment id, user id, and date.
 
     The BciPy data directory is structured as follows:
-    data_directory/
+    data/
         user_ids/
             dates/
                 experiment_ids/

--- a/bcipy/io/tests/test_convert.py
+++ b/bcipy/io/tests/test_convert.py
@@ -288,7 +288,7 @@ class TestMNEConvert(unittest.TestCase):
 
     def test_convert_to_mne_without_remove_system_channels_throws_error(self):
         """Test the convert_to_mne function with system channels removed raises an error.
-        
+
         This is due to MNE requiring the channels be EEG. The system channels are not EEG.
         """
         with self.assertRaises(ValueError):
@@ -471,10 +471,18 @@ class TestConvertETBIDS(unittest.TestCase):
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
         self.trg_data, self.data, self.params = create_bcipy_session_artifacts(self.temp_dir, channels=3)
-        self.eyetracking_data = sample_data(ch_names=['timestamp', 'x', 'y', 'pupil'], daq_type='Gaze', sample_rate=60, rows=5000)
+        self.eyetracking_data = sample_data(
+            ch_names=[
+                'timestamp',
+                'x',
+                'y',
+                'pupil'],
+            daq_type='Gaze',
+            sample_rate=60,
+            rows=5000)
         devices.register(devices.DeviceSpec('Gaze', channels=['timestamp', 'x', 'y', 'pupil'], sample_rate=60))
 
-        write(self.eyetracking_data, Path(self.temp_dir, f'eyetracker.csv'))
+        write(self.eyetracking_data, Path(self.temp_dir, 'eyetracker.csv'))
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir)
@@ -506,7 +514,7 @@ class TestConvertETBIDS(unittest.TestCase):
             output_dir=self.temp_dir,
         )
         self.assertTrue(os.path.exists(response))
-       # Assert the et tsv file was created with the correct name
+        # Assert the et tsv file was created with the correct name
         self.assertTrue(os.path.exists(f"{self.temp_dir}/et/sub-100_ses-01_task-TestTask_run-01_eyetracking.tsv"))
 
     def test_convert_eyetracking_to_bids_reflects_session_id(self):
@@ -536,7 +544,7 @@ class TestConvertETBIDS(unittest.TestCase):
         self.assertTrue(os.path.exists(response))
         # Assert the et tsv file was created with the correct name
         self.assertTrue(os.path.exists(f"{self.temp_dir}/et/sub-01_ses-01_task-TestTask_run-100_eyetracking.tsv"))
-    
+
     def test_convert_eyetracking_to_bids_reflects_task_name(self):
         """Test the convert_eyetracking_to_bids function with a task name"""
         response = convert_eyetracking_to_bids(
@@ -592,7 +600,7 @@ class TestConvertETBIDS(unittest.TestCase):
     def test_convert_et_raises_error_with_multiple_data_files(self):
         """Test the convert_eyetracking_to_bids function raises an error with multiple data files"""
         # create a second data file
-        write(self.eyetracking_data, Path(self.temp_dir, f'eyetracker_2.csv'))
+        write(self.eyetracking_data, Path(self.temp_dir, 'eyetracker_2.csv'))
         with self.assertRaises(ValueError):
             convert_eyetracking_to_bids(
                 f"{self.temp_dir}/",

--- a/bcipy/io/tests/test_convert.py
+++ b/bcipy/io/tests/test_convert.py
@@ -551,6 +551,58 @@ class TestConvertETBIDS(unittest.TestCase):
         # Assert the et tsv file was created with the correct name
         self.assertTrue(os.path.exists(f"{self.temp_dir}/et/sub-01_ses-01_task-TestTaskEtc_run-01_eyetracking.tsv"))
 
+    def test_convert_et_raises_error_with_invalid_data_dir(self):
+        """Test the convert_eyetracking_to_bids function raises an error with invalid output directory"""
+        with self.assertRaises(FileNotFoundError):
+            convert_eyetracking_to_bids(
+                'invalid_data_dir',
+                participant_id='01',
+                session_id='01',
+                run_id='01',
+                task_name='TestTask',
+                output_dir=self.temp_dir
+            )
+
+    def test_convert_et_raises_error_with_output_dir_not_exist(self):
+        """Test the convert_eyetracking_to_bids function raises an error with invalid output directory"""
+        with self.assertRaises(FileNotFoundError):
+            convert_eyetracking_to_bids(
+                f"{self.temp_dir}/",
+                participant_id='01',
+                session_id='01',
+                run_id='01',
+                task_name='TestTask',
+                output_dir='invalid_output_dir'
+            )
+
+    def test_convert_et_raises_error_with_no_data_file(self):
+        """Test the convert_eyetracking_to_bids function raises an error with no data file"""
+        # remove the csv file
+        os.remove(f"{self.temp_dir}/eyetracker.csv")
+        with self.assertRaises(FileNotFoundError):
+            convert_eyetracking_to_bids(
+                f"{self.temp_dir}/",
+                participant_id='01',
+                session_id='01',
+                run_id='01',
+                task_name='TestTask',
+                output_dir=self.temp_dir,
+            )
+
+    def test_convert_et_raises_error_with_multiple_data_files(self):
+        """Test the convert_eyetracking_to_bids function raises an error with multiple data files"""
+        # create a second data file
+        write(self.eyetracking_data, Path(self.temp_dir, f'eyetracker_2.csv'))
+        with self.assertRaises(ValueError):
+            convert_eyetracking_to_bids(
+                f"{self.temp_dir}/",
+                participant_id='01',
+                session_id='01',
+                run_id='01',
+                task_name='TestTask',
+                output_dir=self.temp_dir,
+            )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/bcipy/signal/evaluate/artifact.py
+++ b/bcipy/signal/evaluate/artifact.py
@@ -566,7 +566,8 @@ if __name__ == "__main__":
     # if no path is provided, prompt for one using a GUI
     path = args.path
     if not path:
-        path = load_experimental_data()
+        path = load_experimental_data(
+            message='Select the directory with the sessions to analyze for artifacts', strict=True)
 
     positions = None
     for session in Path(path).iterdir():

--- a/bcipy/signal/model/offline_analysis.py
+++ b/bcipy/signal/model/offline_analysis.py
@@ -510,7 +510,9 @@ def offline_analysis(
     """
     assert parameters, "Parameters are required for offline analysis."
     if not data_folder:
-        data_folder = load_experimental_data()
+        data_folder = load_experimental_data(
+            message="Select the folder containing the data to be analyzed.",
+            strict=True)
 
     # Load default devices which are used for training the model with different channels, etc.
     devices_by_name = devices.load(

--- a/bcipy/task/actions.py
+++ b/bcipy/task/actions.py
@@ -217,7 +217,8 @@ class BciPyCalibrationReportAction(Task):
 
         if not protocol_path:
             protocol_path = ask_directory(
-                prompt="Select BciPy protocol directory with calibration data...")
+                prompt="Select BciPy protocol directory with calibration data...",
+                strict=True)
         self.protocol_path = protocol_path
         self.last_task_dir = last_task_dir
         self.trial_window = (-0.2, 1.0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ Pillow==9.4.0
 py-cpuinfo==9.0.0
 pyopengl==3.1.7
 PyQt6==6.7.1
+PyQt6-sip==13.8
 pywavelets==1.4.1
 tqdm==4.62.2
 reportlab==4.2.0


### PR DESCRIPTION
# Overview

Cleanup convert methods. Add DSI-24 support. Add 1020 coordinate methods. Add the ability to output eye tracker data. Minor bugfix on install dependencies. 

## Ticket

https://www.pivotaltracker.com/story/show/186801441
https://www.pivotaltracker.com/story/show/188668716 (data shared in Google Drive)

## Contributions

- `convert`: add convert et data to BIDS. Modify the demo to handle older data structures. 
- `load`: cleanup BciPySessionTaskData
- `raw_data`: add 1020 methods
- `requirements.txt` define `PyQt6-sip` to permit 3.8 builds

## Test

- `make test-all`
- Ran the demo_convert on Matrix Multimodal data and uploaded for NEU. 

## Documentation

- Are documentation updates required? In-line, README, or [documentation](https://github.com/BciPy/bcipy.github.io)? Done.

## Changelog

- Is the CHANGELOG.md updated with your detailed changes? Yes
