### PR TITLE
LM Toolkit Refinements

### DIFF
--- a/bcipy/exceptions.py
+++ b/bcipy/exceptions.py
@@ -1,4 +1,3 @@
-
 class BciPyCoreException(Exception):
     """BciPy Core Exception.
 
@@ -91,12 +90,13 @@ class KenLMInstallationException(BciPyCoreException):
 
 class InvalidSymbolSetException(BciPyCoreException):
     """Invalid Symbol Set Exception.
-    
+
     Thrown when querying a language model for predictions without setting the symbol set."""
     ...
 
+
 class LanguageModelNameInUseException(BciPyCoreException):
     """Language Model Name In Use Exception.
-    
+
     Thrown when attempting to register a language model type with a duplicate name."""
     ...

--- a/bcipy/helpers/copy_phrase_wrapper.py
+++ b/bcipy/helpers/copy_phrase_wrapper.py
@@ -10,7 +10,7 @@ from bcipy.core.stimuli import InquirySchedule, StimuliOrder
 from bcipy.core.symbols import BACKSPACE_CHAR
 from bcipy.exceptions import BciPyCoreException
 from bcipy.helpers.language_model import histogram, with_min_prob
-from bcipy.language.main import LanguageModel
+from bcipy.language.main import CharacterLanguageModel, LanguageModel
 from bcipy.task.control.criteria import (CriteriaEvaluator,
                                          MaxIterationsCriteria,
                                          MinIterationsCriteria,
@@ -180,6 +180,9 @@ class CopyPhraseWrapper:
     def initialize_series(self) -> Tuple[bool, InquirySchedule]:
         """If a decision is made initializes the next series."""
         assert self.lmodel, "Language model must be initialized."
+        if not isinstance(self.lmodel, CharacterLanguageModel):
+            raise BciPyCoreException(
+                "Only character language models are currently supported.")
 
         try:
             # First, reset the history for this new series

--- a/bcipy/helpers/language_model.py
+++ b/bcipy/helpers/language_model.py
@@ -1,13 +1,13 @@
 """Helper functions for language model use."""
 import inspect
 import math
-from typing import Dict, List, Tuple, Type
+from typing import Callable, Dict, List, Tuple
 
 import numpy as np
 
 from bcipy.core.symbols import alphabet
-from bcipy.language.main import LanguageModel
 from bcipy.exceptions import LanguageModelNameInUseException
+from bcipy.language.main import LanguageModel
 
 # pylint: disable=unused-import
 # flake8: noqa
@@ -15,12 +15,12 @@ from bcipy.exceptions import LanguageModelNameInUseException
 """Only imported models will be included in language_models_by_name"""
 # flake8: noqa
 from bcipy.language.model.causal import CausalLanguageModelAdapter
-from bcipy.language.model.ngram import NGramLanguageModelAdapter
 from bcipy.language.model.mixture import MixtureLanguageModelAdapter
+from bcipy.language.model.ngram import NGramLanguageModelAdapter
 from bcipy.language.model.oracle import OracleLanguageModel
 from bcipy.language.model.uniform import UniformLanguageModel
 
-VALID_LANGUAGE_MODELS = {
+VALID_LANGUAGE_MODELS: Dict[str, Callable[[], LanguageModel]] = {
     "CAUSAL": CausalLanguageModelAdapter,
     "NGRAM": NGramLanguageModelAdapter,
     "MIXTURE": MixtureLanguageModelAdapter,
@@ -29,12 +29,12 @@ VALID_LANGUAGE_MODELS = {
 }
 
 
-def language_models_by_name() -> Dict[str, LanguageModel]:
+def language_models_by_name() -> Dict[str, Callable[[], LanguageModel]]:
     """Returns available language models indexed by name."""
     return VALID_LANGUAGE_MODELS
 
 
-def register_language_model(name: str, lm_type: Type[LanguageModel]) -> None:
+def register_language_model(name: str, lm_type: Callable[[], LanguageModel]) -> None:
     if name in VALID_LANGUAGE_MODELS:
         raise LanguageModelNameInUseException(
             f"{name} is already registered as {VALID_LANGUAGE_MODELS[name]}.")

--- a/bcipy/language/main.py
+++ b/bcipy/language/main.py
@@ -1,23 +1,24 @@
 """Defines the language model base class."""
 from abc import abstractmethod
-from typing import List, Tuple, Protocol, Union
+from typing import List, Optional, Protocol, Tuple, Union, runtime_checkable
 
 
-class LanguageModel(Protocol):
-    """Protocol for BciPy Language Models."""
-
-    symbol_set: List[str] = None
+class UsesSymbols(Protocol):
+    """A protocol for classes in which symbols can be set."""
+    symbol_set: Optional[List[str]] = None
 
     @abstractmethod
     def set_symbol_set(self, symbol_set: List[str]) -> None:
         """Updates the symbol set of the model. Must be called prior to prediction"""
-        ...
 
 
-class CharacterLanguageModel(LanguageModel, Protocol):
+@runtime_checkable
+class CharacterLanguageModel(UsesSymbols, Protocol):
+    """Protocol for BciPy Language models that predict characters."""
 
     @abstractmethod
-    def predict_character(self, evidence: Union[str, List[str]]) -> List[Tuple]:
+    def predict_character(self, evidence: Union[str,
+                                                List[str]]) -> List[Tuple]:
         """
         Using the provided data, compute the probability distribution over the entire symbol set.
         Args:
@@ -26,19 +27,24 @@ class CharacterLanguageModel(LanguageModel, Protocol):
         Response:
             probability - a list of symbols with probability
         """
-        ...
 
-class WordLanguageModel(LanguageModel, Protocol):
+
+@runtime_checkable
+class WordLanguageModel(UsesSymbols, Protocol):
+    """Protocol for BciPy Language models that predict words."""
 
     @abstractmethod
-    def predict_word(self, evidence: Union[str, List[str]], num_predictions: int) -> List[Tuple]:
+    def predict_word(self, evidence: Union[str, List[str]],
+                     num_predictions: int) -> List[Tuple]:
         """
         Using the provided data, compute log likelihoods of word completions
         in the symbol set.
         Args:
             evidence - ['H', 'E']
-            
+
         Response:
             a list of words with associated log likelihoods
         """
-        ...
+
+
+LanguageModel = Union[CharacterLanguageModel, WordLanguageModel]

--- a/bcipy/language/model/causal.py
+++ b/bcipy/language/model/causal.py
@@ -1,13 +1,12 @@
 from typing import Optional
 
-from bcipy.language.main import CharacterLanguageModel
-from bcipy.language.model.adapter import LanguageModelAdapter
-from bcipy.config import LM_PATH
-
 from textslinger.causal import CausalLanguageModel
 
+from bcipy.config import LM_PATH
+from bcipy.language.model.adapter import LanguageModelAdapter
 
-class CausalLanguageModelAdapter(LanguageModelAdapter, CharacterLanguageModel):
+
+class CausalLanguageModelAdapter(LanguageModelAdapter):
     """Character language model based on a pre-trained causal model."""
 
     def __init__(self,
@@ -15,11 +14,11 @@ class CausalLanguageModelAdapter(LanguageModelAdapter, CharacterLanguageModel):
                  lm_path: Optional[str] = None,
                  lm_device: str = "cpu",
                  lm_left_context: str = "",
-                 beam_width: int = None,
+                 beam_width: Optional[int] = None,
                  fp16: bool = True,
                  mixed_case_context: bool = True,
                  case_simple: bool = True,
-                 max_completed: int = None,
+                 max_completed: Optional[int] = None,
                  ):
         """
         Initialize instance variables and load model parameters
@@ -56,11 +55,17 @@ class CausalLanguageModelAdapter(LanguageModelAdapter, CharacterLanguageModel):
         self.mixed_case_context = mixed_case_context
         self.case_simple = case_simple
 
-
     def _load_model(self) -> None:
         """Load the model itself using stored parameters"""
 
-        self.model = CausalLanguageModel(symbol_set=self.model_symbol_set, lang_model_name=self.model_name, lm_path=self.model_dir,
-                                         lm_device=self.lm_device, lm_left_context=self.lm_left_context,
-                                         beam_width=self.beam_width, fp16=self.fp16, mixed_case_context=self.mixed_case_context,
-                                         case_simple=self.case_simple, max_completed=self.max_completed)
+        self.model = CausalLanguageModel(
+            symbol_set=self.model_symbol_set,
+            lang_model_name=self.model_name,
+            lm_path=self.model_dir,
+            lm_device=self.lm_device,
+            lm_left_context=self.lm_left_context,
+            beam_width=self.beam_width,
+            fp16=self.fp16,
+            mixed_case_context=self.mixed_case_context,
+            case_simple=self.case_simple,
+            max_completed=self.max_completed)

--- a/bcipy/language/model/mixture.py
+++ b/bcipy/language/model/mixture.py
@@ -1,13 +1,12 @@
-from typing import Optional, Dict, List
-
-from bcipy.language.main import CharacterLanguageModel
-from bcipy.language.model.adapter import LanguageModelAdapter
-from bcipy.config import LM_PATH
+from typing import Dict, List, Optional
 
 from textslinger.mixture import MixtureLanguageModel
 
+from bcipy.config import LM_PATH
+from bcipy.language.model.adapter import LanguageModelAdapter
 
-class MixtureLanguageModelAdapter(LanguageModelAdapter, CharacterLanguageModel):
+
+class MixtureLanguageModelAdapter(LanguageModelAdapter):
     """
         Character language model that mixes any combination of other models
     """
@@ -43,5 +42,5 @@ class MixtureLanguageModelAdapter(LanguageModelAdapter, CharacterLanguageModel):
 
     def _load_model(self) -> None:
         """Load the model itself using stored parameters"""
-        self.model = MixtureLanguageModel(self.model_symbol_set, self.lm_types, self.lm_weights, self.lm_params)
-
+        self.model = MixtureLanguageModel(self.model_symbol_set, self.lm_types,
+                                          self.lm_weights, self.lm_params)

--- a/bcipy/language/model/ngram.py
+++ b/bcipy/language/model/ngram.py
@@ -1,12 +1,12 @@
 from typing import Optional
 
-from bcipy.language.main import CharacterLanguageModel
-from bcipy.language.model.adapter import LanguageModelAdapter
 from textslinger.ngram import NGramLanguageModel
+
 from bcipy.config import LM_PATH
+from bcipy.language.model.adapter import LanguageModelAdapter
 
 
-class NGramLanguageModelAdapter(LanguageModelAdapter, CharacterLanguageModel):
+class NGramLanguageModelAdapter(LanguageModelAdapter):
     """Character n-gram language model using the KenLM library for querying"""
 
     def __init__(self,
@@ -23,7 +23,7 @@ class NGramLanguageModelAdapter(LanguageModelAdapter, CharacterLanguageModel):
         ngram_model = ngram_params['model_file']['value']
         self.lm_path = lm_path or f"{LM_PATH}/{ngram_model}"
 
-
     def _load_model(self) -> None:
         """Load the model itself using stored parameters"""
-        self.model = NGramLanguageModel(symbol_set=self.model_symbol_set, lm_path=self.lm_path)
+        self.model = NGramLanguageModel(symbol_set=self.model_symbol_set,
+                                        lm_path=self.lm_path)

--- a/bcipy/language/model/uniform.py
+++ b/bcipy/language/model/uniform.py
@@ -1,11 +1,11 @@
 """Uniform language model"""
-from typing import List, Optional, Union, Tuple, Dict
-
-from bcipy.language.main import CharacterLanguageModel
-from bcipy.core.symbols import BACKSPACE_CHAR
-from bcipy.exceptions import InvalidSymbolSetException
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
+
+from bcipy.core.symbols import BACKSPACE_CHAR, DEFAULT_SYMBOL_SET
+from bcipy.exceptions import InvalidSymbolSetException
+from bcipy.language.main import CharacterLanguageModel
 
 
 class UniformLanguageModel(CharacterLanguageModel):
@@ -18,14 +18,16 @@ class UniformLanguageModel(CharacterLanguageModel):
     """
 
     def __init__(self):
-        self.symbol_set = None
+        self.set_symbol_set(DEFAULT_SYMBOL_SET)
 
     def set_symbol_set(self, symbol_set: List[str]) -> None:
+        """Updates the symbol set of the model. Must be called prior to prediction"""
         self.symbol_set = symbol_set
 
         self.model_symbol_set = [ch for ch in symbol_set]
-        self.model_symbol_set.remove(BACKSPACE_CHAR)
-    
+        if BACKSPACE_CHAR in symbol_set:
+            self.model_symbol_set.remove(BACKSPACE_CHAR)
+
     def predict_character(self, evidence: Union[str, List[str]]) -> List[Tuple]:
         """
         Using the provided data, compute probabilities over the entire symbol.
@@ -40,14 +42,18 @@ class UniformLanguageModel(CharacterLanguageModel):
             list of (symbol, probability) tuples
         """
 
-        if self.symbol_set is None:
-            raise InvalidSymbolSetException("symbol set must be set prior to requesting predictions.")
+        if not self.symbol_set:
+            raise InvalidSymbolSetException(
+                "symbol set must be set prior to requesting predictions.")
 
         probs = equally_probable(self.model_symbol_set)
-        return list(zip(self.model_symbol_set, probs)) + [(BACKSPACE_CHAR, 0.0)]
+        return list(zip(self.model_symbol_set, probs)) + [(BACKSPACE_CHAR, 0.0)
+                                                          ]
 
-def equally_probable(alphabet: List[str],
-                     specified: Optional[Dict[str, float]] = None) -> List[float]:
+
+def equally_probable(
+        alphabet: List[str],
+        specified: Optional[Dict[str, float]] = None) -> List[float]:
     """Returns a list of probabilities which correspond to the provided
     alphabet. Unless overridden by the specified values, all items will
     have the same probability. All probabilities sum to 1.0.

--- a/bcipy/language/tests/test_mixture.py
+++ b/bcipy/language/tests/test_mixture.py
@@ -1,15 +1,16 @@
 """Tests for MIXTURE Language Model"""
 
-import pytest
-import unittest
 import os
+import unittest
 from operator import itemgetter
 
-from bcipy.exceptions import InvalidSymbolSetException
+import pytest
 from textslinger.exceptions import InvalidLanguageModelException
-from bcipy.core.symbols import DEFAULT_SYMBOL_SET, BACKSPACE_CHAR, SPACE_CHAR
-from bcipy.language.model.mixture import MixtureLanguageModelAdapter
+
+from bcipy.core.symbols import BACKSPACE_CHAR, DEFAULT_SYMBOL_SET, SPACE_CHAR
+from bcipy.exceptions import InvalidSymbolSetException
 from bcipy.language.main import CharacterLanguageModel
+from bcipy.language.model.mixture import MixtureLanguageModelAdapter
 
 
 @pytest.mark.slow
@@ -25,7 +26,6 @@ class TestMixtureLanguageModelAdapter(unittest.TestCase):
                                                  lm_params=cls.lm_params)
         cls.lmodel.set_symbol_set(DEFAULT_SYMBOL_SET)
 
-
     @pytest.mark.slow
     def test_default_load(self):
         """Test loading model with parameters from json
@@ -33,12 +33,10 @@ class TestMixtureLanguageModelAdapter(unittest.TestCase):
         lm = MixtureLanguageModelAdapter()
         lm.set_symbol_set(DEFAULT_SYMBOL_SET)
 
-
     def test_init(self):
         """Test default parameters"""
         self.assertEqual(self.lmodel.symbol_set, DEFAULT_SYMBOL_SET)
         self.assertTrue(isinstance(self.lmodel, CharacterLanguageModel))
-
 
     def test_invalid_symbol_set(self):
         """Should raise an exception if predict is called without setting symbol set"""
@@ -57,7 +55,6 @@ class TestMixtureLanguageModelAdapter(unittest.TestCase):
             lm = MixtureLanguageModelAdapter(lm_types=["CAUSAL", "PHONY"], lm_weights=[0.5, 0.5],
                                              lm_params=[{"lang_model_name": "gpt2"}, {}])
             lm.set_symbol_set(DEFAULT_SYMBOL_SET)
-
 
     def test_invalid_model_weights(self):
         """Test that the proper exception is thrown if given an improper number of lm_weights"""
@@ -81,7 +78,6 @@ class TestMixtureLanguageModelAdapter(unittest.TestCase):
             lm = MixtureLanguageModelAdapter(lm_types=["NGRAM", "CAUSAL"], lm_weights=[0.5, 0.8],
                                              lm_params=[{"lm_path": self.kenlm_path}, {"lang_model_name": "gpt2"}])
             lm.set_symbol_set(DEFAULT_SYMBOL_SET)
-
 
     def test_non_mutable_evidence(self):
         """Test that the model does not change the evidence variable passed in."""

--- a/bcipy/language/tests/test_oracle.py
+++ b/bcipy/language/tests/test_oracle.py
@@ -2,10 +2,10 @@
 
 import unittest
 
-from bcipy.language.model.oracle import OracleLanguageModel
-from bcipy.language.main import CharacterLanguageModel
 from bcipy.core.symbols import BACKSPACE_CHAR, DEFAULT_SYMBOL_SET
 from bcipy.exceptions import InvalidSymbolSetException
+from bcipy.language.main import CharacterLanguageModel
+from bcipy.language.model.oracle import OracleLanguageModel
 
 
 class TestOracleLanguageModel(unittest.TestCase):
@@ -16,7 +16,6 @@ class TestOracleLanguageModel(unittest.TestCase):
         with self.assertRaises(AssertionError):
             OracleLanguageModel()
 
-
     def test_init_with_text(self):
         """Test with task_text provided"""
         lmodel = OracleLanguageModel(task_text="HELLO_WORLD")
@@ -24,17 +23,16 @@ class TestOracleLanguageModel(unittest.TestCase):
         self.assertEqual(
             len(lmodel.symbol_set), 28,
             "Should be the alphabet plus the backspace and space chars")
-        
-        self.assertTrue(isinstance(lmodel, CharacterLanguageModel))
 
+        self.assertTrue(isinstance(lmodel, CharacterLanguageModel))
 
     def test_invalid_symbol_set(self):
         """Should raise an exception if predict is called before settting the symbol set"""
+        lm = OracleLanguageModel(task_text="HELLO_WORLD")
+        lm.set_symbol_set([])
         with self.assertRaises(InvalidSymbolSetException):
-            lm = OracleLanguageModel(task_text="HELLO_WORLD")
             lm.predict_character("this_should_fail")
 
-    
     def test_predict(self):
         """Test the predict method"""
         lm = OracleLanguageModel(task_text="HELLO_WORLD")

--- a/bcipy/language/tests/test_uniform.py
+++ b/bcipy/language/tests/test_uniform.py
@@ -2,12 +2,10 @@
 
 import unittest
 
-from bcipy.language.model.uniform import UniformLanguageModel
-from bcipy.language.main import CharacterLanguageModel
 from bcipy.core.symbols import BACKSPACE_CHAR, DEFAULT_SYMBOL_SET
 from bcipy.exceptions import InvalidSymbolSetException
-
-from bcipy.language.model.uniform import equally_probable
+from bcipy.language.main import CharacterLanguageModel
+from bcipy.language.model.uniform import UniformLanguageModel, equally_probable
 
 
 class TestUniformLanguageModel(unittest.TestCase):
@@ -18,7 +16,6 @@ class TestUniformLanguageModel(unittest.TestCase):
         cls.lm = UniformLanguageModel()
         cls.lm.set_symbol_set(DEFAULT_SYMBOL_SET)
 
-
     def test_init(self):
         """Test default parameters"""
         lmodel = UniformLanguageModel()
@@ -28,13 +25,12 @@ class TestUniformLanguageModel(unittest.TestCase):
             "Should be the alphabet plus the backspace and space chars")
         self.assertTrue(isinstance(lmodel, CharacterLanguageModel))
 
-
     def test_invalid_symbol_set(self):
         """Should raise an exception if predict is called before setting a symbol set"""
+        lm = UniformLanguageModel()
+        lm.set_symbol_set([])
         with self.assertRaises(InvalidSymbolSetException):
-            lm = UniformLanguageModel()
             lm.predict_character("this_should_fail")
-
 
     def test_predict(self):
         """Test the predict method"""
@@ -46,7 +42,6 @@ class TestUniformLanguageModel(unittest.TestCase):
         self.assertEqual(len(set(probs)), 1, "All values should be the same")
         self.assertTrue(0 < probs[0] < 1)
         self.assertAlmostEqual(sum(probs), 1)
-
 
     def test_equally_probable(self):
         """Test generation of equally probable values."""

--- a/bcipy/simulator/task/copy_phrase.py
+++ b/bcipy/simulator/task/copy_phrase.py
@@ -4,6 +4,7 @@ import logging
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from bcipy.acquisition.multimodal import ClientManager
 from bcipy.core.parameters import Parameters
 from bcipy.core.stimuli import InquirySchedule
 from bcipy.display.main import Display
@@ -11,10 +12,8 @@ from bcipy.feedback.visual.visual_feedback import VisualFeedback
 from bcipy.language.main import LanguageModel
 from bcipy.signal.model.base_model import SignalModel
 from bcipy.simulator.data.sampler import Sampler
-from bcipy.simulator.task.null_display import NullDisplay
 from bcipy.simulator.task.null_daq import NullDAQ
-from bcipy.acquisition.multimodal import ClientManager
-
+from bcipy.simulator.task.null_display import NullDisplay
 from bcipy.simulator.util.state import SimState
 from bcipy.task import TaskMode
 from bcipy.task.control.evidence import EvidenceEvaluator
@@ -52,7 +51,7 @@ class SimulatorCopyPhraseTask(RSVPCopyPhraseTask):
     def __init__(self, parameters: Parameters, file_save: str,
                  signal_models: List[SignalModel],
                  language_model: LanguageModel, samplers: Dict[SignalModel,
-                                                                      Sampler]):
+                                                               Sampler]):
         self.args_sm = signal_models
         self.args_lm = language_model
         self.save_session_every_inquiry = False

--- a/bcipy/simulator/task/replay_task.py
+++ b/bcipy/simulator/task/replay_task.py
@@ -41,7 +41,7 @@ class ReplayTask(SimulatorCopyPhraseTask):
     def __init__(self, parameters: Parameters, file_save: str,
                  signal_models: List[SignalModel],
                  language_model: LanguageModel, samplers: Dict[SignalModel,
-                                                                      Sampler]):
+                                                               Sampler]):
         super().__init__(parameters, file_save, signal_models, language_model,
                          samplers)
 


### PR DESCRIPTION
# Overview

Refactored Language Model protocols; fixed type issues, linting, and import sort order.

## Discussion

Our protocols were not correct. It was possible to create a LanguageModel just by implementing the `set_symbol_set` method, which was not the intention. I changed the hierarchy here to make `LanguageModel` a Union type of `CharacterLanguageModel` and `WordLanguageModel`. This also necessitated changes to the types in the helper module.

I also removed the symbol_set property from the Protocol. That property is an implementation detail since it's not used by any code that uses a Language Model. Also, it potentially introduces a subtle bug since it's possible to set that attribute through either the property or the `set_symbol_set` method.