### PR TITLE
Fix typos in the documentation

### DIFF
--- a/bcipy/core/README.md
+++ b/bcipy/core/README.md
@@ -1,6 +1,6 @@
 # BciPy Core Module
 
-Core data strucutres and methods needed for BciPy operation. These include triggers, parameters, and raw data.
+Core data structures and methods needed for BciPy operation. These include triggers, parameters, and raw data.
 
 ## Contents
 

--- a/bcipy/display/README.md
+++ b/bcipy/display/README.md
@@ -10,7 +10,7 @@ The module is organized into several key components:
 - `paradigm/`: BCI paradigm-specific display implementations
   - `rsvp/`: RSVP Keyboard display components
   - `matrix/`: Matrix Speller display components
-  - `vep/`:  *WIP* Visual Evoked Potetinal display components.
+  - `vep/`:  *WIP* Visual Evoked Potential display components.
 - `components/`: Reusable display components
 - `tests/`: Unit and integration tests
 - `demo/`: Example implementations and usage

--- a/bcipy/gui/viewer/README.md
+++ b/bcipy/gui/viewer/README.md
@@ -10,7 +10,7 @@ The main entry point for the code is data\_viewer.py. The data\_viewer is plugga
 
 ### Task monitoring
 
-The primary usage of the viewer is to monitor signal quality during BCI task execution. There is a configuration parameter (acq\_show\_viewer) to control whether or not the viewer is initialized during task startup. This parameter can be set either through the UI or by editing the paramters.json file. If selected, the Viewer will launch during the initialization of the data acquisition module in a new GUI window. The module detects the usage of multiple monitors and will appear in the secondary monitor so that it does not interfere with the main experiment.
+The primary usage of the viewer is to monitor signal quality during BCI task execution. There is a configuration parameter (acq\_show\_viewer) to control whether or not the viewer is initialized during task startup. This parameter can be set either through the UI or by editing the parameters.json file. If selected, the Viewer will launch during the initialization of the data acquisition module in a new GUI window. The module detects the usage of multiple monitors and will appear in the secondary monitor so that it does not interfere with the main experiment.
 
 By default all active channels will be displayed. However, the Viewer has controls to toggle the visibility of any channel and limit the display to a given montage. Channel information is provided to the viewer through metadata, so it can work for any device supported by BciPy.
 

--- a/bcipy/signal/README.md
+++ b/bcipy/signal/README.md
@@ -4,7 +4,7 @@ The BciPy Signal module contains all code needed to process, evaluate, model, an
 
 ## Evaluate
 
-The evaluation module contains functions for evaluating signals based on configured rules. The module contains functionailty for detecting artifacts in EEG signals, and for evaluating the quality of the signal. In addition, analysis functions are provided to evaluate the performance of the BCI system. Currently, the fusion of the signals is evaluated using the `calculate_eeg_gaze_fusion_acc` function.
+The evaluation module contains functions for evaluating signals based on configured rules. The module contains functionality for detecting artifacts in EEG signals, and for evaluating the quality of the signal. In addition, analysis functions are provided to evaluate the performance of the BCI system. Currently, the fusion of the signals is evaluated using the `calculate_eeg_gaze_fusion_acc` function.
 
 ## Process
 

--- a/bcipy/signal/evaluate/README.md
+++ b/bcipy/signal/evaluate/README.md
@@ -41,7 +41,7 @@ artifact_detector = ArtifactDetection(raw_data, parameters, device_spec, session
 detected_artifacts = artifact_detector.detect_artifacts()
 ```
 
-This can be used in conjunction with the `ArtifactDetection` semiautomatic mode to determine artifacts that overlap with triggers of interest and correct any labels before removal. To use the semiautomatic mode, the user must provide a list of triggers of interest. The `ArtifactDetection` class can be inititalized with `semi_automatic`. The `semi_automatic` parameter is a boolean that determines if the user wants to manually correct or add to the detected artifacts.
+This can be used in conjunction with the `ArtifactDetection` semiautomatic mode to determine artifacts that overlap with triggers of interest and correct any labels before removal. To use the semiautomatic mode, the user must provide a list of triggers of interest. The `ArtifactDetection` class can be initialized with `semi_automatic`. The `semi_automatic` parameter is a boolean that determines if the user wants to manually correct or add to the detected artifacts.
 
 ```python
 
@@ -64,7 +64,7 @@ artifact_detector = ArtifactDetection(raw_data, parameters, device_spec, session
 detected_artifacts = artifact_detector.detect_artifacts()
 ```
 
-Finally, if wanting to export only the triggers with timestamps for use in another software, the detected artifcats can be exported to a txt file using the `write_mne_annotations` method.
+Finally, if wanting to export only the triggers with timestamps for use in another software, the detected artifacts can be exported to a txt file using the `write_mne_annotations` method.
 
 ```python
 from bcipy.signal.evaluate.artifact import ArtifactDetection, write_mne_annotations

--- a/bcipy/signal/model/README.md
+++ b/bcipy/signal/model/README.md
@@ -56,7 +56,7 @@ This model involves the following stages:
 
 ## Eye Tracking Models
 
-These models may be trained and evalulated, but are still being integrated into the BciPy system for online use.
+These models may be trained and evaluated, but are still being integrated into the BciPy system for online use.
 
 ### Gaze Model
 
@@ -64,7 +64,7 @@ These models may be trained and evalulated, but are still being integrated into 
 
 These models are used to update the posterior probability of stimuli viewed by a user based on gaze data. The gaze model uses a generative model to estimate the likelihood of the gaze data given the stimuli. There are several models implemented in this module, including a Gaussian Mixture Model (GMIndividual) and a Gaussian Process Model (GaussianProcess). When training data via offline analysis, if the data folder contains gaze data, the gaze model will be trained and saved to the output directory.
 
-## Fusion Analyis
+## Fusion Analysis
 
 *Note*: The fusion analysis is currently under development and is not yet fully implemented.
 

--- a/bcipy/task/README.md
+++ b/bcipy/task/README.md
@@ -73,7 +73,7 @@ This action is used to run an offline analysis on the data collected during a se
 
 ## Running Tasks using the SessionOrchestrator
 
-The `SessionOrchestrator` is a class that can be used to run a Protocol (sequence of Tasks/Actions). The core BciPy client and GUI use this class and resulting data strucutures. It will run the tasks in the order defined, handle the transition between tasks, and persist data. There are several optional arguments that can be provided to the orchestrator:
+The `SessionOrchestrator` is a class that can be used to run a Protocol (sequence of Tasks/Actions). The core BciPy client and GUI use this class and resulting data structures. It will run the tasks in the order defined, handle the transition between tasks, and persist data. There are several optional arguments that can be provided to the orchestrator:
 
 experiment_id: str
     This is used to load any defined protocols or field collections. If no experiment_id is provided, a default will be used, and the orchestrator will run any tasks in the order they were added.


### PR DESCRIPTION
9 spelling fixes across 7 documentation files, found with `codespell`. Prose only, no code or identifiers touched.

I read each hit in context and left the false positives alone.