### PR TITLE
Simulator Metrics

### DIFF
--- a/bcipy/simulator/README.md
+++ b/bcipy/simulator/README.md
@@ -9,20 +9,24 @@ This Simulator module aims to automate experimentation by sampling EEG data from
 `main.py` is the entry point for program. After following `BciPy` readme steps for setup, run the module from terminal:
 
 ```
-(venv) $ python bcipy/simulator -h
-usage: simulator [-h] -d DATA_FOLDER [-g GLOB_PATTERN] -m MODEL_PATH -p PARAMETERS [-n N]
+(venv) $ bcipy-sim -h
+usage: bcipy-sim [-h] [-i] [--gui] [-d DATA_FOLDER] [-m MODEL_PATH] [-p PARAMETERS] [-n N] [-s SAMPLER] [-o OUTPUT]
 
 optional arguments:
   -h, --help            show this help message and exit
+  -i, --interactive     Use interactive command line for selecting simulator inputs
+  --gui                 Use interactive GUI for selecting simulator inputs
   -d DATA_FOLDER, --data_folder DATA_FOLDER
-                        Raw data folders to be processed.
-  -g GLOB_PATTERN, --glob_pattern GLOB_PATTERN
-                        glob pattern to select a subset of data folders Ex. "*RSVP_Copy_Phrase*"
+                        Raw data folders to be processed. Multiple values can be provided, or a single parent folder.
   -m MODEL_PATH, --model_path MODEL_PATH
-                        Signal models to be used
+                        Signal models to be used. Multiple models can be provided.
   -p PARAMETERS, --parameters PARAMETERS
                         Parameter File to be used
   -n N                  Number of times to run the simulation
+  -s SAMPLER, --sampler SAMPLER
+                        Sampling strategy
+  -o OUTPUT, --output OUTPUT
+                        Sim output path
 ```
 
 For example,
@@ -30,21 +34,24 @@ For example,
 
 #### Program Args
 
-- `d` : the data wrapper folder argument is necessary. This folder is expected to contain 1 or more session folders. Each session folder should contain
+- `i` : Interactive command line interface. Provide this flag by itself to be prompted for each parameter.
+- `gui`: A graphical user interface for configuring a simulation. This mode will output the command line arguments which can be used to repeat the simulation.
+- `d` : Raw data folders to be processed. One ore more values can be provided. Each session data folder should contain
   _raw_data.csv_, _triggers.txt_, _parameters.json_. These files will be used to construct a data pool from which simulator will sample EEG and other device responses. The parameters file in each data folder will be used to check compatibility with the simulation/model parameters.
-- `g` : optional glob filter that can be used to select a subset of data within the wrapper directory.
-  - Ex. `"*Matrix_Copy*Jan_2024*"` will select all data for all Matrix Copy Phrase sessions recorded in January of 2024 (assuming the BciPy folder naming convention).
-  - Glob patterns can also include nested directories (ex. `"*/*Matrix_Copy*"`).
 - `p` : path to the parameters.json file used to run the simulation. These parameters will be applied to
   all raw_data files when loading. This file can specify various aspects of the simulation, including the language model to be used, the text to be spelled, etc. Timing-related parameters should generally match the parameters file used for training the signal model(s).
-- `m`: all pickle (.pkl) files in this directory will be loaded as signal models.
+- `m`: Path to a pickled (.pkl) signal model. One or more models can be provided.
+- `n`: Number of simulation runs
+- `o`: Output directory for all simulation artifacts.
 
 #### Sim Output Details
 
-Output folders are generally located in the `simulator/generated` directory. Each simulation will create a new directory. The directory name will be  prefixed with `SIM` and will include the current date and time.
+Output folders are generally located in the `data/simulator` directory, but can be configured per simulation. Each simulation will create a new directory. The directory name will be  prefixed with `SIM` and will include the current date and time.
 
 - `parameters.json` captures params used for the simulation.
-- `sim.log` is a log file for the simulation
+- `sim.log` is a log file for the simulation; metrics will be output here.
+- `summary_data.json` summarizes session data from each of the runs into a single data structure.
+- `metrics.png` boxplots for several metrics summarizing all simulation runs.
 
 A directory is created for each simulation run. The directory contents are similar to the session output in a normal bcipy task. Each run directory contains:
 

--- a/bcipy/simulator/data/sampler.py
+++ b/bcipy/simulator/data/sampler.py
@@ -103,7 +103,7 @@ class TargetNontargetSampler(Sampler):
             filtered_data = self.data_engine.query(filters, samples=1)
             sample_rows.append(filtered_data[0])
 
-        log.debug(f"Samples:\n{format_samples(sample_rows)}")
+        log.info(f"Samples:\n{format_samples(sample_rows)}")
         return sample_rows
 
     def query_filters(self, symbol: str, is_target: bool) -> List[QueryFilter]:
@@ -221,7 +221,7 @@ class InquirySampler(Sampler):
             Trial(**sorted_inquiry_df.iloc[i])
             for i in range(len(sorted_inquiry_df))
         ]
-        log.debug(f"EEG Samples:\n{format_samples(rows)}")
+        log.info(f"EEG Samples:\n{format_samples(rows)}")
         return rows
 
 

--- a/bcipy/simulator/metrics.py
+++ b/bcipy/simulator/metrics.py
@@ -4,7 +4,7 @@ import logging
 from collections import Counter
 from json import load
 from pathlib import Path
-from typing import Dict, List
+from typing import Any, Dict, List
 
 import pandas as pd
 
@@ -18,7 +18,7 @@ SUMMARY_DATA_FILE_NAME = "summary_data.json"
 TASK_SUMMARY_PREFIX = "task_summary__"
 
 
-def add_item(container: Dict[str, List], key: str, value: float):
+def add_item(container: Dict[str, List], key: str, value: Any):
     """Add or append value"""
     if key in container:
         container[key].append(value)
@@ -63,12 +63,11 @@ def session_paths(sim_dir: str) -> List[Path]:
     ]
 
 
-def summarize(sim_dir: str) -> Dict:
+def summarize(sim_dir: str) -> Dict[str, List[Any]]:
     """Summarize all session runs."""
-    combined_metrics = {}
+    combined_metrics: Dict[str, List[Any]] = {}
     for session_path in session_paths(sim_dir):
         with open(session_path, 'r', encoding=DEFAULT_ENCODING) as json_file:
-            print("Loading: " + session_path)
             session_dict = load(json_file)
             add_items(combined_metrics, session_dict)
     return combined_metrics

--- a/bcipy/simulator/metrics.py
+++ b/bcipy/simulator/metrics.py
@@ -144,13 +144,13 @@ def report(sim_dir: str, show_plots: bool = False) -> None:
     """Summarize the data, write as a JSON file, and output a summary to
     the top level log file."""
     summary = summarize(sim_dir)
-    save_json_data(summarize(sim_dir), sim_dir, SUMMARY_DATA_FILE_NAME)
+    save_json_data(summary, sim_dir, SUMMARY_DATA_FILE_NAME)
 
     df = pd.DataFrame(summary)
     log_descriptive_stats(df)
 
     logger.info("Typed:")
-    logger.info(Counter(summary['typed']))
+    logger.info(Counter(summary.get('typed')))
     ave_minutes = round((df['total_seconds'] / 60).mean(), 2)
     logger.info(f"Average duration: {ave_minutes} minutes")
     plot_results(df, save_path=plot_save_path(sim_dir), show=show_plots)

--- a/bcipy/simulator/metrics.py
+++ b/bcipy/simulator/metrics.py
@@ -1,0 +1,114 @@
+"""Summarize metrics across simulator runs."""
+
+import logging
+from collections import Counter
+from json import load
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+
+from bcipy.config import DEFAULT_ENCODING
+from bcipy.io.save import save_json_data
+from bcipy.simulator.util.artifact import TOP_LEVEL_LOGGER_NAME
+
+logger = logging.getLogger(TOP_LEVEL_LOGGER_NAME)
+
+SUMMARY_DATA_FILE_NAME = "summary_data.json"
+TASK_SUMMARY_PREFIX = "task_summary__"
+
+
+def add_item(container: Dict[str, List], key: str, value: float):
+    """Add or append value"""
+    if key in container:
+        container[key].append(value)
+    else:
+        container[key] = [value]
+
+
+def get_final_typed(session_dict: Dict) -> str:
+    """Get the final typed word"""
+    all_series = session_dict['series']
+    if all_series.keys():
+        last_series_key = str(max(map(int, all_series.keys())))
+        inquiries = all_series.get(last_series_key, {})
+        if inquiries.keys():
+            last_inquiry_key = str(max(map(int, inquiries.keys())))
+            return inquiries.get(last_inquiry_key).get('next_display_state',
+                                                       '')
+    return ''
+
+
+def add_items(combined_metrics: Dict, session_dict: Dict):
+    """Add all items of interest from the session data."""
+    keys = [
+        'total_number_series', 'total_inquiries', 'total_selections',
+        'inquiries_per_selection'
+    ]
+    for key in keys:
+        add_item(combined_metrics, key, session_dict[key])
+
+    for key in session_dict['task_summary'].keys():
+        if 'switch' not in key and 'rate' not in key:
+            add_item(combined_metrics, f"{TASK_SUMMARY_PREFIX}{key}",
+                     session_dict['task_summary'][key])
+    add_item(combined_metrics, 'typed', get_final_typed(session_dict))
+
+
+def session_paths(sim_dir: str) -> List[Path]:
+    """List of paths to the session.json files"""
+    return [
+        Path(run_dir, "session.json")
+        for run_dir in sorted(Path(sim_dir).glob("run*/"))
+    ]
+
+
+def summarize(sim_dir: str) -> Dict:
+    """Summarize all session runs."""
+    combined_metrics = {}
+    for session_path in session_paths(sim_dir):
+        with open(session_path, 'r', encoding=DEFAULT_ENCODING) as json_file:
+            print("Loading: " + session_path)
+            session_dict = load(json_file)
+            add_items(combined_metrics, session_dict)
+    return combined_metrics
+
+
+def rename_df_column(colname: str) -> str:
+    """Rename dataframe columns for reporting"""
+    if colname.startswith(TASK_SUMMARY_PREFIX):
+        return colname[len(TASK_SUMMARY_PREFIX):]
+    return colname
+
+
+def log_descriptive_stats(df: pd.DataFrame) -> None:
+    """Log the descriptive statistics for the given dataframe.
+
+    See https://stackoverflow.com/questions/25351968/how-can-i-display-full-non-truncated-dataframe-information-in-html-when-conver
+    """
+    df.rename(columns=rename_df_column, inplace=True)
+
+    pd.set_option('display.max_columns', None)
+    pd.set_option('display.width', 2000)
+    pd.set_option('display.float_format', "{:20,.2f}".format)
+    pd.set_option('display.max_colwidth', None)
+
+    logger.info(f"Metrics:\n{df.describe()}")
+
+    pd.reset_option('display.max_columns')
+    pd.reset_option('display.width')
+    pd.reset_option('display.float_format')
+    pd.reset_option('display.max_colwidth')
+
+
+def report(sim_dir: str) -> None:
+    """Summarize the data, write as a JSON file, and output a summary to
+    the top level log file."""
+    summary = summarize(sim_dir)
+    save_json_data(summarize(sim_dir), sim_dir, SUMMARY_DATA_FILE_NAME)
+
+    df = pd.DataFrame(summary)
+    log_descriptive_stats(df)
+
+    logger.info("Typed:")
+    logger.info(Counter(summary['typed']))

--- a/bcipy/simulator/metrics.py
+++ b/bcipy/simulator/metrics.py
@@ -1,11 +1,13 @@
 """Summarize metrics across simulator runs."""
 
 import logging
+import sys
 from collections import Counter
 from json import load
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
+import matplotlib.pyplot as plt
 import pandas as pd
 
 from bcipy.config import DEFAULT_ENCODING
@@ -100,6 +102,25 @@ def log_descriptive_stats(df: pd.DataFrame) -> None:
     pd.reset_option('display.max_colwidth')
 
 
+def plot_save_path(sim_dir: str) -> str:
+    """Save path for plots."""
+    return f"{sim_dir}/metrics.png"
+
+
+def plot_results(df: pd.DataFrame,
+                 save_path: Optional[str] = None,
+                 show: bool = True) -> None:
+    """Plot the dataframe"""
+    df.boxplot(column=[
+        'total_number_series', 'total_inquiries', 'inquiries_per_selection', 'selections_correct',
+        'selections_incorrect'
+    ], figsize=(11, 8.5))
+    if save_path:
+        plt.savefig(save_path)
+    if show:
+        plt.show()
+
+
 def report(sim_dir: str) -> None:
     """Summarize the data, write as a JSON file, and output a summary to
     the top level log file."""
@@ -111,3 +132,8 @@ def report(sim_dir: str) -> None:
 
     logger.info("Typed:")
     logger.info(Counter(summary['typed']))
+    plot_results(df, save_path=plot_save_path(sim_dir))
+
+
+if __name__ == '__main__':
+    report(sim_dir=sys.argv[1])

--- a/bcipy/simulator/task/task_factory.py
+++ b/bcipy/simulator/task/task_factory.py
@@ -56,14 +56,14 @@ class TaskFactory():
         self.signal_models = [
             load_signal_model(path) for path in signal_model_paths
         ]
-        logger.debug(self.signal_models)
+        logger.info(self.signal_models)
 
         logger.info("Initializing language model")
         self.language_model = init_language_model(self.parameters)
-        logger.debug(self.language_model)
+        logger.info(self.language_model)
 
         self.samplers = self.init_samplers(self.signal_models)
-        logger.debug(self.samplers)
+        logger.info(self.samplers)
 
     def init_samplers(
             self,

--- a/bcipy/simulator/task/task_runner.py
+++ b/bcipy/simulator/task/task_runner.py
@@ -5,6 +5,7 @@ import logging
 import sys
 from pathlib import Path
 
+import bcipy.simulator.metrics as metrics
 # pylint: disable=unused-import
 # flake8: noqa
 from bcipy.simulator.data.sampler import Sampler, TargetNontargetSampler
@@ -108,7 +109,7 @@ def main():
                         type=Path,
                         required=False,
                         default=DEFAULT_SAVE_LOCATION,
-                        help="Number of times to run the simulation")
+                        help="Sim output path")
     args = parser.parse_args()
     sim_args = vars(args)
 
@@ -134,6 +135,7 @@ def main():
                             task_factory=task_factory,
                             runs=runs)
         runner.run()
+        metrics.report(sim_dir)
 
 
 if __name__ == '__main__':

--- a/bcipy/simulator/task/task_runner.py
+++ b/bcipy/simulator/task/task_runner.py
@@ -5,7 +5,7 @@ import logging
 import sys
 from pathlib import Path
 
-import bcipy.simulator.metrics as metrics
+import bcipy.simulator.util.metrics as metrics
 # pylint: disable=unused-import
 # flake8: noqa
 from bcipy.simulator.data.sampler import Sampler, TargetNontargetSampler

--- a/bcipy/simulator/tests/test_metrics.py
+++ b/bcipy/simulator/tests/test_metrics.py
@@ -2,7 +2,8 @@
 import unittest
 from unittest.mock import patch
 
-from bcipy.simulator.metrics import (add_item, add_items, get_final_typed,
+from bcipy.simulator.metrics import (add_item, add_items, calculate_duration,
+                                     get_final_typed, plot_save_path,
                                      rename_df_column, summarize)
 
 SAMPLE_SERIES_DATA = {
@@ -86,7 +87,7 @@ class TestSimMetrics(unittest.TestCase):
         """Test session metrics accumulation"""
         combined = {}
         session_data = SAMPLE_SESSION1
-        add_items(combined, session_data)
+        add_items(combined, session_data, inquiry_seconds=2)
         for key in [
                 "total_number_series", "total_inquiries", "total_selections",
                 "inquiries_per_selection", "task_summary__selections_correct",
@@ -97,17 +98,23 @@ class TestSimMetrics(unittest.TestCase):
             self.assertTrue(key in combined)
             self.assertEqual(1, len(combined[key]))
 
+    @patch('bcipy.simulator.metrics.max_inquiry_duration')
+    @patch('bcipy.simulator.metrics.sim_parameters')
     @patch('bcipy.simulator.metrics.load')
     @patch('bcipy.simulator.metrics.open')
     @patch('bcipy.simulator.metrics.session_paths')
-    def test_summarize(self, session_path_mock, open_mock, json_mock):
+    def test_summarize(self, session_path_mock, open_mock, json_mock,
+                       sim_parameters_mock, max_inquiry_duration_mock):
         """Test summary function"""
         session_path_mock.return_value = [
             'run1/session.json', 'run2/session.json'
         ]
         json_mock.side_effect = [SAMPLE_SESSION1, SAMPLE_SESSION2]
+        max_inquiry_duration_mock.return_value = 2
         result = summarize("sim-dir")
 
+        sim_parameters_mock.assert_called_once_with("sim-dir")
+        max_inquiry_duration_mock.assert_called_once()
         self.assertEqual(open_mock.call_count, 2)
         for key in [
                 "total_number_series", "total_inquiries", "total_selections",
@@ -125,6 +132,15 @@ class TestSimMetrics(unittest.TestCase):
                          rename_df_column("total_inquiries"))
         self.assertEqual("selections_correct",
                          rename_df_column("task_summary__selections_correct"))
+
+    def test_plot_name(self):
+        """Test naming for plots"""
+        self.assertEqual("sim_dir/metrics.png", plot_save_path("sim_dir"))
+
+    def test_compute_duration(self):
+        """Test the calculation of the overall session duration"""
+        self.assertEqual(
+            250, calculate_duration(inquiry_count=100, inquiry_seconds=2.5))
 
 
 if __name__ == '__main__':

--- a/bcipy/simulator/tests/test_metrics.py
+++ b/bcipy/simulator/tests/test_metrics.py
@@ -2,11 +2,12 @@
 import unittest
 from unittest.mock import Mock, patch
 
-from bcipy.simulator.metrics import (SUMMARY_DATA_FILE_NAME, add_item,
-                                     add_items, calculate_duration,
-                                     get_final_typed, log_descriptive_stats,
-                                     plot_results, plot_save_path,
-                                     rename_df_column, report, summarize)
+from bcipy.simulator.util.metrics import (SUMMARY_DATA_FILE_NAME, add_item,
+                                          add_items, calculate_duration,
+                                          get_final_typed,
+                                          log_descriptive_stats, plot_results,
+                                          plot_save_path, rename_df_column,
+                                          report, summarize)
 
 SAMPLE_SERIES_DATA = {
     "1": {
@@ -113,11 +114,11 @@ class TestSimMetrics(unittest.TestCase):
             self.assertTrue(key in combined)
             self.assertEqual(1, len(combined[key]))
 
-    @patch('bcipy.simulator.metrics.max_inquiry_duration')
-    @patch('bcipy.simulator.metrics.sim_parameters')
-    @patch('bcipy.simulator.metrics.load')
-    @patch('bcipy.simulator.metrics.open')
-    @patch('bcipy.simulator.metrics.session_paths')
+    @patch('bcipy.simulator.util.metrics.max_inquiry_duration')
+    @patch('bcipy.simulator.util.metrics.sim_parameters')
+    @patch('bcipy.simulator.util.metrics.load')
+    @patch('bcipy.simulator.util.metrics.open')
+    @patch('bcipy.simulator.util.metrics.session_paths')
     def test_summarize(self, session_path_mock, open_mock, json_mock,
                        sim_parameters_mock, max_inquiry_duration_mock):
         """Test summary function"""
@@ -157,8 +158,8 @@ class TestSimMetrics(unittest.TestCase):
         self.assertEqual(
             250, calculate_duration(inquiry_count=100, inquiry_seconds=2.5))
 
-    @patch("bcipy.simulator.metrics.plt.show")
-    @patch("bcipy.simulator.metrics.plt.savefig")
+    @patch("bcipy.simulator.util.metrics.plt.show")
+    @patch("bcipy.simulator.util.metrics.plt.savefig")
     def test_plot_results_no_save(self, savefig_mock, show_mock):
         """Test plotting without saving"""
         mock_df = Mock()
@@ -166,8 +167,8 @@ class TestSimMetrics(unittest.TestCase):
         savefig_mock.assert_not_called()
         show_mock.assert_called_once()
 
-    @patch("bcipy.simulator.metrics.plt.show")
-    @patch("bcipy.simulator.metrics.plt.savefig")
+    @patch("bcipy.simulator.util.metrics.plt.show")
+    @patch("bcipy.simulator.util.metrics.plt.savefig")
     def test_plot_results_no_show(self, savefig_mock, show_mock):
         """Test plotting without saving"""
         mock_df = Mock()
@@ -175,8 +176,8 @@ class TestSimMetrics(unittest.TestCase):
         savefig_mock.assert_not_called()
         show_mock.assert_not_called()
 
-    @patch("bcipy.simulator.metrics.plt.show")
-    @patch("bcipy.simulator.metrics.plt.savefig")
+    @patch("bcipy.simulator.util.metrics.plt.show")
+    @patch("bcipy.simulator.util.metrics.plt.savefig")
     def test_plot_results_with_save(self, savefig_mock, show_mock):
         """Test plotting without saving"""
         mock_df = Mock()
@@ -191,10 +192,10 @@ class TestSimMetrics(unittest.TestCase):
         mock_df.rename.assert_called_once()
         mock_df.describe.assert_called_once()
 
-    @patch("bcipy.simulator.metrics.plot_results")
-    @patch("bcipy.simulator.metrics.log_descriptive_stats")
-    @patch("bcipy.simulator.metrics.save_json_data")
-    @patch("bcipy.simulator.metrics.summarize")
+    @patch("bcipy.simulator.util.metrics.plot_results")
+    @patch("bcipy.simulator.util.metrics.log_descriptive_stats")
+    @patch("bcipy.simulator.util.metrics.save_json_data")
+    @patch("bcipy.simulator.util.metrics.summarize")
     def test_report(self, summarize_mock, save_json_data_mock, log_stats_mock,
                     plot_results_mock):
         """Test reporting"""

--- a/bcipy/simulator/tests/test_metrics.py
+++ b/bcipy/simulator/tests/test_metrics.py
@@ -1,0 +1,131 @@
+"""Test simulator metrics"""
+import unittest
+from unittest.mock import patch
+
+from bcipy.simulator.metrics import (add_item, add_items, get_final_typed,
+                                     rename_df_column, summarize)
+
+SAMPLE_SERIES_DATA = {
+    "1": {
+        "0": {
+            "next_display_state": "HELL"
+        }
+    },
+    "2": {
+        "0": {
+            "next_display_state": "HELL"
+        },
+        "1": {
+            "next_display_state": "HELLO"
+        }
+    }
+}
+
+SAMPLE_SESSION1 = {
+    "series": SAMPLE_SERIES_DATA,
+    "total_time_spent": 0.0,
+    "total_minutes": 0.0,
+    "total_number_series": 14,
+    "total_inquiries": 45,
+    "total_selections": 14,
+    "inquiries_per_selection": 3.2,
+    "task_summary": {
+        "selections_correct": 14,
+        "selections_incorrect": 0,
+        "selections_correct_symbols": 14,
+        "switch_total": 0,
+        "switch_per_selection": 0.0,
+        "switch_response_time": None,
+        "typing_accuracy": 1.0,
+        "correct_rate": 0,
+        "copy_rate": 0
+    }
+}
+
+SAMPLE_SESSION2 = {
+    "series": SAMPLE_SERIES_DATA,
+    "total_time_spent": 0.0,
+    "total_minutes": 0.0,
+    "total_number_series": 14,
+    "total_inquiries": 16,
+    "total_selections": 14,
+    "inquiries_per_selection": 1.1428571428571428,
+    "task_summary": {
+        "selections_correct": 14,
+        "selections_incorrect": 0,
+        "selections_correct_symbols": 14,
+        "switch_total": 0,
+        "switch_per_selection": 0.0,
+        "switch_response_time": None,
+        "typing_accuracy": 1.0,
+        "correct_rate": 0,
+        "copy_rate": 0
+    }
+}
+
+
+class TestSimMetrics(unittest.TestCase):
+    """Tests for simulator metrics"""
+
+    def test_add_item(self):
+        """Test adding an item to a dict of sequences."""
+        container = {'data1': [1]}
+        add_item(container, 'data2', 10)
+        self.assertTrue('data2' in container)
+        self.assertEqual([10], container['data2'])
+
+        add_item(container, 'data1', 2)
+        self.assertEqual([1, 2], container['data1'])
+
+    def test_get_final_typed(self):
+        """Get final typed text from the series data"""
+        session_data = {'series': SAMPLE_SERIES_DATA}
+        self.assertEqual("HELLO", get_final_typed(session_data))
+
+    def test_add_session_items(self):
+        """Test session metrics accumulation"""
+        combined = {}
+        session_data = SAMPLE_SESSION1
+        add_items(combined, session_data)
+        for key in [
+                "total_number_series", "total_inquiries", "total_selections",
+                "inquiries_per_selection", "task_summary__selections_correct",
+                "task_summary__selections_incorrect",
+                "task_summary__selections_correct_symbols",
+                "task_summary__typing_accuracy", "typed"
+        ]:
+            self.assertTrue(key in combined)
+            self.assertEqual(1, len(combined[key]))
+
+    @patch('bcipy.simulator.metrics.load')
+    @patch('bcipy.simulator.metrics.open')
+    @patch('bcipy.simulator.metrics.session_paths')
+    def test_summarize(self, session_path_mock, open_mock, json_mock):
+        """Test summary function"""
+        session_path_mock.return_value = [
+            'run1/session.json', 'run2/session.json'
+        ]
+        json_mock.side_effect = [SAMPLE_SESSION1, SAMPLE_SESSION2]
+        result = summarize("sim-dir")
+
+        self.assertEqual(open_mock.call_count, 2)
+        for key in [
+                "total_number_series", "total_inquiries", "total_selections",
+                "inquiries_per_selection", "task_summary__selections_correct",
+                "task_summary__selections_incorrect",
+                "task_summary__selections_correct_symbols",
+                "task_summary__typing_accuracy", "typed"
+        ]:
+            self.assertTrue(key in result)
+            self.assertEqual(2, len(result[key]))
+
+    def test_rename_df_column(self):
+        """Test renaming columns for output"""
+        self.assertEqual("total_inquiries",
+                         rename_df_column("total_inquiries"))
+        self.assertEqual("selections_correct",
+                         rename_df_column("task_summary__selections_correct"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bcipy/simulator/ui/gui.py
+++ b/bcipy/simulator/ui/gui.py
@@ -537,10 +537,10 @@ class SimConfigForm(QWidget):
 
         args = []
         if self.outdir():
-            args.append(f"-o {self.outdir()}")
-        args.append(f"-p {self.parameters_path}")
-        args.extend([f"-m {path}" for path in self.model_paths])
-        args.extend([f"-d {source}" for source in self.data_paths])
+            args.append(f"-o '{self.outdir()}'")
+        args.append(f"-p '{self.parameters_path}'")
+        args.extend([f"-m '{path}'" for path in self.model_paths])
+        args.extend([f"-d '{source}'" for source in self.data_paths])
 
         args.append(f"-n {self.runs()}")
 

--- a/bcipy/simulator/util/artifact.py
+++ b/bcipy/simulator/util/artifact.py
@@ -30,14 +30,14 @@ def configure_logger(log_path: str,
     """
 
     log = logging.getLogger(logger_name)  # configuring root logger
-    log.setLevel(logging.DEBUG)
+    log.setLevel(logging.INFO)
     # Create handlers for logging to the standard output and a file
     stdout_handler = logging.StreamHandler(stream=sys.stdout)
     file_handler = logging.FileHandler(f"{log_path}/{file_name}")
 
     # Set the log levels on the handlers
     stdout_handler.setLevel(logging.INFO)
-    file_handler.setLevel(logging.DEBUG)
+    file_handler.setLevel(logging.INFO)
 
     fmt = '[%(asctime)s][%(name)s][%(levelname)s]: %(message)s'
     fmt_file = logging.Formatter(fmt)

--- a/bcipy/simulator/util/artifact.py
+++ b/bcipy/simulator/util/artifact.py
@@ -13,6 +13,7 @@ from bcipy.config import ROOT
 TOP_LEVEL_LOGGER_NAME = 'sim_logger'
 DEFAULT_LOGFILE_NAME = 'sim.log'
 DEFAULT_SAVE_LOCATION = f"{ROOT}/data/simulator"
+RUN_PREFIX = "run_"
 
 
 def configure_logger(log_path: str,
@@ -78,7 +79,7 @@ def configure_run_directory(sim_dir: str, run: int) -> str:
     """Create the necessary directories and configure the logger.
     Returns the run directory.
     """
-    run_name = f"run_{run}"
+    run_name = f"{RUN_PREFIX}{run}"
     path = f"{sim_dir}/{run_name}"
     os.mkdir(path)
     configure_logger(log_path=path,

--- a/scripts/python/update_params.py
+++ b/scripts/python/update_params.py
@@ -5,7 +5,7 @@ import json
 import shutil
 from pathlib import Path
 
-from bcipy.helpers.parameters import DEFAULT_PARAMETERS_PATH, Parameters
+from bcipy.core.parameters import DEFAULT_PARAMETERS_PATH, Parameters
 
 
 def update(params_path: str) -> None:


### PR DESCRIPTION
# Overview

Compile metrics summarizing all of the runs in a simulation.
* Outputs summary_data.json which collects the metrics from each session.json file in the run.
* Computes descriptive statistics for each field and outputs the results to the log files and console.
* Generates box plots for several statistics of interest.
* Outputs the mean duration of the runs.

## Ticket

https://www.pivotaltracker.com/story/show/188335185

## Contributions

- Also updated sim logging to use INFO, rather than DEBUG to clean up the log files.

## Test

- Unit tests
- Ran several simulations and inspected the output.

## Screenshots
<img width="1765" alt="Screenshot 2024-12-17 at 1 37 33 PM" src="https://github.com/user-attachments/assets/abdf3f2d-cd31-4464-8e69-0f336cdef044" />

<img width="1257" alt="Screenshot 2024-12-17 at 1 37 57 PM" src="https://github.com/user-attachments/assets/0b8facd0-3615-4735-886f-0796275fdf29" />
