### PR TITLE
import cleanup

### DIFF
--- a/bcipy/acquisition/datastream/generator.py
+++ b/bcipy/acquisition/datastream/generator.py
@@ -1,6 +1,7 @@
 """Functions for generating mock data to be used for testing/development."""
 
-from typing import Optional, Generator, Callable
+from typing import Callable, Generator, Optional
+
 from past.builtins import range
 
 from bcipy.config import DEFAULT_ENCODING

--- a/bcipy/acquisition/datastream/lsl_server.py
+++ b/bcipy/acquisition/datastream/lsl_server.py
@@ -5,7 +5,7 @@ import logging
 import time
 import uuid
 from queue import Empty, Queue
-from typing import Optional, Generator
+from typing import Generator, Optional
 
 from pylsl import StreamInfo, StreamOutlet
 
@@ -13,7 +13,8 @@ from bcipy.acquisition.datastream.generator import random_data_generator
 from bcipy.acquisition.datastream.producer import Producer
 from bcipy.acquisition.devices import DeviceSpec
 from bcipy.acquisition.util import StoppableThread
-from bcipy.config import DEFAULT_ENCODING, MARKER_STREAM_NAME, SESSION_LOG_FILENAME
+from bcipy.config import (DEFAULT_ENCODING, MARKER_STREAM_NAME,
+                          SESSION_LOG_FILENAME)
 
 log = logging.getLogger(SESSION_LOG_FILENAME)
 # pylint: disable=too-many-arguments

--- a/bcipy/acquisition/datastream/producer.py
+++ b/bcipy/acquisition/datastream/producer.py
@@ -1,11 +1,11 @@
 """Code for mocking an EEG data stream. Code in this module produces data
 at a specified frequency."""
 import logging
-from builtins import next
-from queue import Queue
 import random
 import threading
 import time
+from builtins import next
+from queue import Queue
 
 from bcipy.acquisition.datastream.generator import random_data_generator
 from bcipy.config import SESSION_LOG_FILENAME

--- a/bcipy/acquisition/demo/demo_eye_tracker_client_and_server.py
+++ b/bcipy/acquisition/demo/demo_eye_tracker_client_and_server.py
@@ -2,8 +2,8 @@
 import time
 
 from bcipy.acquisition import LslAcquisitionClient, await_start
-from bcipy.acquisition.datastream.mock.eye_tracker_server import (eye_tracker_device,
-                                                                  eye_tracker_server)
+from bcipy.acquisition.datastream.mock.eye_tracker_server import (
+    eye_tracker_device, eye_tracker_server)
 
 
 def main():

--- a/bcipy/acquisition/demo/demo_lsl_acq_client.py
+++ b/bcipy/acquisition/demo/demo_lsl_acq_client.py
@@ -1,6 +1,7 @@
 """Demo for the LslAcquisitionClient"""
 
 import time
+
 from bcipy.acquisition import LslAcquisitionClient
 
 

--- a/bcipy/acquisition/demo/demo_lsl_recorder.py
+++ b/bcipy/acquisition/demo/demo_lsl_recorder.py
@@ -1,7 +1,8 @@
 """Sample script to demonstrate usage of the LSL Recorder for writing data from an LSL stream."""
 
-from bcipy.acquisition.protocols.lsl.lsl_recorder import LslRecorder
 import time
+
+from bcipy.acquisition.protocols.lsl.lsl_recorder import LslRecorder
 
 SLEEP = 10
 PATH = '.'

--- a/bcipy/acquisition/devices.py
+++ b/bcipy/acquisition/devices.py
@@ -6,8 +6,8 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Union
 
-from bcipy.config import DEFAULT_ENCODING, DEVICE_SPEC_PATH, SESSION_LOG_FILENAME
-
+from bcipy.config import (DEFAULT_ENCODING, DEVICE_SPEC_PATH,
+                          SESSION_LOG_FILENAME)
 
 IRREGULAR_RATE: int = 0
 DEFAULT_CONFIG = DEVICE_SPEC_PATH

--- a/bcipy/acquisition/marker_writer.py
+++ b/bcipy/acquisition/marker_writer.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 
 import pylsl
+
 from bcipy.config import SESSION_LOG_FILENAME
 
 log = logging.getLogger(SESSION_LOG_FILENAME)

--- a/bcipy/acquisition/tests/datastream/test_generator.py
+++ b/bcipy/acquisition/tests/datastream/test_generator.py
@@ -1,10 +1,14 @@
 # pylint: disable=too-few-public-methods,no-self-use
 """Tests for datastream generator module"""
-from builtins import next
 import unittest
-from past.builtins import map, range
+from builtins import next
+
 from mock import mock_open, patch
-from bcipy.acquisition.datastream.generator import random_data_generator, file_data_generator, generator_with_args
+from past.builtins import map, range
+
+from bcipy.acquisition.datastream.generator import (file_data_generator,
+                                                    generator_with_args,
+                                                    random_data_generator)
 from bcipy.acquisition.util import mock_data
 
 

--- a/bcipy/acquisition/tests/protocols/lsl/test_lsl_recorder.py
+++ b/bcipy/acquisition/tests/protocols/lsl/test_lsl_recorder.py
@@ -1,11 +1,11 @@
 """Tests for LslRecorder"""
+import logging
 import tempfile
 import time
 import unittest
 from pathlib import Path
 
 import pytest
-import logging
 
 from bcipy.acquisition.datastream.lsl_server import LslDataServer
 from bcipy.acquisition.datastream.mock.eye_tracker_server import \

--- a/bcipy/acquisition/util.py
+++ b/bcipy/acquisition/util.py
@@ -1,6 +1,7 @@
 """Defines utility classes and functions used by the acquisition module."""
 import multiprocessing
 import threading
+
 import numpy as np
 
 

--- a/bcipy/core/demo/demo_report.py
+++ b/bcipy/core/demo/demo_report.py
@@ -1,20 +1,17 @@
 from pathlib import Path
-from bcipy.io.load import load_json_parameters, load_raw_data, load_experimental_data
-from bcipy.core.triggers import trigger_decoder, TriggerType
-from bcipy.config import (
-    BCIPY_ROOT,
-    DEFAULT_PARAMETERS_FILENAME,
-    RAW_DATA_FILENAME,
-    TRIGGER_FILENAME,
-    DEFAULT_DEVICE_SPEC_FILENAME)
 
 from bcipy.acquisition import devices
+from bcipy.config import (BCIPY_ROOT, DEFAULT_DEVICE_SPEC_FILENAME,
+                          DEFAULT_PARAMETERS_FILENAME, RAW_DATA_FILENAME,
+                          TRIGGER_FILENAME)
+from bcipy.core.report import Report, SessionReportSection, SignalReportSection
+from bcipy.core.triggers import TriggerType, trigger_decoder
 from bcipy.helpers.acquisition import analysis_channels
 from bcipy.helpers.visualization import visualize_erp
-from bcipy.signal.process import get_default_transform
+from bcipy.io.load import (load_experimental_data, load_json_parameters,
+                           load_raw_data)
 from bcipy.signal.evaluate.artifact import ArtifactDetection
-from bcipy.core.report import Report, SignalReportSection, SessionReportSection
-
+from bcipy.signal.process import get_default_transform
 
 if __name__ == "__main__":
     import argparse

--- a/bcipy/core/demo/demo_session_tools.py
+++ b/bcipy/core/demo/demo_session_tools.py
@@ -4,9 +4,9 @@ import json
 from pathlib import Path
 
 from bcipy.config import SESSION_DATA_FILENAME, SESSION_SUMMARY_FILENAME
-from bcipy.gui.file_dialog import ask_directory
 from bcipy.core.session import (read_session, session_csv, session_data,
                                 session_db, session_excel)
+from bcipy.gui.file_dialog import ask_directory
 
 
 def main(data_dir: str):

--- a/bcipy/core/demo/demo_stimuli_generation.py
+++ b/bcipy/core/demo/demo_stimuli_generation.py
@@ -1,5 +1,7 @@
-from bcipy.core.stimuli import StimuliOrder, generate_calibration_inquiries, best_case_rsvp_inq_gen
 import numpy as np
+
+from bcipy.core.stimuli import (StimuliOrder, best_case_rsvp_inq_gen,
+                                generate_calibration_inquiries)
 
 
 def _demo_random_rsvp_inquiry_generator():

--- a/bcipy/core/raw_data.py
+++ b/bcipy/core/raw_data.py
@@ -1,7 +1,7 @@
 """Functionality for reading and writing raw signal data."""
 import csv
 from io import TextIOWrapper
-from typing import List, Optional, TextIO, Tuple, Union, Any
+from typing import Any, List, Optional, TextIO, Tuple, Union
 
 import numpy as np
 import pandas as pd

--- a/bcipy/core/report.py
+++ b/bcipy/core/report.py
@@ -4,13 +4,12 @@ from abc import ABC
 from typing import List, Optional, Tuple
 
 from matplotlib import pyplot as plt
-
 from matplotlib.figure import Figure
-from reportlab.platypus import SimpleDocTemplate, Paragraph, Image
 from reportlab.lib.pagesizes import letter
 from reportlab.lib.styles import getSampleStyleSheet
-from reportlab.platypus import Flowable, KeepTogether
 from reportlab.lib.units import inch
+from reportlab.platypus import (Flowable, Image, KeepTogether, Paragraph,
+                                SimpleDocTemplate)
 
 from bcipy.config import BCIPY_FULL_LOGO_PATH
 from bcipy.signal.evaluate.artifact import ArtifactDetection

--- a/bcipy/core/session.py
+++ b/bcipy/core/session.py
@@ -13,14 +13,15 @@ from openpyxl.chart import BarChart, Reference
 from openpyxl.styles import PatternFill
 from openpyxl.styles.borders import BORDER_THIN, Border, Side
 from openpyxl.styles.colors import COLOR_INDEX
-BLACK = COLOR_INDEX[0]
-WHITE = COLOR_INDEX[1]
-YELLOW = COLOR_INDEX[5]
-from bcipy.config import (DEFAULT_ENCODING,
-                          DEFAULT_PARAMETERS_FILENAME,
+
+from bcipy.config import (DEFAULT_ENCODING, DEFAULT_PARAMETERS_FILENAME,
                           SESSION_DATA_FILENAME, SESSION_SUMMARY_FILENAME)
 from bcipy.io.load import load_json_parameters
 from bcipy.task.data import Session
+
+BLACK = COLOR_INDEX[0]
+WHITE = COLOR_INDEX[1]
+YELLOW = COLOR_INDEX[5]
 
 
 def read_session(file_name: str = SESSION_DATA_FILENAME) -> Session:

--- a/bcipy/core/stimuli.py
+++ b/bcipy/core/stimuli.py
@@ -21,10 +21,11 @@ from pandas import Series
 from PIL import Image
 from psychopy import core
 
-from bcipy.config import DEFAULT_FIXATION_PATH, DEFAULT_TEXT_FIXATION, SESSION_LOG_FILENAME
-from bcipy.exceptions import BciPyCoreException
+from bcipy.config import (DEFAULT_FIXATION_PATH, DEFAULT_TEXT_FIXATION,
+                          SESSION_LOG_FILENAME)
 from bcipy.core.list import grouper
 from bcipy.core.symbols import alphabet
+from bcipy.exceptions import BciPyCoreException
 
 # Prevents pillow from filling the console with debug info
 logging.getLogger('PIL').setLevel(logging.WARNING)

--- a/bcipy/core/tests/test_raw_data.py
+++ b/bcipy/core/tests/test_raw_data.py
@@ -7,13 +7,12 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from mockito import any, mock, unstub, verify, when
 
-from mockito import any, mock, when, verify, unstub
-
-from bcipy.exceptions import BciPyCoreException
 from bcipy.core.raw_data import (RawData, RawDataReader, RawDataWriter,
-                                 load, sample_data, settings, write,
-                                 get_1020_channel_map, get_1020_channels)
+                                 get_1020_channel_map, get_1020_channels, load,
+                                 sample_data, settings, write)
+from bcipy.exceptions import BciPyCoreException
 
 
 class TestRawData(unittest.TestCase):

--- a/bcipy/core/tests/test_report.py
+++ b/bcipy/core/tests/test_report.py
@@ -1,15 +1,15 @@
 import os
+import shutil
+import tempfile
 import unittest
 from unittest.mock import patch
-import tempfile
-import shutil
 
 import matplotlib.pyplot as plt
 import numpy as np
-from reportlab.platypus import Paragraph, Image
-from reportlab.platypus import Flowable, KeepTogether
+from reportlab.platypus import Flowable, Image, KeepTogether, Paragraph
 
-from bcipy.core.report import Report, SessionReportSection, ReportSection, SignalReportSection
+from bcipy.core.report import (Report, ReportSection, SessionReportSection,
+                               SignalReportSection)
 
 
 class TestReport(unittest.TestCase):

--- a/bcipy/core/tests/test_stimuli.py
+++ b/bcipy/core/tests/test_stimuli.py
@@ -9,12 +9,10 @@ import soundfile as sf
 from mockito import any, mock, unstub, verify, when
 from psychopy import core
 
-from bcipy.exceptions import BciPyCoreException
 from bcipy.core.stimuli import (DEFAULT_FIXATION_PATH, InquiryReshaper,
-                                StimuliOrder, TargetPositions,
-                                TrialReshaper, alphabetize,
-                                best_case_rsvp_inq_gen, best_selection,
-                                distributed_target_positions,
+                                StimuliOrder, TargetPositions, TrialReshaper,
+                                alphabetize, best_case_rsvp_inq_gen,
+                                best_selection, distributed_target_positions,
                                 generate_calibration_inquiries,
                                 generate_inquiry, generate_targets,
                                 get_fixation, inquiry_nontarget_counts,
@@ -22,6 +20,7 @@ from bcipy.core.stimuli import (DEFAULT_FIXATION_PATH, InquiryReshaper,
                                 jittered_timing, play_sound,
                                 random_target_positions, soundfiles,
                                 target_index, update_inquiry_timing)
+from bcipy.exceptions import BciPyCoreException
 
 MOCK_FS = 44100
 

--- a/bcipy/core/tests/test_triggers.py
+++ b/bcipy/core/tests/test_triggers.py
@@ -5,14 +5,13 @@ from unittest.mock import mock_open, patch
 import psychopy
 from mockito import any, mock, unstub, verify, when
 
-from bcipy.exceptions import BciPyCoreException
 from bcipy.core.triggers import (FlushFrequency, Trigger, TriggerHandler,
                                  TriggerType, _calibration_trigger,
                                  apply_offsets, exclude_types,
                                  find_starting_offset, offset_device,
                                  offset_label, read, read_data,
-                                 starting_offsets_by_device,
-                                 trigger_decoder)
+                                 starting_offsets_by_device, trigger_decoder)
+from bcipy.exceptions import BciPyCoreException
 
 
 class TestCalibrationTrigger(unittest.TestCase):

--- a/bcipy/demo/bci_main_demo.py
+++ b/bcipy/demo/bci_main_demo.py
@@ -1,5 +1,5 @@
-from bcipy.main import bci_main
 from bcipy.config import DEFAULT_PARAMETERS_PATH
+from bcipy.main import bci_main
 
 parameter_location = DEFAULT_PARAMETERS_PATH  # Path to a valid BciPy parameters file
 user = 'test_demo_user'  # User ID

--- a/bcipy/display/__init__.py
+++ b/bcipy/display/__init__.py
@@ -4,13 +4,9 @@ This import statement allows users to import submodules from display more direct
 `from bcipy.display import init_display_window` vs. `from bcipy.display.main import init_display_window`
 """
 from bcipy.config import BCIPY_LOGO_PATH
-from .main import (
-    Display,
-    InformationProperties,
-    init_display_window,
-    StimuliProperties,
-    VEPStimuliProperties
-)
+
+from .main import (Display, InformationProperties, StimuliProperties,
+                   VEPStimuliProperties, init_display_window)
 
 __all__ = [
     'Display',

--- a/bcipy/display/demo/components/demo_layouts.py
+++ b/bcipy/display/demo/components/demo_layouts.py
@@ -10,12 +10,12 @@ from psychopy.visual.line import Line
 from psychopy.visual.rect import Rect
 from psychopy.visual.shape import ShapeStim
 
+from bcipy.core.symbols import alphabet
 from bcipy.display.components.layout import (Layout, at_top, centered,
                                              envelope, height_units,
                                              scaled_size)
 from bcipy.display.paradigm.matrix.layout import symbol_positions
 from bcipy.display.paradigm.vep.layout import BoxConfiguration, checkerboard
-from bcipy.core.symbols import alphabet
 
 
 def make_window():

--- a/bcipy/display/paradigm/matrix/__init__.py
+++ b/bcipy/display/paradigm/matrix/__init__.py
@@ -1,6 +1,4 @@
-from .display import (
-    MatrixDisplay
-)
+from .display import MatrixDisplay
 
 __all__ = [
     'MatrixDisplay'

--- a/bcipy/display/paradigm/matrix/display.py
+++ b/bcipy/display/paradigm/matrix/display.py
@@ -6,14 +6,14 @@ from psychopy import core, visual
 
 import bcipy.display.components.layout as layout
 from bcipy.config import MATRIX_IMAGE_FILENAME, SESSION_LOG_FILENAME
+from bcipy.core.stimuli import resize_image
+from bcipy.core.symbols import alphabet, frequency_order, qwerty_order
+from bcipy.core.triggers import _calibration_trigger
 from bcipy.display import (BCIPY_LOGO_PATH, Display, InformationProperties,
                            StimuliProperties)
 from bcipy.display.components.task_bar import TaskBar
 from bcipy.display.main import PreviewParams, init_preview_button_handler
 from bcipy.display.paradigm.matrix.layout import symbol_positions
-from bcipy.core.stimuli import resize_image
-from bcipy.core.symbols import alphabet, frequency_order, qwerty_order
-from bcipy.core.triggers import _calibration_trigger
 
 logger = logging.getLogger(SESSION_LOG_FILENAME)
 

--- a/bcipy/display/paradigm/rsvp/__init__.py
+++ b/bcipy/display/paradigm/rsvp/__init__.py
@@ -1,6 +1,4 @@
-from .display import (
-    RSVPDisplay
-)
+from .display import RSVPDisplay
 
 __all__ = [
     'RSVPDisplay'

--- a/bcipy/display/paradigm/rsvp/mode/calibration.py
+++ b/bcipy/display/paradigm/rsvp/mode/calibration.py
@@ -1,5 +1,5 @@
-from bcipy.display.paradigm.rsvp.display import RSVPDisplay
 from bcipy.core.symbols import SPACE_CHAR
+from bcipy.display.paradigm.rsvp.display import RSVPDisplay
 
 
 class CalibrationDisplay(RSVPDisplay):

--- a/bcipy/display/paradigm/rsvp/mode/copy_phrase.py
+++ b/bcipy/display/paradigm/rsvp/mode/copy_phrase.py
@@ -1,8 +1,8 @@
 from psychopy import visual
 
-from bcipy.display.paradigm.rsvp.display import BCIPY_LOGO_PATH, RSVPDisplay
 from bcipy.core.stimuli import resize_image
 from bcipy.core.symbols import SPACE_CHAR
+from bcipy.display.paradigm.rsvp.display import BCIPY_LOGO_PATH, RSVPDisplay
 
 """Note:
 

--- a/bcipy/display/paradigm/vep/display.py
+++ b/bcipy/display/paradigm/vep/display.py
@@ -6,6 +6,10 @@ from typing import (Any, Dict, Iterable, List, NamedTuple, Optional, Tuple,
 from psychopy import core, visual  # type: ignore
 
 import bcipy.display.components.layout as layout
+from bcipy.core.list import expanded
+from bcipy.core.stimuli import resize_image
+from bcipy.core.symbols import alphabet
+from bcipy.core.triggers import _calibration_trigger
 from bcipy.display import (BCIPY_LOGO_PATH, Display, InformationProperties,
                            VEPStimuliProperties)
 from bcipy.display.components.layout import scaled_size
@@ -17,10 +21,6 @@ from bcipy.display.paradigm.vep.codes import (DEFAULT_FLICKER_RATES,
 from bcipy.display.paradigm.vep.layout import BoxConfiguration, animation_path
 from bcipy.display.paradigm.vep.vep_stim import VEPStim
 from bcipy.helpers.clock import Clock
-from bcipy.core.list import expanded
-from bcipy.core.stimuli import resize_image
-from bcipy.core.symbols import alphabet
-from bcipy.core.triggers import _calibration_trigger
 
 
 class StimTime(NamedTuple):

--- a/bcipy/display/tests/components/test_task_bar.py
+++ b/bcipy/display/tests/components/test_task_bar.py
@@ -1,7 +1,9 @@
 """Task bar component tests"""
 import unittest
-from unittest.mock import patch, Mock
-from bcipy.display.components.task_bar import TaskBar, CalibrationTaskBar, CopyPhraseTaskBar
+from unittest.mock import Mock, patch
+
+from bcipy.display.components.task_bar import (CalibrationTaskBar,
+                                               CopyPhraseTaskBar, TaskBar)
 
 
 class TestTaskBar(unittest.TestCase):

--- a/bcipy/display/tests/test_display.py
+++ b/bcipy/display/tests/test_display.py
@@ -1,7 +1,8 @@
 import unittest
 
-from mockito import any, mock, when, unstub
 import psychopy
+from mockito import any, mock, unstub, when
+
 from bcipy.display.main import init_display_window
 
 

--- a/bcipy/feedback/feedback.py
+++ b/bcipy/feedback/feedback.py
@@ -1,4 +1,5 @@
 import logging
+
 from bcipy.config import SESSION_LOG_FILENAME
 
 REGISTERED_FEEDBACK_TYPES = ['sound', 'visual']

--- a/bcipy/feedback/sound/auditory_feedback.py
+++ b/bcipy/feedback/sound/auditory_feedback.py
@@ -1,6 +1,7 @@
-from bcipy.feedback.feedback import Feedback
-from psychopy import core
 import sounddevice as sd
+from psychopy import core
+
+from bcipy.feedback.feedback import Feedback
 
 
 class AuditoryFeedback(Feedback):

--- a/bcipy/feedback/tests/sound/test_sound_feedback.py
+++ b/bcipy/feedback/tests/sound/test_sound_feedback.py
@@ -1,10 +1,9 @@
 import unittest
 
-from mockito import mock, when, unstub
+import sounddevice as sd
+from mockito import mock, unstub, when
 
 from bcipy.feedback.sound.auditory_feedback import AuditoryFeedback
-
-import sounddevice as sd
 
 
 class TestSoundFeedback(unittest.TestCase):

--- a/bcipy/feedback/visual/visual_feedback.py
+++ b/bcipy/feedback/visual/visual_feedback.py
@@ -1,12 +1,12 @@
 # mypy: disable-error-code="return-value"
 from enum import Enum
+from typing import List, Tuple, Union
 
 from psychopy import core, visual
-from typing import Tuple, List, Union
 
+from bcipy.core.stimuli import resize_image
 from bcipy.feedback.feedback import Feedback
 from bcipy.helpers.clock import Clock
-from bcipy.core.stimuli import resize_image
 
 
 class FeedbackType(Enum):

--- a/bcipy/gui/alert.py
+++ b/bcipy/gui/alert.py
@@ -1,8 +1,11 @@
 """GUI alert messages"""
 # pylint: disable=no-name-in-module
 import sys
+
 from PyQt6.QtWidgets import QApplication
-from bcipy.gui.main import alert_message, AlertMessageType, AlertResponse, AlertMessageResponse
+
+from bcipy.gui.main import (AlertMessageResponse, AlertMessageType,
+                            AlertResponse, alert_message)
 
 
 def confirm(message: str) -> bool:

--- a/bcipy/gui/bciui.py
+++ b/bcipy/gui/bciui.py
@@ -1,19 +1,12 @@
-from typing import Callable, Type
-from PyQt6.QtCore import pyqtSignal
-from PyQt6.QtWidgets import (
-    QWidget,
-    QVBoxLayout,
-    QHBoxLayout,
-    QPushButton,
-    QScrollArea,
-    QLayout,
-    QSizePolicy,
-    QMessageBox,
-    QApplication,
-)
-from typing import Optional, List
-from bcipy.config import BCIPY_ROOT
 import sys
+from typing import Callable, List, Optional, Type
+
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtWidgets import (QApplication, QHBoxLayout, QLayout, QMessageBox,
+                             QPushButton, QScrollArea, QSizePolicy,
+                             QVBoxLayout, QWidget)
+
+from bcipy.config import BCIPY_ROOT
 
 
 class BCIUI(QWidget):

--- a/bcipy/gui/experiments/ExperimentField.py
+++ b/bcipy/gui/experiments/ExperimentField.py
@@ -3,34 +3,19 @@
 # pylint: disable=E0611
 
 import sys
-
 from typing import List
 
 from PyQt6.QtCore import Qt
-from PyQt6.QtWidgets import (
-    QHBoxLayout,
-    QPushButton,
-    QScrollArea,
-    QVBoxLayout,
-    QWidget,
-)
+from PyQt6.QtWidgets import (QHBoxLayout, QPushButton, QScrollArea,
+                             QVBoxLayout, QWidget)
 
-from bcipy.gui.main import (
-    AlertMessageType,
-    AlertMessageResponse,
-    AlertResponse,
-    MessageBox,
-    app,
-    BoolInput,
-    DirectoryInput,
-    FileInput,
-    FloatInput,
-    FormInput,
-    IntegerInput,
-    TextInput,
-)
 from bcipy.config import EXPERIMENT_DATA_FILENAME
-from bcipy.helpers.validate import validate_experiment, validate_field_data_written
+from bcipy.gui.main import (AlertMessageResponse, AlertMessageType,
+                            AlertResponse, BoolInput, DirectoryInput,
+                            FileInput, FloatInput, FormInput, IntegerInput,
+                            MessageBox, TextInput, app)
+from bcipy.helpers.validate import (validate_experiment,
+                                    validate_field_data_written)
 from bcipy.io.load import load_experiments, load_fields
 from bcipy.io.save import save_experiment_field_data
 
@@ -332,6 +317,7 @@ def start_experiment_field_collection_gui(
 def start_app() -> None:
     """Start Experiment Field Collection."""
     import argparse
+
     from bcipy.config import DEFAULT_EXPERIMENT_ID, EXPERIMENT_DATA_FILENAME
 
     parser = argparse.ArgumentParser()

--- a/bcipy/gui/experiments/ExperimentRegistry.py
+++ b/bcipy/gui/experiments/ExperimentRegistry.py
@@ -1,28 +1,19 @@
-from typing import List, Optional
-from PyQt6.QtWidgets import (
-    QComboBox,
-    QVBoxLayout,
-    QHBoxLayout,
-    QLabel,
-    QLineEdit,
-    QPushButton,
-    QScrollArea,
-)
-from bcipy.gui.bciui import BCIUI, DynamicItem, DynamicList, SmallButton, run_bciui
-from bcipy.io.load import load_fields, load_experiments
-from bcipy.io.save import save_experiment_data
-from bcipy.config import (
-    DEFAULT_ENCODING,
-    DEFAULT_EXPERIMENT_PATH,
-    DEFAULT_FIELD_PATH,
-    EXPERIMENT_FILENAME,
-    FIELD_FILENAME,
-    BCIPY_ROOT,
-)
-from bcipy.task.registry import TaskRegistry
-import subprocess
-from bcipy.task.orchestrator.protocol import serialize_protocol
 import json
+import subprocess
+from typing import List, Optional
+
+from PyQt6.QtWidgets import (QComboBox, QHBoxLayout, QLabel, QLineEdit,
+                             QPushButton, QScrollArea, QVBoxLayout)
+
+from bcipy.config import (BCIPY_ROOT, DEFAULT_ENCODING,
+                          DEFAULT_EXPERIMENT_PATH, DEFAULT_FIELD_PATH,
+                          EXPERIMENT_FILENAME, FIELD_FILENAME)
+from bcipy.gui.bciui import (BCIUI, DynamicItem, DynamicList, SmallButton,
+                             run_bciui)
+from bcipy.io.load import load_experiments, load_fields
+from bcipy.io.save import save_experiment_data
+from bcipy.task.orchestrator.protocol import serialize_protocol
+from bcipy.task.registry import TaskRegistry
 
 
 class ExperimentRegistry(BCIUI):

--- a/bcipy/gui/experiments/FieldRegistry.py
+++ b/bcipy/gui/experiments/FieldRegistry.py
@@ -1,7 +1,7 @@
 import sys
-from bcipy.gui.main import BCIGui, app, AlertMessageType, AlertMessageResponse
 
 from bcipy.config import DEFAULT_FIELD_PATH, FIELD_FILENAME
+from bcipy.gui.main import AlertMessageResponse, AlertMessageType, BCIGui, app
 from bcipy.io.load import load_fields
 from bcipy.io.save import save_field_data
 

--- a/bcipy/gui/experiments/demo/demo_experiment_field_collection.py
+++ b/bcipy/gui/experiments/demo/demo_experiment_field_collection.py
@@ -1,6 +1,5 @@
-from bcipy.core.session import collect_experiment_field_data
 from bcipy.config import DEFAULT_EXPERIMENT_ID
-
+from bcipy.core.session import collect_experiment_field_data
 
 experiment_name = DEFAULT_EXPERIMENT_ID
 # this will save the data at the location you've run the demo from!

--- a/bcipy/gui/file_dialog.py
+++ b/bcipy/gui/file_dialog.py
@@ -6,8 +6,8 @@ from typing import Union
 from PyQt6 import QtGui
 from PyQt6.QtWidgets import QApplication, QFileDialog, QWidget
 
-from bcipy.preferences import preferences
 from bcipy.exceptions import BciPyCoreException
+from bcipy.preferences import preferences
 
 DEFAULT_FILE_TYPES = "All Files (*)"
 

--- a/bcipy/gui/intertask_gui.py
+++ b/bcipy/gui/intertask_gui.py
@@ -1,15 +1,11 @@
+import logging
 from typing import Callable, List
 
-from PyQt6.QtWidgets import (
-    QLabel,
-    QHBoxLayout,
-    QPushButton,
-    QProgressBar,
-    QApplication
-)
-from bcipy.gui.bciui import BCIUI, run_bciui
+from PyQt6.QtWidgets import (QApplication, QHBoxLayout, QLabel, QProgressBar,
+                             QPushButton)
+
 from bcipy.config import SESSION_LOG_FILENAME
-import logging
+from bcipy.gui.bciui import BCIUI, run_bciui
 
 logger = logging.getLogger(SESSION_LOG_FILENAME)
 

--- a/bcipy/gui/parameters/params_form.py
+++ b/bcipy/gui/parameters/params_form.py
@@ -11,10 +11,10 @@ from PyQt6.QtWidgets import (QApplication, QFileDialog, QHBoxLayout,
                              QPushButton, QScrollArea, QVBoxLayout, QWidget)
 
 from bcipy.config import BCIPY_ROOT, DEFAULT_PARAMETERS_PATH
+from bcipy.core.parameters import Parameters, changes_from_default
 from bcipy.gui.main import (BoolInput, DirectoryInput, FileInput, FloatInput,
                             FormInput, IntegerInput, RangeInput, SearchInput,
                             SelectionInput, TextInput, static_text_control)
-from bcipy.core.parameters import Parameters, changes_from_default
 
 
 class ParamsForm(QWidget):

--- a/bcipy/gui/tests/viewer/test_gui_main.py
+++ b/bcipy/gui/tests/viewer/test_gui_main.py
@@ -1,5 +1,6 @@
 import unittest
-from bcipy.gui.main import float_input_properties, FloatInputProperties
+
+from bcipy.gui.main import FloatInputProperties, float_input_properties
 
 
 class TestFloatInputProperties(unittest.TestCase):

--- a/bcipy/gui/tests/viewer/test_ring_buffer.py
+++ b/bcipy/gui/tests/viewer/test_ring_buffer.py
@@ -1,5 +1,6 @@
 """Tests for the RingBuffer data structure"""
 import unittest
+
 from bcipy.gui.viewer.ring_buffer import RingBuffer
 
 

--- a/bcipy/gui/viewer/data_source/data_source.py
+++ b/bcipy/gui/viewer/data_source/data_source.py
@@ -1,5 +1,5 @@
-from queue import Queue, Empty
 import itertools as it
+from queue import Empty, Queue
 
 
 class DataSource:

--- a/bcipy/gui/viewer/data_source/file_streamer.py
+++ b/bcipy/gui/viewer/data_source/file_streamer.py
@@ -1,6 +1,7 @@
 """Streams file data for the viewer"""
 import logging
 import time
+
 from bcipy.acquisition.util import StoppableThread
 from bcipy.config import SESSION_LOG_FILENAME
 from bcipy.core.raw_data import RawDataReader

--- a/bcipy/gui/viewer/data_viewer.py
+++ b/bcipy/gui/viewer/data_viewer.py
@@ -4,28 +4,27 @@ from functools import partial
 from queue import Queue
 from typing import Callable, Dict, List, Optional, Tuple
 
+import matplotlib
+import matplotlib.ticker as ticker
+import numpy as np
 from PyQt6.QtCore import Qt, QTimer  # pylint: disable=no-name-in-module
 from PyQt6.QtWidgets import (QApplication, QCheckBox, QComboBox, QHBoxLayout,
                              QLabel, QPushButton, QSpinBox, QVBoxLayout,
                              QWidget)
 
-import matplotlib
-import matplotlib.ticker as ticker
-import numpy as np
 matplotlib.use('Qt5Agg')
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 
-
 from bcipy.acquisition.devices import DeviceSpec
 from bcipy.acquisition.util import StoppableProcess
+from bcipy.core.parameters import DEFAULT_PARAMETERS_PATH, Parameters
+from bcipy.core.raw_data import settings
 from bcipy.gui.main import static_text_control
 from bcipy.gui.viewer.data_source.data_source import QueueDataSource
 from bcipy.gui.viewer.data_source.file_streamer import FileStreamer
 from bcipy.gui.viewer.data_source.lsl_data_source import LslDataSource
 from bcipy.gui.viewer.ring_buffer import RingBuffer
-from bcipy.core.parameters import DEFAULT_PARAMETERS_PATH, Parameters
-from bcipy.core.raw_data import settings
 from bcipy.signal.process.transform import Downsample, get_default_transform
 
 

--- a/bcipy/helpers/clock.py
+++ b/bcipy/helpers/clock.py
@@ -1,6 +1,7 @@
 """Functionality related to clocks to keep track of time in experiments."""
 
 from typing import Callable
+
 from pylsl import local_clock
 
 

--- a/bcipy/helpers/demo/demo_visualization.py
+++ b/bcipy/helpers/demo/demo_visualization.py
@@ -17,11 +17,11 @@ import bcipy.acquisition.devices as devices
 from bcipy.config import (DEFAULT_DEVICE_SPEC_FILENAME,
                           DEFAULT_PARAMETERS_FILENAME, RAW_DATA_FILENAME,
                           TRIGGER_FILENAME)
+from bcipy.core.triggers import TriggerType, trigger_decoder
 from bcipy.helpers.acquisition import analysis_channels
+from bcipy.helpers.visualization import visualize_erp
 from bcipy.io.load import (load_experimental_data, load_json_parameters,
                            load_raw_data)
-from bcipy.core.triggers import TriggerType, trigger_decoder
-from bcipy.helpers.visualization import visualize_erp
 from bcipy.signal.process import get_default_transform
 
 if __name__ == '__main__':

--- a/bcipy/helpers/offset.py
+++ b/bcipy/helpers/offset.py
@@ -1,23 +1,17 @@
-from typing import Any, List, Tuple
-from textwrap import wrap
 from pathlib import Path
+from textwrap import wrap
+from typing import Any, List, Tuple
 
 import matplotlib.pyplot as plt
 import numpy as np
-
 from scipy.stats import normaltest
 
-from bcipy.io.load import load_raw_data, ask_directory, load_json_parameters
+from bcipy.config import (DEFAULT_PARAMETERS_FILENAME,
+                          DEFAULT_TRIGGER_CHANNEL_NAME, DIODE_TRIGGER,
+                          RAW_DATA_FILENAME, TRIGGER_FILENAME)
 from bcipy.core.raw_data import RawData
-from bcipy.core.triggers import trigger_decoder, TriggerType
-
-from bcipy.config import (
-    TRIGGER_FILENAME,
-    DIODE_TRIGGER,
-    RAW_DATA_FILENAME,
-    DEFAULT_TRIGGER_CHANNEL_NAME,
-    DEFAULT_PARAMETERS_FILENAME
-)
+from bcipy.core.triggers import TriggerType, trigger_decoder
+from bcipy.io.load import ask_directory, load_json_parameters, load_raw_data
 
 
 def sample_to_seconds(sample_rate: float, sample: int) -> float:

--- a/bcipy/helpers/task.py
+++ b/bcipy/helpers/task.py
@@ -8,9 +8,10 @@ from psychopy import core, event, visual
 
 from bcipy.acquisition.multimodal import ClientManager, ContentType
 from bcipy.acquisition.record import Record
-from bcipy.config import MAX_PAUSE_SECONDS, SESSION_COMPLETE_MESSAGE, SESSION_LOG_FILENAME
-from bcipy.helpers.clock import Clock
+from bcipy.config import (MAX_PAUSE_SECONDS, SESSION_COMPLETE_MESSAGE,
+                          SESSION_LOG_FILENAME)
 from bcipy.core.stimuli import get_fixation
+from bcipy.helpers.clock import Clock
 from bcipy.task.exceptions import InsufficientDataException
 
 log = logging.getLogger(SESSION_LOG_FILENAME)

--- a/bcipy/helpers/tests/test_acquisition.py
+++ b/bcipy/helpers/tests/test_acquisition.py
@@ -4,13 +4,13 @@ from unittest.mock import Mock, call, patch
 
 from bcipy.acquisition.devices import DeviceSpec, DeviceStatus
 from bcipy.config import DEFAULT_DEVICE_SPEC_FILENAME as spec_name
+from bcipy.core.parameters import Parameters
 from bcipy.helpers.acquisition import (RAW_DATA_FILENAME, StreamType,
                                        active_content_types, init_acquisition,
                                        init_device, is_stream_type_active,
                                        max_inquiry_duration, parse_stream_type,
                                        raw_data_filename, server_spec,
                                        stream_types)
-from bcipy.core.parameters import Parameters
 
 
 class TestAcquisition(unittest.TestCase):

--- a/bcipy/helpers/tests/test_copy_phrase_wrapper.py
+++ b/bcipy/helpers/tests/test_copy_phrase_wrapper.py
@@ -1,7 +1,7 @@
 import unittest
 
-from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
 from bcipy.core.symbols import DEFAULT_SYMBOL_SET
+from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
 from bcipy.language.model.uniform import UniformLanguageModel
 from bcipy.task.data import EvidenceType
 

--- a/bcipy/helpers/tests/test_language_model.py
+++ b/bcipy/helpers/tests/test_language_model.py
@@ -1,8 +1,8 @@
 """Unit test for language model helper"""
 import unittest
-
 from collections import Counter
-from bcipy.helpers.language_model import norm_domain, with_min_prob, histogram
+
+from bcipy.helpers.language_model import histogram, norm_domain, with_min_prob
 
 
 class TestLanguageModelRelated(unittest.TestCase):

--- a/bcipy/helpers/tests/test_offset.py
+++ b/bcipy/helpers/tests/test_offset.py
@@ -1,25 +1,21 @@
-import unittest
 import shutil
+import tempfile
+import unittest
 import zipfile
 from pathlib import Path
-import tempfile
+
 import pytest
-
 from matplotlib import pyplot as plt
+from mockito import unstub, verify, when
 
-from mockito import when, unstub, verify
-
-from bcipy.helpers.offset import (
-    calculate_latency,
-    sample_to_seconds,
-    extract_data_latency_calculation,
-    sample_rate_diffs,
-    lsl_timestamp_diffs
-)
-from bcipy.io.load import load_raw_data
-from bcipy.core.raw_data import RawData
-from bcipy.core.triggers import trigger_decoder, TriggerType
 from bcipy.config import RAW_DATA_FILENAME, TRIGGER_FILENAME
+from bcipy.core.raw_data import RawData
+from bcipy.core.triggers import TriggerType, trigger_decoder
+from bcipy.helpers.offset import (calculate_latency,
+                                  extract_data_latency_calculation,
+                                  lsl_timestamp_diffs, sample_rate_diffs,
+                                  sample_to_seconds)
+from bcipy.io.load import load_raw_data
 
 pwd = Path(__file__).absolute().parent
 input_folder = pwd / "resources/mock_offset/time_test_data/"

--- a/bcipy/helpers/tests/test_system_utils.py
+++ b/bcipy/helpers/tests/test_system_utils.py
@@ -1,15 +1,13 @@
-import unittest
-from bcipy.helpers.utils import (
-    is_connected,
-    is_battery_powered,
-    is_screen_refresh_rate_low,
-    get_screen_info,
-    ScreenInfo,
-)
 import socket
+import unittest
+
 import psutil
+from mockito import any, mock, verify, when
 from pyglet import canvas
-from mockito import any, when, mock, verify
+
+from bcipy.helpers.utils import (ScreenInfo, get_screen_info,
+                                 is_battery_powered, is_connected,
+                                 is_screen_refresh_rate_low)
 
 
 class TestSystemUtilsAlerts(unittest.TestCase):

--- a/bcipy/helpers/tests/test_validate.py
+++ b/bcipy/helpers/tests/test_validate.py
@@ -1,13 +1,11 @@
 import unittest
 
 from bcipy.config import DEFAULT_EXPERIMENT_ID
+from bcipy.exceptions import (InvalidExperimentException,
+                              InvalidFieldException,
+                              UnregisteredExperimentException,
+                              UnregisteredFieldException)
 from bcipy.helpers.validate import validate_experiment, validate_experiments
-from bcipy.exceptions import (
-    InvalidExperimentException,
-    InvalidFieldException,
-    UnregisteredExperimentException,
-    UnregisteredFieldException,
-)
 
 
 class TestValidateExperiment(unittest.TestCase):

--- a/bcipy/helpers/tests/test_visualization.py
+++ b/bcipy/helpers/tests/test_visualization.py
@@ -1,15 +1,15 @@
-import unittest
-import tempfile
 import shutil
+import tempfile
+import unittest
 from pathlib import Path
 
-from mockito import when, any, verify, unstub, mock
+from mockito import any, mock, unstub, verify, when
 
-from bcipy.helpers.visualization import visualize_session_data
-from bcipy.helpers import visualization
-from bcipy.core.raw_data import RawData
-from bcipy.io.load import load_json_parameters
 from bcipy.config import DEFAULT_PARAMETERS_PATH
+from bcipy.core.raw_data import RawData
+from bcipy.helpers import visualization
+from bcipy.helpers.visualization import visualize_session_data
+from bcipy.io.load import load_json_parameters
 
 
 class TestVisualizeSessionData(unittest.TestCase):

--- a/bcipy/helpers/validate.py
+++ b/bcipy/helpers/validate.py
@@ -1,17 +1,15 @@
 import os
 
-from bcipy.config import (
-    DEFAULT_EXPERIMENT_PATH,
-    DEFAULT_FIELD_PATH,
-    EXPERIMENT_FILENAME,
-    FIELD_FILENAME)
-from bcipy.io.load import load_experiments, load_fields
-from bcipy.helpers.utils import is_battery_powered, is_connected, is_screen_refresh_rate_low
-from bcipy.exceptions import (InvalidFieldException,
-                              InvalidExperimentException,
+from bcipy.config import (DEFAULT_EXPERIMENT_PATH, DEFAULT_FIELD_PATH,
+                          EXPERIMENT_FILENAME, FIELD_FILENAME)
+from bcipy.exceptions import (InvalidExperimentException,
+                              InvalidFieldException,
                               UnregisteredExperimentException,
                               UnregisteredFieldException)
 from bcipy.gui.alert import confirm
+from bcipy.helpers.utils import (is_battery_powered, is_connected,
+                                 is_screen_refresh_rate_low)
+from bcipy.io.load import load_experiments, load_fields
 from bcipy.task.orchestrator.protocol import validate_protocol_string
 
 

--- a/bcipy/helpers/visualization.py
+++ b/bcipy/helpers/visualization.py
@@ -9,7 +9,6 @@ import mne
 import numpy as np
 import pandas as pd
 import seaborn as sns
-
 from matplotlib.figure import Figure
 from matplotlib.patches import Ellipse
 from mne import Epochs
@@ -17,16 +16,16 @@ from scipy import linalg
 
 import bcipy.acquisition.devices as devices
 from bcipy.config import (DEFAULT_DEVICE_SPEC_FILENAME,
-                          DEFAULT_GAZE_IMAGE_PATH, RAW_DATA_FILENAME,
-                          TRIGGER_FILENAME, SESSION_LOG_FILENAME,
-                          DEFAULT_PARAMETERS_PATH)
-from bcipy.helpers.acquisition import analysis_channels
-from bcipy.io.convert import convert_to_mne
-from bcipy.io.load import choose_csv_file, load_raw_data, load_json_parameters
+                          DEFAULT_GAZE_IMAGE_PATH, DEFAULT_PARAMETERS_PATH,
+                          RAW_DATA_FILENAME, SESSION_LOG_FILENAME,
+                          TRIGGER_FILENAME)
 from bcipy.core.parameters import Parameters
 from bcipy.core.raw_data import RawData
 from bcipy.core.stimuli import mne_epochs
 from bcipy.core.triggers import TriggerType, trigger_decoder
+from bcipy.helpers.acquisition import analysis_channels
+from bcipy.io.convert import convert_to_mne
+from bcipy.io.load import choose_csv_file, load_json_parameters, load_raw_data
 from bcipy.signal.process import (Composition, ERPTransformParams,
                                   get_default_transform)
 

--- a/bcipy/io/convert.py
+++ b/bcipy/io/convert.py
@@ -1,23 +1,24 @@
 # mypy: disable-error-code="no-redef"
 """Functionality for converting the bcipy raw data output to other formats"""
+import glob
 import logging
 import os
 import tarfile
+from enum import Enum
 from typing import List, Optional, Tuple
-import glob
 
 import mne
-from enum import Enum
 from mne.io import RawArray
-from mne_bids import BIDSPath, write_raw_bids, find_matching_paths, read_raw_bids, get_entity_vals
+from mne_bids import (BIDSPath, find_matching_paths, get_entity_vals,
+                      read_raw_bids, write_raw_bids)
 from tqdm import tqdm
 
 from bcipy.acquisition.devices import preconfigured_device
-from bcipy.config import (RAW_DATA_FILENAME,
-                          TRIGGER_FILENAME, SESSION_LOG_FILENAME)
-from bcipy.io.load import load_raw_data
+from bcipy.config import (RAW_DATA_FILENAME, SESSION_LOG_FILENAME,
+                          TRIGGER_FILENAME)
 from bcipy.core.raw_data import RawData, get_1020_channel_map
 from bcipy.core.triggers import trigger_decoder
+from bcipy.io.load import load_raw_data
 from bcipy.signal.process import Composition
 
 logger = logging.getLogger(SESSION_LOG_FILENAME)

--- a/bcipy/io/demo/demo_convert.py
+++ b/bcipy/io/demo/demo_convert.py
@@ -4,10 +4,12 @@ To use at bcipy root,
 
     `python bcipy/io/demo/demo_convert.py -d "path://to/bcipy/data/folder"`
 """
-from typing import Optional, List
 from pathlib import Path
-from bcipy.io.convert import convert_to_bids, ConvertFormat, convert_eyetracking_to_bids
+from typing import List, Optional
+
 from bcipy.gui.file_dialog import ask_directory
+from bcipy.io.convert import (ConvertFormat, convert_eyetracking_to_bids,
+                              convert_to_bids)
 from bcipy.io.load import BciPySessionTaskData, load_bcipy_data
 
 EXCLUDED_TASKS = ['Report', 'Offline', 'Intertask', 'BAD']

--- a/bcipy/io/demo/demo_load_BIDS.py
+++ b/bcipy/io/demo/demo_load_BIDS.py
@@ -8,10 +8,11 @@ The BIDS directory should contain a dataset_description.json file and a
 participants.tsv file, along with the data files in the appropriate subdirectories.
 """
 
-from bcipy.io.convert import BIDS_to_MNE
-from bcipy.io.load import load_experimental_data
 import mne
 from mne.viz import plot_compare_evokeds
+
+from bcipy.io.convert import BIDS_to_MNE
+from bcipy.io.load import load_experimental_data
 
 # This script demonstrates how to load BIDS data using the BciPy library. This assumes that the data is
 # already in BIDS format (BV, EDF, or BDF, with the channels.tsv file) and that the BIDS directory is

--- a/bcipy/io/load.py
+++ b/bcipy/io/load.py
@@ -11,12 +11,11 @@ from typing import List, Optional, Union
 from bcipy.config import (DEFAULT_ENCODING, DEFAULT_EXPERIMENT_PATH,
                           DEFAULT_FIELD_PATH, DEFAULT_PARAMETERS_PATH,
                           EXPERIMENT_FILENAME, FIELD_FILENAME,
-                          SIGNAL_MODEL_FILE_SUFFIX, SESSION_LOG_FILENAME)
-from bcipy.gui.file_dialog import ask_directory, ask_filename
-from bcipy.exceptions import (BciPyCoreException,
-                              InvalidExperimentException)
+                          SESSION_LOG_FILENAME, SIGNAL_MODEL_FILE_SUFFIX)
 from bcipy.core.parameters import Parameters
 from bcipy.core.raw_data import RawData
+from bcipy.exceptions import BciPyCoreException, InvalidExperimentException
+from bcipy.gui.file_dialog import ask_directory, ask_filename
 from bcipy.preferences import preferences
 from bcipy.signal.model import SignalModel
 

--- a/bcipy/io/save.py
+++ b/bcipy/io/save.py
@@ -9,13 +9,11 @@ from time import localtime, strftime
 from typing import Any, Dict, List, Tuple, Union
 
 from bcipy.acquisition.devices import DeviceSpec
-from bcipy.config import (DEFAULT_ENCODING,
-                          DEFAULT_EXPERIMENT_ID,
+from bcipy.config import (DEFAULT_ENCODING, DEFAULT_EXPERIMENT_ID,
                           DEFAULT_LM_PARAMETERS_FILENAME,
                           DEFAULT_LM_PARAMETERS_PATH,
                           DEFAULT_PARAMETERS_FILENAME,
-                          SIGNAL_MODEL_FILE_SUFFIX,
-                          STIMULI_POSITIONS_FILENAME)
+                          SIGNAL_MODEL_FILE_SUFFIX, STIMULI_POSITIONS_FILENAME)
 from bcipy.signal.model.base_model import SignalModel
 
 

--- a/bcipy/io/tests/test_convert.py
+++ b/bcipy/io/tests/test_convert.py
@@ -5,29 +5,21 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import Tuple, Union
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
+import mne
 
 import bcipy.acquisition.devices as devices
-import mne
 from bcipy.config import (DEFAULT_ENCODING, DEFAULT_PARAMETERS_FILENAME,
                           RAW_DATA_FILENAME, TRIGGER_FILENAME)
-from bcipy.io.convert import (
-    archive_list,
-    compress,
-    ConvertFormat,
-    convert_to_bids,
-    convert_to_mne,
-    decompress,
-    norm_to_tobii,
-    tobii_to_norm,
-    convert_eyetracking_to_bids,
-    BIDS_to_MNE
-)
 from bcipy.core.parameters import Parameters
 from bcipy.core.raw_data import RawData, sample_data, write
 from bcipy.core.triggers import MOCK_TRIGGER_DATA
+from bcipy.io.convert import (BIDS_to_MNE, ConvertFormat, archive_list,
+                              compress, convert_eyetracking_to_bids,
+                              convert_to_bids, convert_to_mne, decompress,
+                              norm_to_tobii, tobii_to_norm)
 from bcipy.signal.generator.generator import gen_random_data
-
 
 CHANNEL_NAMES = [
     'Fp1', 'Fp2', 'F3', 'F4', 'C3', 'C4', 'P3', 'P4',

--- a/bcipy/io/tests/test_load.py
+++ b/bcipy/io/tests/test_load.py
@@ -11,15 +11,14 @@ from mockito import any, expect, unstub, when
 from bcipy.config import (DEFAULT_ENCODING, DEFAULT_EXPERIMENT_PATH,
                           DEFAULT_FIELD_PATH, DEFAULT_PARAMETERS_PATH,
                           EXPERIMENT_FILENAME, FIELD_FILENAME)
+from bcipy.core.parameters import Parameters
 from bcipy.exceptions import BciPyCoreException, InvalidExperimentException
 from bcipy.io.load import (choose_signal_model, choose_signal_models,
-                           copy_parameters, extract_mode,
+                           copy_parameters, extract_mode, load_bcipy_data,
                            load_experiment_fields, load_experiments,
-                           load_bcipy_data,
                            load_fields, load_json_parameters,
                            load_signal_model, load_users)
 from bcipy.io.tests.test_convert import create_bcipy_session_artifacts
-from bcipy.core.parameters import Parameters
 
 MOCK_EXPERIMENT = {
     "test": {

--- a/bcipy/io/tests/test_save.py
+++ b/bcipy/io/tests/test_save.py
@@ -1,17 +1,15 @@
+import json
 import os
 import shutil
-import unittest
 import tempfile
-import json
+import unittest
 
-from bcipy.config import (
-    DEFAULT_PARAMETERS_PATH,
-    DEFAULT_PARAMETERS_FILENAME,
-    DEFAULT_EXPERIMENT_ID,
-    STIMULI_POSITIONS_FILENAME)
+from mockito import any, unstub, when
+
+from bcipy.config import (DEFAULT_EXPERIMENT_ID, DEFAULT_PARAMETERS_FILENAME,
+                          DEFAULT_PARAMETERS_PATH, STIMULI_POSITIONS_FILENAME)
 from bcipy.io import save
 from bcipy.io.save import init_save_data_structure, save_stimuli_position_info
-from mockito import any, unstub, when
 
 
 class TestSave(unittest.TestCase):

--- a/bcipy/language/__init__.py
+++ b/bcipy/language/__init__.py
@@ -1,4 +1,4 @@
-from .main import LanguageModel, CharacterLanguageModel, WordLanguageModel
+from .main import CharacterLanguageModel, LanguageModel, WordLanguageModel
 
 __all__ = [
     "LanguageModel",

--- a/bcipy/language/demo/demo_causal.py
+++ b/bcipy/language/demo/demo_causal.py
@@ -1,6 +1,5 @@
-from bcipy.language.model.causal import CausalLanguageModelAdapter
 from bcipy.core.symbols import DEFAULT_SYMBOL_SET
-
+from bcipy.language.model.causal import CausalLanguageModelAdapter
 
 if __name__ == "__main__":
     lm = CausalLanguageModelAdapter(lang_model_name="figmtu/opt-350m-aac")

--- a/bcipy/language/demo/demo_mixture.py
+++ b/bcipy/language/demo/demo_mixture.py
@@ -1,6 +1,5 @@
-from bcipy.language.model.mixture import MixtureLanguageModelAdapter
 from bcipy.core.symbols import DEFAULT_SYMBOL_SET
-
+from bcipy.language.model.mixture import MixtureLanguageModelAdapter
 
 if __name__ == "__main__":
     # Load the default mixture model from lm_params.json

--- a/bcipy/language/demo/demo_ngram.py
+++ b/bcipy/language/demo/demo_ngram.py
@@ -1,9 +1,9 @@
 # Basic sanity test of using KenLM to predict a sentence using a 12-gram character model.
 
-from bcipy.language.model.ngram import NGramLanguageModelAdapter
-from bcipy.core.symbols import DEFAULT_SYMBOL_SET
 from bcipy.config import LM_PATH
+from bcipy.core.symbols import DEFAULT_SYMBOL_SET
 from bcipy.exceptions import KenLMInstallationException
+from bcipy.language.model.ngram import NGramLanguageModelAdapter
 
 try:
     import kenlm

--- a/bcipy/language/tests/test_causal.py
+++ b/bcipy/language/tests/test_causal.py
@@ -1,15 +1,15 @@
 """Tests for CAUSAL Language Model"""
 
-import pytest
 import unittest
 from operator import itemgetter
 
-from bcipy.exceptions import InvalidSymbolSetException
-from bcipy.core.symbols import DEFAULT_SYMBOL_SET, BACKSPACE_CHAR, SPACE_CHAR
-from bcipy.language.model.causal import CausalLanguageModelAdapter
-from bcipy.language.main import CharacterLanguageModel
-
+import pytest
 from textslinger.exceptions import InvalidLanguageModelException
+
+from bcipy.core.symbols import BACKSPACE_CHAR, DEFAULT_SYMBOL_SET, SPACE_CHAR
+from bcipy.exceptions import InvalidSymbolSetException
+from bcipy.language.main import CharacterLanguageModel
+from bcipy.language.model.causal import CausalLanguageModelAdapter
 
 
 @pytest.mark.slow

--- a/bcipy/main.py
+++ b/bcipy/main.py
@@ -5,8 +5,8 @@ from typing import Optional, Type
 
 from bcipy.config import CUSTOM_TASK_EXPERIMENT_ID, DEFAULT_PARAMETERS_PATH
 from bcipy.exceptions import BciPyCoreException
-from bcipy.io.load import load_experiments, load_json_parameters
 from bcipy.helpers.validate import validate_bcipy_session, validate_experiment
+from bcipy.io.load import load_experiments, load_json_parameters
 from bcipy.task import Task, TaskRegistry
 from bcipy.task.orchestrator import SessionOrchestrator
 from bcipy.task.orchestrator.protocol import parse_protocol

--- a/bcipy/preferences.py
+++ b/bcipy/preferences.py
@@ -1,8 +1,9 @@
 """Module for recording and loading application state and user preferences."""
 import json
 from pathlib import Path
-from typing import Optional, Any, Dict
-from bcipy.config import DEFAULT_ENCODING, PREFERENCES_PATH, BCIPY_ROOT
+from typing import Any, Dict, Optional
+
+from bcipy.config import BCIPY_ROOT, DEFAULT_ENCODING, PREFERENCES_PATH
 
 
 class Pref:

--- a/bcipy/signal/evaluate/artifact.py
+++ b/bcipy/signal/evaluate/artifact.py
@@ -1,34 +1,27 @@
 # mypy: disable-error-code="assignment,arg-type"
+import logging
 import os
 from enum import Enum
-from pathlib import Path
-from typing import Union, List, Tuple, Optional
 from logging import getLogger
-import logging
-
-from bcipy.config import (
-    DEFAULT_PARAMETERS_FILENAME,
-    RAW_DATA_FILENAME,
-    TRIGGER_FILENAME,
-    DEFAULT_DEVICE_SPEC_FILENAME,
-    BCIPY_ROOT,
-    SESSION_LOG_FILENAME
-)
-from bcipy.helpers.acquisition import analysis_channels
-from bcipy.io.load import (
-    load_experimental_data,
-    load_json_parameters,
-    load_raw_data,
-)
-from bcipy.core.stimuli import mne_epochs
-from bcipy.io.convert import convert_to_mne
-from bcipy.core.raw_data import RawData
-from bcipy.signal.process import get_default_transform
-from bcipy.core.triggers import TriggerType, trigger_decoder
-import bcipy.acquisition.devices as devices
-from bcipy.acquisition.devices import DeviceSpec
+from pathlib import Path
+from typing import List, Optional, Tuple, Union
 
 import mne
+
+import bcipy.acquisition.devices as devices
+from bcipy.acquisition.devices import DeviceSpec
+from bcipy.config import (BCIPY_ROOT, DEFAULT_DEVICE_SPEC_FILENAME,
+                          DEFAULT_PARAMETERS_FILENAME, RAW_DATA_FILENAME,
+                          SESSION_LOG_FILENAME, TRIGGER_FILENAME)
+from bcipy.core.raw_data import RawData
+from bcipy.core.stimuli import mne_epochs
+from bcipy.core.triggers import TriggerType, trigger_decoder
+from bcipy.helpers.acquisition import analysis_channels
+from bcipy.io.convert import convert_to_mne
+from bcipy.io.load import (load_experimental_data, load_json_parameters,
+                           load_raw_data)
+from bcipy.signal.process import get_default_transform
+
 mne.set_log_level('WARNING')
 log = getLogger(SESSION_LOG_FILENAME)
 

--- a/bcipy/signal/evaluate/fusion.py
+++ b/bcipy/signal/evaluate/fusion.py
@@ -1,25 +1,24 @@
 # mypy: disable-error-code="assignment,var-annotated"
+import logging
+from typing import List, Tuple
+
 import numpy as np
 from sklearn.utils import resample
-from typing import List, Tuple
-import logging
 from tqdm import tqdm
 
-from bcipy.config import (TRIGGER_FILENAME, SESSION_LOG_FILENAME)
-from bcipy.helpers.acquisition import analysis_channels
+from bcipy.acquisition.devices import DeviceSpec
+from bcipy.config import SESSION_LOG_FILENAME, TRIGGER_FILENAME
+from bcipy.core.parameters import Parameters
 from bcipy.core.raw_data import RawData
 from bcipy.core.stimuli import update_inquiry_timing
 from bcipy.core.triggers import TriggerType, trigger_decoder
+from bcipy.helpers.acquisition import analysis_channels
 from bcipy.preferences import preferences
-from bcipy.signal.model.base_model import SignalModelMetadata
-from bcipy.signal.model.base_model import SignalModel
+from bcipy.signal.model.base_model import SignalModel, SignalModelMetadata
 from bcipy.signal.model.gaussian_mixture import GaussianProcess
 from bcipy.signal.model.pca_rda_kde import PcaRdaKdeModel
 from bcipy.signal.process import (ERPTransformParams, extract_eye_info,
                                   filter_inquiries, get_default_transform)
-from bcipy.acquisition.devices import DeviceSpec
-from bcipy.core.parameters import Parameters
-
 
 logger = logging.getLogger(SESSION_LOG_FILENAME)
 

--- a/bcipy/signal/generator/generator.py
+++ b/bcipy/signal/generator/generator.py
@@ -1,5 +1,6 @@
-import numpy as np
 from typing import List
+
+import numpy as np
 
 
 def truncate_float(num: float, precision: int) -> float:

--- a/bcipy/signal/model/__init__.py
+++ b/bcipy/signal/model/__init__.py
@@ -1,9 +1,8 @@
-from bcipy.signal.model.base_model import SignalModel, ModelEvaluationReport
+from bcipy.signal.model.base_model import ModelEvaluationReport, SignalModel
+from bcipy.signal.model.gaussian_mixture.gaussian_mixture import (
+    GaussianProcess, GMIndividual)
 from bcipy.signal.model.pca_rda_kde.pca_rda_kde import PcaRdaKdeModel
 from bcipy.signal.model.rda_kde.rda_kde import RdaKdeModel
-from bcipy.signal.model.gaussian_mixture.gaussian_mixture import (
-    GMIndividual, GaussianProcess)
-
 
 __all__ = [
     "SignalModel",

--- a/bcipy/signal/model/cross_validation.py
+++ b/bcipy/signal/model/cross_validation.py
@@ -1,10 +1,10 @@
-import numpy as np
+import logging
 
+import numpy as np
 import scipy.optimize
 from sklearn import metrics
-from bcipy.config import SESSION_LOG_FILENAME
 
-import logging
+from bcipy.config import SESSION_LOG_FILENAME
 
 log = logging.getLogger(SESSION_LOG_FILENAME)
 

--- a/bcipy/signal/model/dimensionality_reduction.py
+++ b/bcipy/signal/model/dimensionality_reduction.py
@@ -1,6 +1,6 @@
 import logging
-
 from typing import Optional
+
 import numpy as np
 from sklearn.decomposition import PCA
 

--- a/bcipy/signal/model/gaussian_mixture/__init__.py
+++ b/bcipy/signal/model/gaussian_mixture/__init__.py
@@ -1,4 +1,4 @@
-from .gaussian_mixture import GMIndividual, GaussianProcess, GazeModelResolver
+from .gaussian_mixture import GaussianProcess, GazeModelResolver, GMIndividual
 
 __all__ = [
     'GMIndividual',

--- a/bcipy/signal/model/gaussian_mixture/gaussian_mixture.py
+++ b/bcipy/signal/model/gaussian_mixture/gaussian_mixture.py
@@ -1,17 +1,17 @@
 import pickle
+import warnings
+from enum import Enum
 from pathlib import Path
 from typing import List
-from enum import Enum
 
-from bcipy.exceptions import SignalException
-from bcipy.core.stimuli import GazeReshaper
-from bcipy.signal.model import SignalModel
-
-from sklearn.mixture import GaussianMixture
 import numpy as np
 import scipy.stats as stats
+from sklearn.mixture import GaussianMixture
 
-import warnings
+from bcipy.core.stimuli import GazeReshaper
+from bcipy.exceptions import SignalException
+from bcipy.signal.model import SignalModel
+
 warnings.filterwarnings("ignore")  # ignore DeprecationWarnings from tensorflow
 
 

--- a/bcipy/signal/model/offline_analysis.py
+++ b/bcipy/signal/model/offline_analysis.py
@@ -5,33 +5,32 @@ from pathlib import Path
 from typing import List
 
 import numpy as np
-
 from sklearn.metrics import balanced_accuracy_score
 from sklearn.model_selection import train_test_split
 
 import bcipy.acquisition.devices as devices
 from bcipy.acquisition.devices import DeviceSpec
-from bcipy.config import (DEFAULT_DEVICE_SPEC_FILENAME,
-                          DEFAULT_PARAMETERS_PATH, DEFAULT_DEVICES_PATH,
-                          TRIGGER_FILENAME, SESSION_LOG_FILENAME)
-from bcipy.helpers.acquisition import analysis_channels, raw_data_filename
-from bcipy.io.load import (load_experimental_data, load_json_parameters,
-                           load_raw_data)
-from bcipy.gui.alert import confirm
+from bcipy.config import (DEFAULT_DEVICE_SPEC_FILENAME, DEFAULT_DEVICES_PATH,
+                          DEFAULT_PARAMETERS_PATH, SESSION_LOG_FILENAME,
+                          TRIGGER_FILENAME)
 from bcipy.core.parameters import Parameters
-from bcipy.io.save import save_model
+from bcipy.core.raw_data import RawData
 from bcipy.core.stimuli import update_inquiry_timing
 from bcipy.core.symbols import alphabet
-from bcipy.core.raw_data import RawData
-from bcipy.helpers.utils import report_execution_time
 from bcipy.core.triggers import TriggerType, trigger_decoder
+from bcipy.gui.alert import confirm
+from bcipy.helpers.acquisition import analysis_channels, raw_data_filename
+from bcipy.helpers.utils import report_execution_time
+from bcipy.io.load import (load_experimental_data, load_json_parameters,
+                           load_raw_data)
+from bcipy.io.save import save_model
 from bcipy.preferences import preferences
+from bcipy.signal.evaluate.fusion import calculate_eeg_gaze_fusion_acc
 from bcipy.signal.model.base_model import SignalModel, SignalModelMetadata
-from bcipy.signal.model.gaussian_mixture import (GazeModelResolver)
+from bcipy.signal.model.gaussian_mixture import GazeModelResolver
 from bcipy.signal.model.pca_rda_kde import PcaRdaKdeModel
 from bcipy.signal.process import (ERPTransformParams, extract_eye_info,
                                   filter_inquiries, get_default_transform)
-from bcipy.signal.evaluate.fusion import calculate_eeg_gaze_fusion_acc
 
 log = logging.getLogger(SESSION_LOG_FILENAME)
 logging.basicConfig(level=logging.INFO, format="[%(threadName)-9s][%(asctime)s][%(name)s][%(levelname)s]: %(message)s")

--- a/bcipy/signal/model/pca_rda_kde/pca_rda_kde.py
+++ b/bcipy/signal/model/pca_rda_kde/pca_rda_kde.py
@@ -4,8 +4,8 @@ from typing import List
 
 import numpy as np
 
-from bcipy.exceptions import SignalException
 from bcipy.core.stimuli import InquiryReshaper
+from bcipy.exceptions import SignalException
 from bcipy.signal.model import ModelEvaluationReport, SignalModel
 from bcipy.signal.model.classifier import RegularizedDiscriminantAnalysis
 from bcipy.signal.model.cross_validation import (cost_cross_validation_auc,

--- a/bcipy/signal/model/rda_kde/rda_kde.py
+++ b/bcipy/signal/model/rda_kde/rda_kde.py
@@ -3,14 +3,16 @@ from pathlib import Path
 from typing import List
 
 import numpy as np
+
+from bcipy.core.stimuli import InquiryReshaper
+from bcipy.exceptions import SignalException
 from bcipy.signal.model import ModelEvaluationReport, SignalModel
 from bcipy.signal.model.classifier import RegularizedDiscriminantAnalysis
-from bcipy.signal.model.cross_validation import cost_cross_validation_auc, cross_validation
+from bcipy.signal.model.cross_validation import (cost_cross_validation_auc,
+                                                 cross_validation)
 from bcipy.signal.model.density_estimation import KernelDensityEstimate
 from bcipy.signal.model.dimensionality_reduction import MockPCA
 from bcipy.signal.model.pipeline import Pipeline
-from bcipy.exceptions import SignalException
-from bcipy.core.stimuli import InquiryReshaper
 
 
 class RdaKdeModel(SignalModel):

--- a/bcipy/signal/process/__init__.py
+++ b/bcipy/signal/process/__init__.py
@@ -1,8 +1,8 @@
+from bcipy.signal.process.extract_gaze import extract_eye_info
 from bcipy.signal.process.filter import filter_inquiries
 from bcipy.signal.process.transform import (Composition, Downsample,
                                             ERPTransformParams,
                                             get_default_transform)
-from bcipy.signal.process.extract_gaze import extract_eye_info
 
 __all__ = [
     "filter_inquiries",

--- a/bcipy/signal/process/decomposition/cwt.py
+++ b/bcipy/signal/process/decomposition/cwt.py
@@ -1,4 +1,5 @@
 from typing import Tuple
+
 import numpy as np
 import pywt
 

--- a/bcipy/signal/process/decomposition/psd.py
+++ b/bcipy/signal/process/decomposition/psd.py
@@ -1,12 +1,12 @@
-import matplotlib.pyplot as plt
-import seaborn as sns
-import numpy as np
 from enum import Enum
-from scipy.signal import welch
-from scipy.integrate import simps
-from mne.time_frequency import psd_array_multitaper
-
 from typing import Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+import seaborn as sns
+from mne.time_frequency import psd_array_multitaper
+from scipy.integrate import simps
+from scipy.signal import welch
 
 from bcipy.exceptions import SignalException
 

--- a/bcipy/signal/tests/evaluate/test_artifact.py
+++ b/bcipy/signal/tests/evaluate/test_artifact.py
@@ -1,7 +1,10 @@
 import unittest
-from mockito import when, mock, unstub
-from bcipy.signal.evaluate.artifact import ArtifactDetection, DefaultArtifactParameters, ArtifactType
+
+from mockito import mock, unstub, when
+
 from bcipy.signal.evaluate import artifact
+from bcipy.signal.evaluate.artifact import (ArtifactDetection, ArtifactType,
+                                            DefaultArtifactParameters)
 
 
 class TestArtifactDetection(unittest.TestCase):

--- a/bcipy/signal/tests/model/gaussian_mixture/test_gaussian_mixture.py
+++ b/bcipy/signal/tests/model/gaussian_mixture/test_gaussian_mixture.py
@@ -1,10 +1,8 @@
 import unittest
 
-from bcipy.signal.model.gaussian_mixture import (
-    GaussianProcess,
-    GMIndividual,
-    GazeModelResolver
-)
+from bcipy.signal.model.gaussian_mixture import (GaussianProcess,
+                                                 GazeModelResolver,
+                                                 GMIndividual)
 
 
 class TestGazeModelResolver(unittest.TestCase):

--- a/bcipy/signal/tests/model/pca_rda_kde/test_pca_rda_kde.py
+++ b/bcipy/signal/tests/model/pca_rda_kde/test_pca_rda_kde.py
@@ -8,10 +8,10 @@ import numpy as np
 import pytest
 from scipy.stats import norm
 
+from bcipy.core.symbols import alphabet
 from bcipy.exceptions import SignalException
 from bcipy.io.load import load_signal_models
 from bcipy.io.save import save_model
-from bcipy.core.symbols import alphabet
 from bcipy.signal.model import ModelEvaluationReport, PcaRdaKdeModel
 from bcipy.signal.model.classifier import RegularizedDiscriminantAnalysis
 from bcipy.signal.model.cross_validation import cross_validation

--- a/bcipy/signal/tests/model/rda_kde/test_rda_kde.py
+++ b/bcipy/signal/tests/model/rda_kde/test_rda_kde.py
@@ -9,13 +9,13 @@ import pytest
 from scipy.stats import norm
 
 from bcipy.core.symbols import alphabet
+from bcipy.exceptions import SignalException
 from bcipy.signal.model import ModelEvaluationReport, RdaKdeModel
 from bcipy.signal.model.classifier import RegularizedDiscriminantAnalysis
 from bcipy.signal.model.cross_validation import cross_validation
 from bcipy.signal.model.density_estimation import KernelDensityEstimate
 from bcipy.signal.model.dimensionality_reduction import MockPCA
 from bcipy.signal.model.pipeline import Pipeline
-from bcipy.exceptions import SignalException
 
 expected_output_folder = Path(__file__).absolute().parent.parent / "unit_test_expected_output"
 

--- a/bcipy/signal/tests/model/test_offline_analysis.py
+++ b/bcipy/signal/tests/model/test_offline_analysis.py
@@ -1,15 +1,18 @@
 """Integration test of offline_analysis.py (slow)"""
-import unittest
-from pathlib import Path
-import pytest
+import gzip
+import random
+import re
 import shutil
 import tempfile
-import re
-import numpy as np
-import random
-import gzip
+import unittest
+from pathlib import Path
 
-from bcipy.config import RAW_DATA_FILENAME, DEFAULT_PARAMETERS_FILENAME, TRIGGER_FILENAME, DEFAULT_DEVICE_SPEC_FILENAME
+import numpy as np
+import pytest
+
+from bcipy.config import (DEFAULT_DEVICE_SPEC_FILENAME,
+                          DEFAULT_PARAMETERS_FILENAME, RAW_DATA_FILENAME,
+                          TRIGGER_FILENAME)
 from bcipy.io.load import load_json_parameters
 from bcipy.signal.model.offline_analysis import offline_analysis
 

--- a/bcipy/signal/tests/process/test_downsample.py
+++ b/bcipy/signal/tests/process/test_downsample.py
@@ -1,6 +1,8 @@
-from bcipy.signal.process import Downsample
-import numpy as np
 import unittest
+
+import numpy as np
+
+from bcipy.signal.process import Downsample
 
 
 class TestDownsample(unittest.TestCase):

--- a/bcipy/simulator/demo/demo_group_simulation.py
+++ b/bcipy/simulator/demo/demo_group_simulation.py
@@ -32,12 +32,13 @@ output_dir/
 The summary data at the simulation run level (summary_data.json) will be the the data used to compare across users, phrases, language models.
 
 """
-from typing import Optional
 from pathlib import Path
+from typing import Optional
+
+import bcipy.simulator.util.metrics as metrics
 from bcipy.io.load import load_json_parameters
 from bcipy.simulator.task.task_factory import TaskFactory
 from bcipy.simulator.task.task_runner import TaskRunner, init_simulation_dir
-import bcipy.simulator.util.metrics as metrics
 
 # Define the phrases, starting indeces, and language models to use for the simulation
 
@@ -175,9 +176,12 @@ def run_simulation(
 
 
 if __name__ == "__main__":
-    from bcipy.io.load import load_experimental_data
     from pathlib import Path
+
     from tqdm import tqdm
+
+    from bcipy.io.load import load_experimental_data
+
     # load experimental directory. This will have users/run/data
     data_dir = Path(load_experimental_data())
 

--- a/bcipy/simulator/task/task_runner.py
+++ b/bcipy/simulator/task/task_runner.py
@@ -8,8 +8,8 @@ from typing import Any, Dict
 
 from rich.progress import track
 
-from bcipy.io.load import load_json_parameters
 import bcipy.simulator.util.metrics as metrics
+from bcipy.io.load import load_json_parameters
 # pylint: disable=wildcard-import,unused-wildcard-import
 # flake8: noqa
 from bcipy.simulator.data.sampler import *

--- a/bcipy/task/__init__.py
+++ b/bcipy/task/__init__.py
@@ -2,7 +2,6 @@
 This import statement allows users to import submodules from Task
 """
 from .main import Task, TaskData, TaskMode
-
 # Makes the following classes available to the task registry
 from .registry import TaskRegistry
 

--- a/bcipy/task/actions.py
+++ b/bcipy/task/actions.py
@@ -1,31 +1,32 @@
 # mypy: disable-error-code="assignment,arg-type"
-import subprocess
-from typing import Any, Optional, List, Callable, Tuple
-import logging
-from pathlib import Path
 import glob
+import logging
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, List, Optional, Tuple
 
-from bcipy.gui.bciui import run_bciui
 from matplotlib.figure import Figure
 
+from bcipy.acquisition import devices
+from bcipy.acquisition.devices import DeviceSpec
+from bcipy.config import (RAW_DATA_FILENAME, SESSION_LOG_FILENAME,
+                          TRIGGER_FILENAME)
+from bcipy.core.parameters import Parameters
+from bcipy.core.raw_data import RawData
+from bcipy.core.report import (Report, ReportSection, SessionReportSection,
+                               SignalReportSection)
+from bcipy.core.triggers import TriggerType, trigger_decoder
+from bcipy.gui.bciui import run_bciui
+from bcipy.gui.experiments.ExperimentField import \
+    start_experiment_field_collection_gui
 from bcipy.gui.file_dialog import ask_directory
 from bcipy.gui.intertask_gui import IntertaskGUI
-from bcipy.gui.experiments.ExperimentField import start_experiment_field_collection_gui
-from bcipy.task import Task, TaskMode, TaskData
-from bcipy.core.triggers import trigger_decoder, TriggerType
-
-from bcipy.acquisition import devices
 from bcipy.helpers.acquisition import analysis_channels
-from bcipy.core.parameters import Parameters
-from bcipy.acquisition.devices import DeviceSpec
-from bcipy.io.load import load_raw_data
-from bcipy.core.raw_data import RawData
-from bcipy.signal.process import get_default_transform
-from bcipy.core.report import SignalReportSection, SessionReportSection, Report, ReportSection
-from bcipy.config import SESSION_LOG_FILENAME, RAW_DATA_FILENAME, TRIGGER_FILENAME
 from bcipy.helpers.visualization import visualize_erp
+from bcipy.io.load import load_raw_data
 from bcipy.signal.evaluate.artifact import ArtifactDetection
-
+from bcipy.signal.process import get_default_transform
+from bcipy.task import Task, TaskData, TaskMode
 
 logger = logging.getLogger(SESSION_LOG_FILENAME)
 

--- a/bcipy/task/calibration.py
+++ b/bcipy/task/calibration.py
@@ -1,4 +1,5 @@
 """Base calibration task."""
+import logging
 from abc import abstractmethod
 from typing import Any, Dict, Iterator, List, NamedTuple, Optional, Tuple
 
@@ -7,25 +8,24 @@ from psychopy.visual import Window
 
 import bcipy.task.data as session_data
 from bcipy.acquisition import ClientManager
-from bcipy.config import (SESSION_DATA_FILENAME, TRIGGER_FILENAME,
-                          WAIT_SCREEN_MESSAGE, SESSION_LOG_FILENAME)
-from bcipy.helpers.acquisition import init_acquisition, LslDataServer
-from bcipy.display import init_display_window, Display
-from bcipy.helpers.clock import Clock
+from bcipy.config import (SESSION_DATA_FILENAME, SESSION_LOG_FILENAME,
+                          TRIGGER_FILENAME, WAIT_SCREEN_MESSAGE)
 from bcipy.core.parameters import Parameters
-from bcipy.io.save import _save_session_related_data
 from bcipy.core.stimuli import (DEFAULT_TEXT_FIXATION, StimuliOrder,
                                 TargetPositions,
                                 generate_calibration_inquiries)
 from bcipy.core.symbols import alphabet
-from bcipy.helpers.task import (get_user_input, pause_calibration,
-                                trial_complete_message)
 from bcipy.core.triggers import (FlushFrequency, Trigger, TriggerHandler,
                                  TriggerType, convert_timing_triggers,
                                  offset_label)
+from bcipy.display import Display, init_display_window
+from bcipy.helpers.acquisition import LslDataServer, init_acquisition
+from bcipy.helpers.clock import Clock
+from bcipy.helpers.task import (get_user_input, pause_calibration,
+                                trial_complete_message)
+from bcipy.io.save import _save_session_related_data
 from bcipy.task import Task, TaskData, TaskMode
 
-import logging
 logger = logging.getLogger(SESSION_LOG_FILENAME)
 
 

--- a/bcipy/task/control/criteria.py
+++ b/bcipy/task/control/criteria.py
@@ -1,9 +1,11 @@
-import numpy as np
 import logging
-from typing import Dict, List
 from copy import copy
+from typing import Dict, List
+
+import numpy as np
 
 from bcipy.config import SESSION_LOG_FILENAME
+
 log = logging.getLogger(SESSION_LOG_FILENAME)
 
 

--- a/bcipy/task/control/evidence.py
+++ b/bcipy/task/control/evidence.py
@@ -8,9 +8,9 @@ import numpy as np
 from bcipy.acquisition.multimodal import ContentType
 from bcipy.config import SESSION_LOG_FILENAME
 from bcipy.core.parameters import Parameters
+from bcipy.core.stimuli import GazeReshaper, TrialReshaper
 from bcipy.display.main import ButtonPressMode
 from bcipy.helpers.acquisition import analysis_channels
-from bcipy.core.stimuli import TrialReshaper, GazeReshaper
 from bcipy.signal.model import SignalModel
 from bcipy.signal.process import extract_eye_info
 from bcipy.task.data import EvidenceType

--- a/bcipy/task/control/handler.py
+++ b/bcipy/task/control/handler.py
@@ -1,14 +1,14 @@
 import logging
 import string
-from typing import Dict, List, Tuple, Optional
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
 from bcipy.config import SESSION_LOG_FILENAME
-from bcipy.core.stimuli import InquirySchedule, inq_generator, StimuliOrder
-from bcipy.core.symbols import SPACE_CHAR, BACKSPACE_CHAR
-from bcipy.task.control.query import RandomStimuliAgent, StimuliAgent
+from bcipy.core.stimuli import InquirySchedule, StimuliOrder, inq_generator
+from bcipy.core.symbols import BACKSPACE_CHAR, SPACE_CHAR
 from bcipy.task.control.criteria import CriteriaEvaluator
+from bcipy.task.control.query import RandomStimuliAgent, StimuliAgent
 from bcipy.task.data import EvidenceType
 
 log = logging.getLogger(SESSION_LOG_FILENAME)

--- a/bcipy/task/demo/actions/demo_calibration_report.py
+++ b/bcipy/task/demo/actions/demo_calibration_report.py
@@ -1,7 +1,8 @@
 import logging
-from bcipy.task.actions import BciPyCalibrationReportAction
+
 from bcipy.config import DEFAULT_PARAMETERS_PATH
 from bcipy.io.load import load_json_parameters
+from bcipy.task.actions import BciPyCalibrationReportAction
 
 logging.basicConfig(level=logging.INFO)
 

--- a/bcipy/task/demo/control/demo_handler.py
+++ b/bcipy/task/demo/control/demo_handler.py
@@ -1,5 +1,6 @@
-from bcipy.task.control.handler import EvidenceFusion, DecisionMaker
 import numpy as np
+
+from bcipy.task.control.handler import DecisionMaker, EvidenceFusion
 
 
 def _demo_fusion():

--- a/bcipy/task/demo/orchestrator/demo_orchestrator.py
+++ b/bcipy/task/demo/orchestrator/demo_orchestrator.py
@@ -1,9 +1,11 @@
 from bcipy.config import DEFAULT_PARAMETERS_PATH
+from bcipy.task.actions import (BciPyCalibrationReportAction, IntertaskAction,
+                                OfflineAnalysisAction)
 from bcipy.task.orchestrator import SessionOrchestrator
-from bcipy.task.actions import (OfflineAnalysisAction, IntertaskAction, BciPyCalibrationReportAction)
-from bcipy.task.paradigm.rsvp import RSVPCalibrationTask
 # from bcipy.task.paradigm.rsvp import RSVPCopyPhraseTask, RSVPTimingVerificationCalibration
 from bcipy.task.paradigm.matrix import MatrixCalibrationTask
+from bcipy.task.paradigm.rsvp import RSVPCalibrationTask
+
 # from bcipy.task.paradigm.matrix.timing_verification import MatrixTimingVerificationCalibration
 
 

--- a/bcipy/task/main.py
+++ b/bcipy/task/main.py
@@ -1,11 +1,11 @@
-from dataclasses import dataclass
-from typing import Optional
-from bcipy.core.parameters import Parameters
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from enum import Enum
+from typing import Optional
 
-from bcipy.core.stimuli import play_sound
 from bcipy.config import STATIC_AUDIO_PATH
+from bcipy.core.parameters import Parameters
+from bcipy.core.stimuli import play_sound
 
 
 @dataclass

--- a/bcipy/task/orchestrator/orchestrator.py
+++ b/bcipy/task/orchestrator/orchestrator.py
@@ -1,29 +1,23 @@
 # mypy: disable-error-code="arg-type, assignment"
 import errno
-import os
 import json
-import subprocess
-from datetime import datetime
-import random
 import logging
+import os
+import random
+import subprocess
 import time
+from datetime import datetime
 from logging import Logger
-from typing import List, Type, Optional
+from typing import List, Optional, Type
 
+from bcipy.config import (DEFAULT_EXPERIMENT_ID, DEFAULT_PARAMETERS_FILENAME,
+                          DEFAULT_PARAMETERS_PATH, DEFAULT_USER_ID,
+                          MULTIPHRASE_FILENAME, PROTOCOL_FILENAME,
+                          PROTOCOL_LOG_FILENAME, SESSION_LOG_FILENAME)
 from bcipy.core.parameters import Parameters
-from bcipy.helpers.utils import get_system_info, configure_logger
-from bcipy.task import Task, TaskData, TaskMode
-from bcipy.config import (
-    DEFAULT_EXPERIMENT_ID,
-    DEFAULT_PARAMETERS_FILENAME,
-    DEFAULT_PARAMETERS_PATH,
-    DEFAULT_USER_ID,
-    MULTIPHRASE_FILENAME,
-    PROTOCOL_FILENAME,
-    PROTOCOL_LOG_FILENAME,
-    SESSION_LOG_FILENAME,
-)
+from bcipy.helpers.utils import configure_logger, get_system_info
 from bcipy.io.load import load_json_parameters
+from bcipy.task import Task, TaskData, TaskMode
 
 
 class SessionOrchestrator:

--- a/bcipy/task/orchestrator/protocol.py
+++ b/bcipy/task/orchestrator/protocol.py
@@ -2,8 +2,9 @@
 To start these will be 1:1 with tasks, but later this can be extended to represent training sequences, GUI popups etc"""
 
 from typing import List, Type
-from bcipy.task import Task
+
 from bcipy.config import TASK_SEPERATOR
+from bcipy.task import Task
 from bcipy.task.registry import TaskRegistry
 
 

--- a/bcipy/task/paradigm/matrix/calibration.py
+++ b/bcipy/task/paradigm/matrix/calibration.py
@@ -1,15 +1,15 @@
-from typing import Any, Dict, Optional, List
+from typing import Any, Dict, List, Optional
 
 from psychopy import visual
 
+from bcipy.core.parameters import Parameters
 from bcipy.display import InformationProperties, StimuliProperties
 from bcipy.display.components.task_bar import CalibrationTaskBar
 from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.matrix.display import MatrixDisplay
 from bcipy.helpers.clock import Clock
-from bcipy.core.parameters import Parameters
-from bcipy.io.save import save_stimuli_position_info
 from bcipy.helpers.utils import get_screen_info
+from bcipy.io.save import save_stimuli_position_info
 from bcipy.task.calibration import BaseCalibrationTask
 
 

--- a/bcipy/task/paradigm/matrix/copy_phrase.py
+++ b/bcipy/task/paradigm/matrix/copy_phrase.py
@@ -1,14 +1,14 @@
 """Defines the Copy Phrase Task which uses a Matrix display"""
 from psychopy import visual
 
+from bcipy.core.parameters import Parameters
 from bcipy.display import InformationProperties, StimuliProperties
 from bcipy.display.components.task_bar import CopyPhraseTaskBar
 from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.matrix.display import MatrixDisplay
+from bcipy.helpers.clock import Clock
 from bcipy.task import TaskMode
 from bcipy.task.paradigm.rsvp.copy_phrase import RSVPCopyPhraseTask
-from bcipy.core.parameters import Parameters
-from bcipy.helpers.clock import Clock
 
 
 class MatrixCopyPhraseTask(RSVPCopyPhraseTask):

--- a/bcipy/task/paradigm/matrix/timing_verification.py
+++ b/bcipy/task/paradigm/matrix/timing_verification.py
@@ -1,10 +1,9 @@
 from itertools import cycle, islice, repeat
 from typing import Iterator, List
 
-from bcipy.core.stimuli import (PhotoDiodeStimuli, get_fixation,
-                                jittered_timing)
-from bcipy.task.calibration import Inquiry
+from bcipy.core.stimuli import PhotoDiodeStimuli, get_fixation, jittered_timing
 from bcipy.task import TaskMode
+from bcipy.task.calibration import Inquiry
 from bcipy.task.paradigm.matrix.calibration import (MatrixCalibrationTask,
                                                     MatrixDisplay)
 

--- a/bcipy/task/paradigm/rsvp/__init__.py
+++ b/bcipy/task/paradigm/rsvp/__init__.py
@@ -1,4 +1,5 @@
 # Import all RSVP tasks to make them available to the task registry
 from .calibration.calibration import RSVPCalibrationTask  # noqa
-from .calibration.timing_verification import RSVPTimingVerificationCalibration  # noqa
+from .calibration.timing_verification import \
+    RSVPTimingVerificationCalibration  # noqa
 from .copy_phrase import RSVPCopyPhraseTask  # noqa

--- a/bcipy/task/paradigm/rsvp/calibration/calibration.py
+++ b/bcipy/task/paradigm/rsvp/calibration/calibration.py
@@ -1,11 +1,11 @@
 from psychopy import core, visual
 
+from bcipy.core.parameters import Parameters
 from bcipy.display import Display, InformationProperties, StimuliProperties
 from bcipy.display.components.task_bar import CalibrationTaskBar
 from bcipy.display.main import PreviewParams
 from bcipy.display.paradigm.rsvp.mode.calibration import CalibrationDisplay
 from bcipy.helpers.clock import Clock
-from bcipy.core.parameters import Parameters
 from bcipy.task.calibration import BaseCalibrationTask
 
 

--- a/bcipy/task/paradigm/rsvp/calibration/timing_verification.py
+++ b/bcipy/task/paradigm/rsvp/calibration/timing_verification.py
@@ -3,10 +3,9 @@ from itertools import cycle, islice, repeat
 from typing import Any, Iterator, List
 
 from bcipy.core.parameters import Parameters
-from bcipy.core.stimuli import (PhotoDiodeStimuli, get_fixation,
-                                jittered_timing)
-from bcipy.task.calibration import Inquiry
+from bcipy.core.stimuli import PhotoDiodeStimuli, get_fixation, jittered_timing
 from bcipy.task import TaskMode
+from bcipy.task.calibration import Inquiry
 from bcipy.task.paradigm.rsvp.calibration.calibration import \
     RSVPCalibrationTask
 

--- a/bcipy/task/paradigm/vep/calibration.py
+++ b/bcipy/task/paradigm/vep/calibration.py
@@ -5,6 +5,8 @@ from typing import Any, Dict, Iterator, List, Optional
 from psychopy import visual  # type: ignore
 
 from bcipy.config import DEFAULT_FRAME_RATE, SESSION_LOG_FILENAME
+from bcipy.core.parameters import Parameters
+from bcipy.core.triggers import TriggerType
 from bcipy.display import InformationProperties, VEPStimuliProperties
 from bcipy.display.components.layout import centered
 from bcipy.display.components.task_bar import CalibrationTaskBar
@@ -12,8 +14,6 @@ from bcipy.display.paradigm.vep.codes import DEFAULT_FLICKER_RATES
 from bcipy.display.paradigm.vep.display import VEPDisplay
 from bcipy.display.paradigm.vep.layout import BoxConfiguration
 from bcipy.helpers.clock import Clock
-from bcipy.core.parameters import Parameters
-from bcipy.core.triggers import TriggerType
 from bcipy.task.calibration import BaseCalibrationTask, Inquiry
 from bcipy.task.paradigm.vep.stim_generation import \
     generate_vep_calibration_inquiries

--- a/bcipy/task/registry.py
+++ b/bcipy/task/registry.py
@@ -1,6 +1,7 @@
 """Task Registry ; used to provide task options to the GUI and command line
 tools. User defined tasks can be added to the Registry."""
 from typing import Dict, List, Type
+
 from bcipy.task import Task
 
 
@@ -10,8 +11,8 @@ class TaskRegistry:
     def __init__(self):
         # Collects all non-abstract subclasses of Task. type ignore is used to work around a mypy bug
         # https://github.com/python/mypy/issues/3115
-        from bcipy.task.paradigm import vep, rsvp, matrix  # noqa
         from bcipy.task import actions  # noqa
+        from bcipy.task.paradigm import matrix, rsvp, vep  # noqa
 
         self.registry_dict = {}
         self.collect_subclasses(Task)  # type: ignore[type-abstract]

--- a/bcipy/task/tests/core/test_actions.py
+++ b/bcipy/task/tests/core/test_actions.py
@@ -1,9 +1,12 @@
-import unittest
 import subprocess
+import unittest
 
-from mockito import mock, when, verify, unstub
-from bcipy.task import actions, TaskData
-from bcipy.task.actions import CodeHookAction, OfflineAnalysisAction, ExperimentFieldCollectionAction
+from mockito import mock, unstub, verify, when
+
+from bcipy.task import TaskData, actions
+from bcipy.task.actions import (CodeHookAction,
+                                ExperimentFieldCollectionAction,
+                                OfflineAnalysisAction)
 
 
 class TestActions(unittest.TestCase):

--- a/bcipy/task/tests/core/test_handler.py
+++ b/bcipy/task/tests/core/test_handler.py
@@ -1,11 +1,15 @@
-import unittest
-import numpy as np
 import math
-from bcipy.task.control.handler import DecisionMaker, EvidenceFusion
-from bcipy.task.control.criteria import CriteriaEvaluator, \
-    MaxIterationsCriteria, MinIterationsCriteria, ProbThresholdCriteria
-from bcipy.task.control.query import NBestStimuliAgent
+import unittest
+
+import numpy as np
+
 from bcipy.core.symbols import alphabet
+from bcipy.task.control.criteria import (CriteriaEvaluator,
+                                         MaxIterationsCriteria,
+                                         MinIterationsCriteria,
+                                         ProbThresholdCriteria)
+from bcipy.task.control.handler import DecisionMaker, EvidenceFusion
+from bcipy.task.control.query import NBestStimuliAgent
 
 
 class TestDecisionMaker(unittest.TestCase):

--- a/bcipy/task/tests/core/test_task_main.py
+++ b/bcipy/task/tests/core/test_task_main.py
@@ -1,4 +1,5 @@
 import unittest
+
 from bcipy.task import Task, TaskData, TaskMode
 
 

--- a/bcipy/task/tests/orchestrator/test_orchestrator.py
+++ b/bcipy/task/tests/orchestrator/test_orchestrator.py
@@ -1,12 +1,14 @@
-import unittest
-import logging
 import json
+import logging
+import unittest
+
 from mock import mock_open
-from mockito import any, mock, when, unstub, verify
-from bcipy.task.orchestrator import SessionOrchestrator
-from bcipy.task import Task, TaskData
+from mockito import any, mock, unstub, verify, when
+
 from bcipy.config import DEFAULT_PARAMETERS_PATH
 from bcipy.io.load import load_json_parameters
+from bcipy.task import Task, TaskData
+from bcipy.task.orchestrator import SessionOrchestrator
 
 
 class TestSessionOrchestrator(unittest.TestCase):

--- a/bcipy/task/tests/orchestrator/test_protocol.py
+++ b/bcipy/task/tests/orchestrator/test_protocol.py
@@ -1,7 +1,11 @@
 import unittest
-from bcipy.task.orchestrator.protocol import parse_protocol, serialize_protocol, validate_protocol_string
+
 from bcipy.task.actions import OfflineAnalysisAction
-from bcipy.task.paradigm.rsvp.calibration.calibration import RSVPCalibrationTask
+from bcipy.task.orchestrator.protocol import (parse_protocol,
+                                              serialize_protocol,
+                                              validate_protocol_string)
+from bcipy.task.paradigm.rsvp.calibration.calibration import \
+    RSVPCalibrationTask
 from bcipy.task.paradigm.rsvp.copy_phrase import RSVPCopyPhraseTask
 
 

--- a/bcipy/task/tests/paradigm/matrix/test_matrix_calibration.py
+++ b/bcipy/task/tests/paradigm/matrix/test_matrix_calibration.py
@@ -9,9 +9,9 @@ import bcipy.task.paradigm.matrix.calibration
 from bcipy.acquisition import LslAcquisitionClient
 from bcipy.acquisition.devices import DeviceSpec
 from bcipy.acquisition.multimodal import ContentType
-from bcipy.display.paradigm.matrix import MatrixDisplay
 from bcipy.core.parameters import Parameters
 from bcipy.core.triggers import TriggerHandler, TriggerType
+from bcipy.display.paradigm.matrix import MatrixDisplay
 from bcipy.task.paradigm.matrix.calibration import MatrixCalibrationTask
 
 

--- a/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
+++ b/bcipy/task/tests/paradigm/rsvp/test_copy_phrase.py
@@ -13,11 +13,11 @@ from bcipy.acquisition import LslAcquisitionClient
 from bcipy.acquisition.devices import DeviceSpec
 from bcipy.acquisition.multimodal import ContentType
 from bcipy.config import DEFAULT_ENCODING
-from bcipy.exceptions import TaskConfigurationException
-from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
 from bcipy.core.parameters import Parameters
 from bcipy.core.stimuli import InquirySchedule
 from bcipy.core.triggers import TriggerHandler
+from bcipy.exceptions import TaskConfigurationException
+from bcipy.helpers.copy_phrase_wrapper import CopyPhraseWrapper
 from bcipy.task.data import EvidenceType, Session
 from bcipy.task.paradigm.rsvp.copy_phrase import RSVPCopyPhraseTask
 

--- a/bcipy/tests/test_preferences.py
+++ b/bcipy/tests/test_preferences.py
@@ -1,8 +1,9 @@
 """Tests for the Preferences"""
-import unittest
 import shutil
 import tempfile
+import unittest
 from pathlib import Path
+
 from bcipy.preferences import Preferences
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,9 @@ ignore = [
     "W504",
 ]
 
+[tool.isort]
+skip = [".gitignore"]
+
 [tool.pytest.ini]
 markers = "slow"
 


### PR DESCRIPTION
# Overview

Cleanup code by organizing imports using the isort tool.

## Test

- Ran linting and unit tests.

## Discussion

I used the default line length for imports (79 chars), but this can be configured in pyproject.toml using the `line_length` parameter.