### PR TITLE
Simulator Verbose Mode

### DIFF
--- a/bcipy/helpers/copy_phrase_wrapper.py
+++ b/bcipy/helpers/copy_phrase_wrapper.py
@@ -6,10 +6,10 @@ from typing import List, Tuple
 import numpy as np
 
 from bcipy.config import SESSION_LOG_FILENAME
-from bcipy.exceptions import BciPyCoreException
-from bcipy.helpers.language_model import histogram, with_min_prob
 from bcipy.core.stimuli import InquirySchedule, StimuliOrder
 from bcipy.core.symbols import BACKSPACE_CHAR
+from bcipy.exceptions import BciPyCoreException
+from bcipy.helpers.language_model import histogram, with_min_prob
 from bcipy.language.main import LanguageModel
 from bcipy.task.control.criteria import (CriteriaEvaluator,
                                          MaxIterationsCriteria,
@@ -206,7 +206,7 @@ class CopyPhraseWrapper:
             ]
 
             # display histogram of LM probabilities
-            log.info(histogram(lm_letter_prior))
+            log.debug(histogram(lm_letter_prior))
 
             # Try fusing the lmodel evidence
             try:

--- a/bcipy/simulator/README.md
+++ b/bcipy/simulator/README.md
@@ -47,6 +47,7 @@ For example,
 - `o`: Output directory for all simulation artifacts.
 - `s`: Sampling strategy to use; by default the TargetNonTargetSampler is used. The value provided should be the class name of a Sampler.
 - `sampler_args`: Arguments to pass in to the selected Sampler. Some samplers can be customized with further parameters. These should be structured as a JSON dictionary mapping keys to values. For example: `--sampler_args='{"inquiry_end": 4}'`
+- `-v` or `--verbose`: Execute the simulation in verbose mode for more detailed logging. Useful for debugging.
 
 #### Sim Output Details
 

--- a/bcipy/simulator/data/sampler/inquiry_sampler.py
+++ b/bcipy/simulator/data/sampler/inquiry_sampler.py
@@ -123,5 +123,5 @@ class InquirySampler(Sampler):
             Trial(**sorted_inquiry_df.iloc[i])
             for i in range(len(sorted_inquiry_df))
         ]
-        log.info(f"EEG Samples:\n{format_samples(rows)}")
+        log.debug(f"EEG Samples:\n{format_samples(rows)}")
         return rows

--- a/bcipy/simulator/data/sampler/target_nontarget_sampler.py
+++ b/bcipy/simulator/data/sampler/target_nontarget_sampler.py
@@ -20,7 +20,7 @@ class TargetNontargetSampler(Sampler):
             filtered_data = self.data_engine.query(filters, samples=1)
             sample_rows.append(filtered_data[0])
 
-        log.info(f"Samples:\n{format_samples(sample_rows)}")
+        log.debug(f"Samples:\n{format_samples(sample_rows)}")
         return sample_rows
 
     def query_filters(self, symbol: str, is_target: bool) -> List[QueryFilter]:

--- a/bcipy/simulator/task/copy_phrase.py
+++ b/bcipy/simulator/task/copy_phrase.py
@@ -124,8 +124,8 @@ class SimulatorCopyPhraseTask(RSVPCopyPhraseTask):
             proceed: bool = True) -> List[Tuple[EvidenceType, List[float]]]:
 
         current_state = self.get_sim_state()
-        self.logger.info("Computing evidence with sim_state:")
-        self.logger.info(current_state)
+        self.logger.debug("Computing evidence with sim_state:")
+        self.logger.debug(current_state)
 
         evidences = []
 

--- a/bcipy/simulator/task/copy_phrase.py
+++ b/bcipy/simulator/task/copy_phrase.py
@@ -1,6 +1,7 @@
 # mypy: disable-error-code="union-attr"
 """Simulates the Copy Phrase task"""
 import logging
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from bcipy.core.parameters import Parameters
@@ -143,6 +144,12 @@ class SimulatorCopyPhraseTask(RSVPCopyPhraseTask):
 
     def cleanup(self):
         self.save_session_data()
+        trigger_path = Path(self.trigger_handler.file_path)
+        self.trigger_handler.close()
+
+        # delete empty triggers.txt file
+        if trigger_path.exists() and trigger_path.is_file():
+            trigger_path.unlink(missing_ok=True)
 
     def exit_display(self) -> None:
         """Close the UI and cleanup."""

--- a/bcipy/simulator/task/task_factory.py
+++ b/bcipy/simulator/task/task_factory.py
@@ -66,10 +66,10 @@ class TaskFactory():
         """Log configured objects of interest. This should be done after the
         sim directory has been created and TOP_LEVEL_LOGGER has been configured,
         which may happen some time after object construction."""
-        logger.info("Language model:")
-        logger.info(f"\t{repr(self.language_model)}")
-        logger.info("Models -> Samplers:")
-        logger.info(f"\t{self.samplers}")
+        logger.debug("Language model:")
+        logger.debug(f"\t{repr(self.language_model)}")
+        logger.debug("Models -> Samplers:")
+        logger.debug(f"\t{self.samplers}")
 
     def init_samplers(
             self,

--- a/bcipy/simulator/task/task_runner.py
+++ b/bcipy/simulator/task/task_runner.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from typing import Any, Dict
 
+from rich.progress import track
+
 import bcipy.simulator.util.metrics as metrics
 # pylint: disable=wildcard-import,unused-wildcard-import
 # flake8: noqa
@@ -17,7 +19,7 @@ from bcipy.simulator.util.artifact import (DEFAULT_SAVE_LOCATION,
                                            TOP_LEVEL_LOGGER_NAME,
                                            configure_run_directory,
                                            init_simulation_dir,
-                                           remove_handlers)
+                                           remove_handlers, set_verbose)
 
 logger = logging.getLogger(TOP_LEVEL_LOGGER_NAME)
 
@@ -44,26 +46,28 @@ class TaskRunner():
     def __init__(self,
                  save_dir: str,
                  task_factory: TaskFactory,
-                 runs: int = 1):
+                 runs: int = 1,
+                 verbose: bool = True):
 
         self.task_factory = task_factory
         self.sim_dir = save_dir
         self.runs = runs
+        self.verbose = verbose
 
     def run(self) -> None:
         """Run one or more simulations"""
         self.task_factory.parameters.save(self.sim_dir, 'parameters.json')
-        for i in range(self.runs):
+        for i in track(range(self.runs), description="Processing..."):
             self.do_run(i + 1)
 
     def do_run(self, run: int):
         """Execute a simulation run."""
-        logger.info(f"Executing task {run}")
+        logger.debug(f"Executing task {run}")
         run_dir, run_log = configure_run_directory(self.sim_dir, run)
-        logger.info(run_dir)
+        logger.debug(run_dir)
         task = self.task_factory.make_task(run_dir)
         task.execute()
-        logger.info("Task complete")
+        logger.debug("Task complete")
         remove_handlers(run_log)
 
 
@@ -129,6 +133,10 @@ def main():
                         required=False,
                         default=DEFAULT_SAVE_LOCATION,
                         help="Sim output path")
+    parser.add_argument("-v",
+                        "--verbose",
+                        action='store_true',
+                        help="Verbose mode for more detailed logging.")
     args = parser.parse_args()
     sim_args = vars(args)
 
@@ -148,6 +156,8 @@ def main():
             task=SimulatorCopyPhraseTask,
             sampler_args=parse_args(sim_args['sampler_args']))
 
+    if sim_args['verbose']:
+        set_verbose(True)
     if task_factory:
         sim_dir = init_simulation_dir(save_location=outdir)
         logger.info(sim_dir)

--- a/bcipy/simulator/util/artifact.py
+++ b/bcipy/simulator/util/artifact.py
@@ -15,6 +15,15 @@ DEFAULT_LOGFILE_NAME = 'sim.log'
 DEFAULT_SAVE_LOCATION = f"{ROOT}/data/simulator"
 RUN_PREFIX = "run_"
 
+DEFAULT_VERBOSE = False
+
+
+def set_verbose(value: bool) -> None:
+    """Set default verbose mode"""
+    # pylint: disable=global-statement
+    global DEFAULT_VERBOSE
+    DEFAULT_VERBOSE = value
+
 
 def remove_handlers(log: logging.Logger) -> None:
     """Remove any file handlers from the provided logger."""
@@ -29,7 +38,8 @@ def remove_handlers(log: logging.Logger) -> None:
 def configure_logger(log_path: str,
                      file_name: str,
                      logger_name: Optional[str] = None,
-                     use_stdout: bool = True) -> logging.Logger:
+                     use_stdout: bool = True,
+                     verbose: Optional[bool] = None) -> logging.Logger:
     """Configures logger for standard out and file output.
 
     Parameters
@@ -38,13 +48,17 @@ def configure_logger(log_path: str,
         file_name - name of the log file
         logger_name - None configures the root logger; otherwise configures a named logger.
         use_stdout - if True, INFO messages will be output to stdout.
+        verbose - determines the log level; set True to log as DEBUG
     """
 
     log = logging.getLogger(logger_name)  # configuring root logger
 
     remove_handlers(log)
 
-    log.setLevel(logging.INFO)
+    if verbose is None:
+        verbose = DEFAULT_VERBOSE
+    level = logging.DEBUG if verbose else logging.INFO
+    log.setLevel(level)
     fmt = '[%(asctime)s][%(name)s][%(levelname)s]: %(message)s'
 
     if use_stdout:
@@ -54,14 +68,15 @@ def configure_logger(log_path: str,
         log.addHandler(stdout_handler)
 
     file_handler = logging.FileHandler(f"{log_path}/{file_name}")
-    file_handler.setLevel(logging.INFO)
+    file_handler.setLevel(level)
     file_handler.setFormatter(logging.Formatter(fmt))
     log.addHandler(file_handler)
     return log
 
 
 def init_simulation_dir(save_location: str = DEFAULT_SAVE_LOCATION,
-                        logfile_name: str = DEFAULT_LOGFILE_NAME) -> str:
+                        logfile_name: str = DEFAULT_LOGFILE_NAME,
+                        verbose: Optional[bool] = None) -> str:
     """Setup the folder structure and logging for a simulation.
 
     Parameters
@@ -76,12 +91,15 @@ def init_simulation_dir(save_location: str = DEFAULT_SAVE_LOCATION,
     configure_logger(save_dir,
                      logfile_name,
                      logger_name=TOP_LEVEL_LOGGER_NAME,
-                     use_stdout=True)
+                     use_stdout=True,
+                     verbose=verbose)
     return save_dir
 
 
-def configure_run_directory(sim_dir: str,
-                            run: int) -> Tuple[str, logging.Logger]:
+def configure_run_directory(
+        sim_dir: str,
+        run: int,
+        verbose: Optional[bool] = None) -> Tuple[str, logging.Logger]:
     """Create the necessary directories and configure the logger.
     Returns the run directory.
     """
@@ -91,7 +109,8 @@ def configure_run_directory(sim_dir: str,
     log = configure_logger(log_path=path,
                            file_name=f"{run_name}.log",
                            logger_name=None,
-                           use_stdout=False)
+                           use_stdout=False,
+                           verbose=verbose)
     return path, log
 
 


### PR DESCRIPTION
# Overview

Added simulator flag to control the verbosity of the output.

## Ticket

https://www.pivotaltracker.com/story/show/188328498

## Contributions

- Changed log level for many statements.
- Added a verbose parameter used to control the log level.
- Deleted generated triggers.txt

## Test

- Ran the simulator using both modes and compared the outputs

## Discussion

These changes still output all of the files, but the file contents are much shorter. I opted to keep log files for each run in case any errors were encountered. If we did not have logs at all then these would be missed.

The largest output files are the individual session.json files for each run. These are used for generating the overall metrics. If the simulation artifacts are still too large we can do some further refactoring to accumulate metrics values as we go and delete each run's session.json after that run's data has been accumulated.