### PR TITLE
Use a literal block for the Create GitHub Release step

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Create GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
-      run: >-
+      run: |
         VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
         gh release create \
         "v${VERSION}" \


### PR DESCRIPTION
Fixes #405.

`run: >-` folded the step onto one line, so `VERSION=` was an env prefix on `gh` and the tag came out as `v`. Same block style the `gh release upload` step below already uses.
