### PR TITLE
Simulator Trial Data

### DIFF
--- a/bcipy/core/tests/test_list.py
+++ b/bcipy/core/tests/test_list.py
@@ -1,6 +1,7 @@
 """Tests for list processing utilities"""
 import unittest
-from bcipy.core.list import destutter, grouper
+
+from bcipy.core.list import destutter, expanded, find_index, grouper, swapped
 
 
 class TestListUtilities(unittest.TestCase):
@@ -48,13 +49,46 @@ class TestListUtilities(unittest.TestCase):
         for resp, exp in zip(response, expected):
             self.assertEqual(resp, exp)
 
-    def test_grouper_incomplete_value_error_unsupported_incompelte_mode_defined(self):
+    def test_grouper_incomplete_value_error_unsupported_incompelte_mode_defined(
+            self):
         iterable = 'ABCDEFG'
         chunk_size = 2
         incomplete = 'not_defined'
 
         with self.assertRaises(ValueError):
             grouper(iterable, chunk_size, incomplete=incomplete)
+
+    def test_find_index(self):
+        """Test find index of item"""
+        self.assertEqual(2, find_index([1, 2, 3, 4], 3))
+
+    def test_find_index_using_key(self):
+        """Find index using the key arg"""
+        item1 = dict(a=1, b=1)
+        item2 = dict(a=1, b=2)
+        item3 = dict(a=2, b=1)
+        item4 = dict(a=2, b=2)
+        self.assertEqual(
+            1,
+            find_index([item1, item2, item3, item4],
+                       match_item=2,
+                       key=lambda item: item['b']))
+
+    def test_find_index_matching_predicate(self):
+        """Find the index of the first item matching a predicate"""
+        values = [5, 7, 9, 12]
+        self.assertEqual(1, find_index(values, match_item=lambda val: val > 6))
+
+    def test_swapped(self):
+        """Test swapped function."""
+        self.assertEqual([1, 2, 3, 4, 5], swapped([1, 2, 3, 4, 5], 0, 0))
+        self.assertEqual([1, 4, 3, 2, 5], swapped([1, 2, 3, 4, 5], 1, 3))
+        self.assertEqual([1, 2, 3, 4, 5], swapped([1, 2, 3, 4, 5], 4, 4))
+        self.assertEqual([1, 2, 3, 4, 5], swapped([5, 2, 3, 4, 1], 0, 4))
+
+    def test_expanded(self):
+        """Test expanded function."""
+        self.assertEqual([1, 2, 3, 3, 3], expanded([1, 2, 3], length=5))
 
 
 if __name__ == '__main__':

--- a/bcipy/core/tests/test_list.py
+++ b/bcipy/core/tests/test_list.py
@@ -64,14 +64,14 @@ class TestListUtilities(unittest.TestCase):
 
     def test_find_index_using_key(self):
         """Find index using the key arg"""
-        item1 = dict(a=1, b=1)
-        item2 = dict(a=1, b=2)
-        item3 = dict(a=2, b=1)
-        item4 = dict(a=2, b=2)
+        item1 = dict(a=10, b=10)
+        item2 = dict(a=10, b=20)
+        item3 = dict(a=20, b=10)
+        item4 = dict(a=20, b=20)
         self.assertEqual(
             1,
             find_index([item1, item2, item3, item4],
-                       match_item=2,
+                       match_item=20,
                        key=lambda item: item['b']))
 
     def test_find_index_matching_predicate(self):

--- a/bcipy/simulator/data/sampler.py
+++ b/bcipy/simulator/data/sampler.py
@@ -8,7 +8,8 @@ from typing import Callable, Dict, List, Tuple
 import numpy as np
 import pandas as pd
 
-from bcipy.simulator.data.data_engine import QueryFilter, RawDataEngine, Trial
+from bcipy.simulator.data.data_engine import QueryFilter, RawDataEngine
+from bcipy.simulator.data.trial import Trial
 from bcipy.simulator.util.state import SimState
 
 log = logging.getLogger(__name__)

--- a/bcipy/simulator/data/trial.py
+++ b/bcipy/simulator/data/trial.py
@@ -1,0 +1,128 @@
+"""Functions for trial-related data."""
+import itertools as it
+from pathlib import Path
+from typing import Callable, List, NamedTuple, Optional, Tuple
+
+import numpy as np
+
+from bcipy.config import SESSION_DATA_FILENAME
+from bcipy.core.list import find_index
+from bcipy.core.session import read_session
+from bcipy.simulator.data.data_process import ExtractedExperimentData
+
+
+class Trial(NamedTuple):
+    """Data for a given trial (a symbol within an Inquiry).
+
+    Attrs
+    -----
+        source - directory of the data source
+        series - starts at 1; computed from session.json
+        series_inquiry - starts at 0; inquiry within the series; computed
+            from session.json
+        inquiry_n - starts at 0; value from the start of the session (does not
+            reset at each series); can be computed from raw_data.
+        inquiry_pos  - starts at 1; position in which the symbol was presented
+        symbol - alphabet symbol that was presented
+        target - 1 or 0 indicating a boolean of whether this was a target symbol
+        eeg - EEG data associated with this trial
+    """
+    source: str
+    series: Optional[int]
+    series_inquiry: Optional[int]
+    inquiry_n: int
+    inquiry_pos: int
+    symbol: str
+    target: int
+    eeg: np.ndarray  # Channels by Samples ; ndarray.shape = (channel_n, sample_n)
+
+    def __str__(self):
+        fields = [
+            f"source='{self.source}'", f"series={self.series}",
+            f"series_inquiry={self.series_inquiry}",
+            f"inquiry_n={self.inquiry_n}", f"inquiry_pos={self.inquiry_pos}",
+            f"symbol='{self.symbol}'", f"target={self.target}",
+            f"eeg={self.eeg.shape}"
+        ]
+        return f"Trial({', '.join(fields)})"
+
+    def __repr__(self):
+        return str(self)
+
+
+def session_series_counts(source_dir: str) -> List[int]:
+    """Read the session.json file in the provided directory
+    and compute the number of inquiries per series."""
+    session_path = Path(source_dir, SESSION_DATA_FILENAME)
+    if session_path.exists():
+        session = read_session(str(session_path))
+        return [len(series) for series in session.series]
+    return []
+
+
+def series_inquiry(series_counts: List[int],
+                   inquiry_n: int) -> Tuple[Optional[int], Optional[int]]:
+    """Given the number of inquiries per series and the inquiry from the start of the session,
+    compute the series and inquiry relative to the start of that series.
+
+    Parameters
+    ----------
+        series_counts - number of inquiries for each series in the session.
+        inquiry_n - index of the inquiry from the start of the session
+            starts at 0.
+    Returns
+    -------
+        a tuple of the series (1-based), inquiry_index (0-based) relative to series.
+    """
+    if series_counts:
+        accumulations = list(it.accumulate(series_counts))
+        series_index = find_index(accumulations,
+                                  match_item=lambda val: val > inquiry_n)
+        if series_index is not None:
+            if series_index > 0:
+                inq_index = inquiry_n - accumulations[series_index - 1]
+            else:
+                inq_index = inquiry_n
+            return (series_index + 1, inq_index)
+    return (None, None)
+
+
+def convert_trials(
+    data_source: ExtractedExperimentData,
+    get_series_counts: Callable[[str], List[int]] = session_series_counts
+) -> List[Trial]:
+    """Convert extracted data from a single data source to a list of Trials.
+
+    Parameters
+    ----------
+        data_source - Data from an acquisition device after reshaping and filtering.
+        get_series_counts - function to get the session metadata needed to assign
+            series and relative_inquiry information to each trial. The function should
+            take the source_directory path as an input and return the number of inquiries
+            in each series. By default this is read from the session.json in the source_dir.
+    """
+    trials = []
+    symbols_by_inquiry = data_source.symbols_by_inquiry
+    labels_by_inquiry = data_source.labels_by_inquiry
+    series_counts = get_series_counts(data_source.source_dir)
+
+    for i, inquiry_eeg in enumerate(data_source.trials_by_inquiry):
+        # iterate through each inquiry
+        inquiry_symbols = symbols_by_inquiry[i]
+        inquiry_labels = labels_by_inquiry[i]
+
+        for sym_i, symbol in enumerate(inquiry_symbols):
+            # iterate through each symbol in the inquiry
+            series, inquiry = series_inquiry(series_counts, i)
+            eeg_samples = [channel[sym_i]
+                           for channel in inquiry_eeg]  # (channel_n, sample_n)
+            trials.append(
+                Trial(source=data_source.source_dir,
+                      series=series,
+                      series_inquiry=inquiry,
+                      inquiry_n=i,
+                      inquiry_pos=sym_i + 1,
+                      symbol=symbol,
+                      target=inquiry_labels[sym_i],
+                      eeg=np.array(eeg_samples)))
+    return trials

--- a/bcipy/simulator/tests/test_trial.py
+++ b/bcipy/simulator/tests/test_trial.py
@@ -1,0 +1,148 @@
+"""Test for trial data"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import numpy as np
+
+from bcipy.simulator.data.data_process import (DecodedTriggers,
+                                               ExtractedExperimentData)
+from bcipy.simulator.data.trial import (Trial, convert_trials, series_inquiry,
+                                        session_series_counts)
+
+
+class TestTrial(unittest.TestCase):
+    """Test for trial class and functions."""
+
+    def test_trial_str(self):
+        """Test representation of a trial"""
+        trial = Trial(source="path-to-source",
+                      series=1,
+                      series_inquiry=2,
+                      inquiry_n=2,
+                      inquiry_pos=5,
+                      symbol='M',
+                      target=1,
+                      eeg=np.zeros(shape=(3, 2)))
+        self.assertTrue('series=1' in str(trial))
+        self.assertTrue('eeg=(3, 2)' in str(trial))
+
+    def test_trial_without_optional(self):
+        """Test without the optional data"""
+        trial = Trial(source="path-to-source",
+                      series=None,
+                      series_inquiry=None,
+                      inquiry_n=2,
+                      inquiry_pos=5,
+                      symbol='M',
+                      target=1,
+                      eeg=np.zeros(shape=(3, 2)))
+        self.assertTrue('series=None' in str(trial))
+
+    @patch("bcipy.simulator.data.trial.read_session")
+    @patch("bcipy.simulator.data.trial.Path")
+    def test_session_series_counts(self, path_constructor_mock,
+                                   read_session_mock):
+        """Test computing the series counts from the session data when the
+        session path exists."""
+        path_mock = Mock()
+        path_mock.exists.return_value = True
+        path_constructor_mock.return_value = path_mock
+        session_series_counts("example-data-directory")
+        read_session_mock.assert_called_once()
+
+    @patch("bcipy.simulator.data.trial.read_session")
+    @patch("bcipy.simulator.data.trial.Path")
+    def test_session_series_counts_bad_path(self, path_constructor_mock,
+                                            read_session_mock):
+        """Test computing the series counts from the session data when session
+        data is not present."""
+        path_mock = Mock()
+        path_mock.exists.return_value = False
+        path_constructor_mock.return_value = path_mock
+        session_series_counts("no-session")
+        read_session_mock.assert_not_called()
+
+    def test_series_inquiry(self):
+        """Test series inquiry calculation"""
+        counts = [5, 2, 4]
+        self.assertEqual((1, 0), series_inquiry(counts, 0))
+        self.assertEqual((1, 4), series_inquiry(counts, 4))
+        self.assertEqual((2, 0), series_inquiry(counts, 5))
+        self.assertEqual((2, 1), series_inquiry(counts, 6))
+        self.assertEqual((3, 0), series_inquiry(counts, 7))
+        self.assertEqual((3, 2), series_inquiry(counts, 9))
+        self.assertEqual((3, 3), series_inquiry(counts, 10))
+
+        self.assertEqual((None, None), series_inquiry([], 0))
+
+    def test_convert_trials(self):
+        """Test converting data to trials."""
+
+        sample_data = ExtractedExperimentData(
+            source_dir="test-src",
+            inquiries=np.ones((6, 4, 436)),
+            trials=np.ones((6, 12, 75)),
+            labels=[[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 1]],
+            inquiry_timing=[[150, 180, 210], [150, 180, 210], [150, 180, 210],
+                            [150, 180, 210]],
+            decoded_triggers=DecodedTriggers(
+                targetness=[
+                    'nontarget', 'nontarget', 'nontarget', 'nontarget',
+                    'nontarget', 'nontarget', 'nontarget', 'nontarget',
+                    'nontarget', 'nontarget', 'nontarget', 'target'
+                ],
+                times=[
+                    10.515330292284489, 10.717246917076409, 10.919030375313014,
+                    15.644844584167004, 15.846348999999464, 16.047540083993226,
+                    20.790782417170703, 20.992313000373542, 21.193465375341475,
+                    25.914405125193298, 26.115663417149335, 26.31681716721505
+                ],
+                symbols=[
+                    '<', 'N', 'J', '<', 'N', 'J', 'J', 'B', '<', '<', 'J', 'B'
+                ],
+                corrected_times=[
+                    10.515330292284489, 10.717246917076409, 10.919030375313014,
+                    15.644844584167004, 15.846348999999464, 16.047540083993226,
+                    20.790782417170703, 20.992313000373542, 21.193465375341475,
+                    25.914405125193298, 26.115663417149335, 26.31681716721505
+                ]),
+            trials_per_inquiry=3)
+
+        trials = convert_trials(sample_data, get_series_counts=lambda x: [4])
+        self.assertEqual(12, len(trials))
+
+        # check properties for first element
+        self.assertEqual(trials[0].source, "test-src")
+        self.assertEqual(trials[0].series, 1)
+        self.assertEqual(trials[0].series_inquiry, 0)
+        self.assertEqual(trials[0].inquiry_n, 0)
+        self.assertEqual(trials[0].inquiry_pos, 1)
+        self.assertEqual(trials[0].symbol, '<')
+        self.assertEqual(trials[0].target, 0)
+        self.assertEqual(trials[0].eeg.shape, (6, 75))
+
+        # check properties for last element
+        self.assertEqual(trials[-1].source, "test-src")
+        self.assertEqual(trials[-1].series, 1)
+        self.assertEqual(trials[-1].series_inquiry, 3)
+        self.assertEqual(trials[-1].inquiry_n, 3)
+        self.assertEqual(trials[-1].inquiry_pos, 3)
+        self.assertEqual(trials[-1].symbol, 'B')
+        self.assertEqual(trials[-1].target, 1)
+        self.assertEqual(trials[-1].eeg.shape, (6, 75))
+
+        # check properties when series_counts are different
+        trials = convert_trials(sample_data,
+                                get_series_counts=lambda x: [3, 1])
+        self.assertEqual(trials[-1].series, 2)
+        self.assertEqual(trials[-1].series_inquiry, 0)
+        self.assertEqual(trials[-1].inquiry_n, 3)
+        self.assertEqual(trials[-1].inquiry_pos, 3)
+        self.assertEqual(trials[-1].symbol, 'B')
+        self.assertEqual(trials[-1].target, 1)
+        self.assertEqual(trials[-1].eeg.shape, (6, 75))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Overview

Added session and session_inquiry fields to simulator Trials data to enable more sampling options.

## Ticket

https://www.pivotaltracker.com/story/show/188673150

## Contributions

- Factored trial data into its own module.
- Added unit tests for some list utility functions
- Added unit tests for converting from ExtractedExperimentData to Trials.

## Test

- Ran all unit tests
- Ran the simulator to confirm other functionality was still working.
