### PR TITLE
Sim Logging Bugs

### DIFF
--- a/bcipy/simulator/README.md
+++ b/bcipy/simulator/README.md
@@ -72,9 +72,27 @@ A directory is created for each simulation run. The directory contents are simil
 
 The simulator is structured to support evidence from multiple devices (multimodal). However, it currently only includes processing for EEG device data. To provide support for models trained on data from other devices (ex. Gaze), a `RawDataProcessor` must be added for that device. The Processor pre-processes data collected from that device and prepares it for sampling. A `RawDataProcessor` is matched up to a given signal model using that model's metadata (metadata.device_spec.content_type). See the `data_process` module for more details.
 
+## Parameters
+
+The parameters file is used to configure various aspects of the of the simulation. Timing-related parameters should generally match the parameters file used for training the signal model(s). Following are some specific parameters that you may want to modify, depending on the goals of a particular simulation:
+
+* `task_text` - the text to spell.
+* `lang_model_type` - language model to use in the simulation.
+* `summarize_session` - if set to true a session.xlsx summary will be generated for each simulation run.
+
+### Stoppage Criteria
+
+Parameters which define task stoppage criteria are important to ensure that the simulation runs to completion without getting stuck in an infinite loop. The values for these parameters may also affect analysis of results.
+
+* `min_inq_len` - Specifies the minimum number of inquiries to present before making a decision in copy/spelling tasks.
+* `max_inq_len` - maximum number of inquiries to display before stopping the task.
+* `max_selections` - The maximum number of selections for copy/spelling tasks. The task will end if this number is reached.
+* `max_incorrect` - The maximum number of consecutive incorrect selections for copy/spelling tasks. The task will end if this number is reached.
+* `max_inq_per_series` - Specifies the maximum number of inquiries to present before making a decision in copy/spelling tasks
+
+
 ## Current Limitations
 
 * Only provides EEG support
 * Only one sampler maybe provided for all devices. Ideally we should support a different sampling strategy for each device.
 * Only Copy Phrase is currently supported.
-* Metrics are collected per run, but not summarized across all runs.

--- a/bcipy/simulator/task/copy_phrase.py
+++ b/bcipy/simulator/task/copy_phrase.py
@@ -3,10 +3,10 @@
 import logging
 from typing import Any, Dict, List, Optional, Tuple
 
-from bcipy.display.main import Display
-from bcipy.feedback.visual.visual_feedback import VisualFeedback
 from bcipy.core.parameters import Parameters
 from bcipy.core.stimuli import InquirySchedule
+from bcipy.display.main import Display
+from bcipy.feedback.visual.visual_feedback import VisualFeedback
 from bcipy.language.main import LanguageModel
 from bcipy.signal.model.base_model import SignalModel
 from bcipy.simulator.data.sampler import Sampler
@@ -140,6 +140,9 @@ class SimulatorCopyPhraseTask(RSVPCopyPhraseTask):
             evidence_type = get_evidence_type(model)
             evidences.append((evidence_type, evidence))
         return evidences
+
+    def cleanup(self):
+        self.save_session_data()
 
     def exit_display(self) -> None:
         """Close the UI and cleanup."""

--- a/bcipy/simulator/task/task_runner.py
+++ b/bcipy/simulator/task/task_runner.py
@@ -16,7 +16,7 @@ from bcipy.simulator.util.artifact import (DEFAULT_SAVE_LOCATION,
                                            TOP_LEVEL_LOGGER_NAME,
                                            configure_run_directory,
                                            init_simulation_dir,
-                                           remove_file_logger)
+                                           remove_handlers)
 
 logger = logging.getLogger(TOP_LEVEL_LOGGER_NAME)
 
@@ -47,12 +47,12 @@ class TaskRunner():
     def do_run(self, run: int):
         """Execute a simulation run."""
         logger.info(f"Executing task {run}")
-        run_dir = configure_run_directory(self.sim_dir, run)
+        run_dir, run_log = configure_run_directory(self.sim_dir, run)
         logger.info(run_dir)
         task = self.task_factory.make_task(run_dir)
         task.execute()
         logger.info("Task complete")
-        remove_file_logger(self.sim_dir, run)
+        remove_handlers(run_log)
 
 
 def main():

--- a/bcipy/simulator/task/task_runner.py
+++ b/bcipy/simulator/task/task_runner.py
@@ -15,7 +15,8 @@ from bcipy.simulator.ui import cli, gui
 from bcipy.simulator.util.artifact import (DEFAULT_SAVE_LOCATION,
                                            TOP_LEVEL_LOGGER_NAME,
                                            configure_run_directory,
-                                           init_simulation_dir)
+                                           init_simulation_dir,
+                                           remove_file_logger)
 
 logger = logging.getLogger(TOP_LEVEL_LOGGER_NAME)
 
@@ -41,16 +42,17 @@ class TaskRunner():
         """Run one or more simulations"""
         self.task_factory.parameters.save(self.sim_dir, 'parameters.json')
         for i in range(self.runs):
-            logger.info(f"Executing task {i+1}")
             self.do_run(i + 1)
-            logger.info("Task complete")
 
     def do_run(self, run: int):
         """Execute a simulation run."""
+        logger.info(f"Executing task {run}")
         run_dir = configure_run_directory(self.sim_dir, run)
         logger.info(run_dir)
         task = self.task_factory.make_task(run_dir)
         task.execute()
+        logger.info("Task complete")
+        remove_file_logger(self.sim_dir, run)
 
 
 def main():

--- a/bcipy/simulator/tests/test_sim_artifact.py
+++ b/bcipy/simulator/tests/test_sim_artifact.py
@@ -5,8 +5,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from bcipy.simulator.util.artifact import (RUN_PREFIX, configure_logger,
-                                           remove_file_logger, remove_handlers)
+from bcipy.simulator.util.artifact import configure_logger, remove_handlers
 
 
 class TestSimArtifact(unittest.TestCase):
@@ -65,18 +64,6 @@ class TestSimArtifact(unittest.TestCase):
         log = logging.getLogger()
         self.assertEqual(1, len(log.handlers))
         self.assertTrue(isinstance(log.handlers[0], logging.FileHandler))
-        remove_handlers(log)
-
-    def test_remove_file_logger(self):
-        """Test removal of file handler from root logger"""
-        configure_logger(self.temp_dir,
-                         file_name=f"{RUN_PREFIX}99.log",
-                         logger_name=None,
-                         use_stdout=False)
-        log = logging.getLogger()
-        self.assertEqual(1, len(log.handlers))
-        remove_file_logger(self.temp_dir, run=99)
-        self.assertEqual(0, len(log.handlers))
         remove_handlers(log)
 
 

--- a/bcipy/simulator/tests/test_sim_artifact.py
+++ b/bcipy/simulator/tests/test_sim_artifact.py
@@ -6,7 +6,7 @@ import unittest
 from pathlib import Path
 
 from bcipy.simulator.util.artifact import (RUN_PREFIX, configure_logger,
-                                           remove_file_logger)
+                                           remove_file_logger, remove_handlers)
 
 
 class TestSimArtifact(unittest.TestCase):
@@ -41,6 +41,7 @@ class TestSimArtifact(unittest.TestCase):
         log.info("testing 4 5 6")
         self.assertTrue(Path(self.temp_dir, "test_1b.log").exists())
         self.assertEqual(2, len(log.handlers))
+        remove_handlers(log)
 
     def test_configure_named_logger_without_stdout(self):
         """Test the named logger without logging to stdout."""
@@ -53,6 +54,7 @@ class TestSimArtifact(unittest.TestCase):
         log = logging.getLogger('TEST_LOGGER')
         self.assertEqual(1, len(log.handlers))
         self.assertTrue(isinstance(log.handlers[0], logging.FileHandler))
+        remove_handlers(log)
 
     def test_configure_root_logger(self):
         """Test configure root logger"""
@@ -63,6 +65,7 @@ class TestSimArtifact(unittest.TestCase):
         log = logging.getLogger()
         self.assertEqual(1, len(log.handlers))
         self.assertTrue(isinstance(log.handlers[0], logging.FileHandler))
+        remove_handlers(log)
 
     def test_remove_file_logger(self):
         """Test removal of file handler from root logger"""
@@ -74,6 +77,7 @@ class TestSimArtifact(unittest.TestCase):
         self.assertEqual(1, len(log.handlers))
         remove_file_logger(self.temp_dir, run=99)
         self.assertEqual(0, len(log.handlers))
+        remove_handlers(log)
 
 
 if __name__ == '__main__':

--- a/bcipy/simulator/tests/test_sim_artifact.py
+++ b/bcipy/simulator/tests/test_sim_artifact.py
@@ -67,7 +67,7 @@ class TestSimArtifact(unittest.TestCase):
     def test_remove_file_logger(self):
         """Test removal of file handler from root logger"""
         configure_logger(self.temp_dir,
-                         file_name=f"{RUN_PREFIX}99",
+                         file_name=f"{RUN_PREFIX}99.log",
                          logger_name=None,
                          use_stdout=False)
         log = logging.getLogger()

--- a/bcipy/simulator/tests/test_sim_artifact.py
+++ b/bcipy/simulator/tests/test_sim_artifact.py
@@ -1,0 +1,80 @@
+"""Tests for simulator logging and directory functions."""
+import logging
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from bcipy.simulator.util.artifact import (RUN_PREFIX, configure_logger,
+                                           remove_file_logger)
+
+
+class TestSimArtifact(unittest.TestCase):
+    """Test for simulator artifact functions."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
+
+    def test_configure_named_logger(self):
+        """Test configure named logger"""
+
+        configure_logger(self.temp_dir,
+                         file_name='test_1a.log',
+                         logger_name='TEST_LOGGER',
+                         use_stdout=True)
+
+        log = logging.getLogger('TEST_LOGGER')
+        self.assertEqual(2, len(log.handlers))
+        self.assertEqual('TEST_LOGGER', log.name)
+        log.info("testing 1 2 3")
+        self.assertTrue(Path(self.temp_dir, "test_1a.log").exists())
+
+        self.assertFalse(Path(self.temp_dir, "test_1b.log").exists())
+        configure_logger(self.temp_dir,
+                         file_name='test_1b.log',
+                         logger_name='TEST_LOGGER',
+                         use_stdout=True)
+
+        log.info("testing 4 5 6")
+        self.assertTrue(Path(self.temp_dir, "test_1b.log").exists())
+        self.assertEqual(2, len(log.handlers))
+
+    def test_configure_named_logger_without_stdout(self):
+        """Test the named logger without logging to stdout."""
+
+        configure_logger(self.temp_dir,
+                         file_name='test_2.log',
+                         logger_name='TEST_LOGGER',
+                         use_stdout=False)
+
+        log = logging.getLogger('TEST_LOGGER')
+        self.assertEqual(1, len(log.handlers))
+        self.assertTrue(isinstance(log.handlers[0], logging.FileHandler))
+
+    def test_configure_root_logger(self):
+        """Test configure root logger"""
+        configure_logger(self.temp_dir,
+                         file_name='test_root_logger.log',
+                         logger_name=None,
+                         use_stdout=False)
+        log = logging.getLogger()
+        self.assertEqual(1, len(log.handlers))
+        self.assertTrue(isinstance(log.handlers[0], logging.FileHandler))
+
+    def test_remove_file_logger(self):
+        """Test removal of file handler from root logger"""
+        configure_logger(self.temp_dir,
+                         file_name=f"{RUN_PREFIX}99",
+                         logger_name=None,
+                         use_stdout=False)
+        log = logging.getLogger()
+        self.assertEqual(1, len(log.handlers))
+        remove_file_logger(self.temp_dir, run=99)
+        self.assertEqual(0, len(log.handlers))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bcipy/simulator/util/artifact.py
+++ b/bcipy/simulator/util/artifact.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 import os
 import sys
-from typing import Optional
+from typing import Optional, Tuple
 
 from bcipy.config import ROOT
 
@@ -80,18 +80,19 @@ def init_simulation_dir(save_location: str = DEFAULT_SAVE_LOCATION,
     return save_dir
 
 
-def configure_run_directory(sim_dir: str, run: int) -> str:
+def configure_run_directory(sim_dir: str,
+                            run: int) -> Tuple[str, logging.Logger]:
     """Create the necessary directories and configure the logger.
     Returns the run directory.
     """
     run_name = f"{RUN_PREFIX}{run}"
     path = f"{sim_dir}/{run_name}"
     os.mkdir(path)
-    configure_logger(log_path=path,
-                     file_name=f"{run_name}.log",
-                     logger_name=None,
-                     use_stdout=False)
-    return path
+    log = configure_logger(log_path=path,
+                           file_name=f"{run_name}.log",
+                           logger_name=None,
+                           use_stdout=False)
+    return path, log
 
 
 def remove_file_logger(sim_dir: str, run: int) -> None:

--- a/bcipy/simulator/util/artifact.py
+++ b/bcipy/simulator/util/artifact.py
@@ -16,10 +16,20 @@ DEFAULT_SAVE_LOCATION = f"{ROOT}/data/simulator"
 RUN_PREFIX = "run_"
 
 
+def remove_handlers(log: logging.Logger) -> None:
+    """Remove any file handlers from the provided logger."""
+    handlers = log.handlers[:]  # make copy
+    for handler in handlers:
+        # call the method, which handles locking.
+        log.removeHandler(handler)
+        if isinstance(handler, logging.FileHandler):
+            handler.close()
+
+
 def configure_logger(log_path: str,
                      file_name: str,
                      logger_name: Optional[str] = None,
-                     use_stdout: bool = True):
+                     use_stdout: bool = True) -> logging.Logger:
     """Configures logger for standard out and file output.
 
     Parameters
@@ -32,13 +42,7 @@ def configure_logger(log_path: str,
 
     log = logging.getLogger(logger_name)  # configuring root logger
 
-    # clear existing handlers
-    handlers = log.handlers[:]  # make copy
-    for handler in handlers:
-        # call the method, which handles locking.
-        log.removeHandler(handler)
-        if isinstance(handler, logging.FileHandler):
-            handler.close()
+    remove_handlers(log)
 
     log.setLevel(logging.INFO)
     fmt = '[%(asctime)s][%(name)s][%(levelname)s]: %(message)s'
@@ -49,10 +53,11 @@ def configure_logger(log_path: str,
         stdout_handler.setFormatter(logging.Formatter("%(message)s"))
         log.addHandler(stdout_handler)
 
-    file_handler = logging.FileHandler(f"{log_path}/{file_name}", delay=True)
+    file_handler = logging.FileHandler(f"{log_path}/{file_name}")
     file_handler.setLevel(logging.INFO)
     file_handler.setFormatter(logging.Formatter(fmt))
     log.addHandler(file_handler)
+    return log
 
 
 def init_simulation_dir(save_location: str = DEFAULT_SAVE_LOCATION,

--- a/bcipy/simulator/util/artifact.py
+++ b/bcipy/simulator/util/artifact.py
@@ -31,27 +31,27 @@ def configure_logger(log_path: str,
     """
 
     log = logging.getLogger(logger_name)  # configuring root logger
+
+    # clear existing handlers
+    handlers = log.handlers[:]  # make copy
+    for handler in handlers:
+        # call the method, which handles locking.
+        log.removeHandler(handler)
+        if isinstance(handler, logging.FileHandler):
+            handler.close()
+
     log.setLevel(logging.INFO)
-    # Create handlers for logging to the standard output and a file
-    stdout_handler = logging.StreamHandler(stream=sys.stdout)
-    file_handler = logging.FileHandler(f"{log_path}/{file_name}")
-
-    # Set the log levels on the handlers
-    stdout_handler.setLevel(logging.INFO)
-    file_handler.setLevel(logging.INFO)
-
     fmt = '[%(asctime)s][%(name)s][%(levelname)s]: %(message)s'
-    fmt_file = logging.Formatter(fmt)
-    fmt_stdout = logging.Formatter("%(message)s")
 
-    # Set the log format on each handler
-    stdout_handler.setFormatter(fmt_stdout)
-    file_handler.setFormatter(fmt_file)
-
-    # Add each handler to the Logger object
-    if use_stdout and stdout_handler not in log.handlers:
+    if use_stdout:
+        stdout_handler = logging.StreamHandler(stream=sys.stdout)
+        stdout_handler.setLevel(logging.INFO)
+        stdout_handler.setFormatter(logging.Formatter("%(message)s"))
         log.addHandler(stdout_handler)
 
+    file_handler = logging.FileHandler(f"{log_path}/{file_name}")
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(logging.Formatter(fmt))
     log.addHandler(file_handler)
 
 
@@ -84,8 +84,22 @@ def configure_run_directory(sim_dir: str, run: int) -> str:
     os.mkdir(path)
     configure_logger(log_path=path,
                      file_name=f"{run_name}.log",
+                     logger_name=None,
                      use_stdout=False)
     return path
+
+
+def remove_file_logger(sim_dir: str, run: int) -> None:
+    """Disable any configured file handler for the root logger."""
+    path = f"{sim_dir}/{RUN_PREFIX}{run}"
+
+    log = logging.getLogger()
+    handlers = log.handlers[:]
+    for handler in handlers:
+        if isinstance(handler,
+                      logging.FileHandler) and path in handler.baseFilename:
+            log.removeHandler(handler)
+            handler.close()
 
 
 def directory_name() -> str:

--- a/bcipy/simulator/util/artifact.py
+++ b/bcipy/simulator/util/artifact.py
@@ -49,7 +49,7 @@ def configure_logger(log_path: str,
         stdout_handler.setFormatter(logging.Formatter("%(message)s"))
         log.addHandler(stdout_handler)
 
-    file_handler = logging.FileHandler(f"{log_path}/{file_name}")
+    file_handler = logging.FileHandler(f"{log_path}/{file_name}", delay=True)
     file_handler.setLevel(logging.INFO)
     file_handler.setFormatter(logging.Formatter(fmt))
     log.addHandler(file_handler)


### PR DESCRIPTION
# Overview

Fixed bugs in simulator logging.

## Ticket

https://www.pivotaltracker.com/story/show/188758565

## Contributions

- Ensured that the configure_logger function clears any existing handlers before adding new ones.
- Added unit tests for simulator artifact module to replicate the bug and confirm that it was resolved.
- Fixed a bug in the sim task that occurred during cleanup.
- Added documentation for simulation parameters. One of these controls whether the session.xlsx file is output.

## Test

- Ran all unit tests
- Ran sample simulation

## Discussion

Along with duplicate entries to stdout, the file handlers were also not cleared between runs. This resulted in log statements from subsequent runs being written to all the log files from previous runs. For a large number of runs this potentially resulted in huge log files for the first runs.